### PR TITLE
Add chord display mode: All / First / None

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -393,6 +393,29 @@ h1 {
     border-color: var(--accent);
 }
 
+.chord-mode-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.chord-mode-select {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.875rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    cursor: pointer;
+}
+
+.chord-mode-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
 .compact-toggle {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Replace the "Chords" checkbox with a dropdown offering three display modes:
- **All**: Show every chord (default, existing behavior)
- **First**: Show chords only for first occurrence of each unique chord pattern (by section)
- **None**: Hide all chords (lyrics only)

## How "First" Mode Works

Compares the chord sequence of each section. If a section has the same chord pattern as a previously rendered section, chords are hidden:

```
Verse 1: G-C-D-G  → SHOW (first time seeing this pattern)
Verse 2: G-C-D-G  → HIDE (same pattern as Verse 1)
Chorus:  Em-C-G-D → SHOW (new pattern)
Chorus:  Em-C-G-D → HIDE (same as first Chorus)
```

This matches the common pattern on chord sites where you see chords once per unique progression.

## Changes

- `docs/js/search.js`: New `chordDisplayMode` state, `getSectionChordPattern()` function, updated rendering logic
- `docs/css/style.css`: Styling for chord mode dropdown

## Test Plan

- [ ] Open any song
- [ ] Verify "Chords: All" shows all chords (existing behavior)
- [ ] Switch to "First" - only first occurrence of each chord pattern shows chords
- [ ] Switch to "None" - lyrics only, no chords

## Known Limitation

Some source songs don't include the first chord of a line when it's the same as the previous chord. This is a parser/source data issue tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)