### PR TITLE
Fix broken tests: update imports to actual module paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,10 @@ search = [
     "numpy>=1.24.0",
 ]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/songbook"]
+# Note: This project doesn't use a traditional package structure.
+# Parser code lives in sources/classic-country/src/
+# Build scripts live in scripts/lib/
+# No build system needed - run scripts directly with uv run.
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,15 @@
 Pytest configuration and shared fixtures
 """
 
-import pytest
+import sys
 from pathlib import Path
+
+import pytest
+
+# Add source directories to Python path for imports
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "sources" / "classic-country" / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 
 
 @pytest.fixture

--- a/tests/parser/test_detector.py
+++ b/tests/parser/test_detector.py
@@ -4,7 +4,7 @@ Tests for structure detection
 
 import pytest
 from bs4 import BeautifulSoup
-from src.songbook import StructureDetector
+from parser import StructureDetector
 
 
 class TestStructureDetector:

--- a/tests/parser/test_integration.py
+++ b/tests/parser/test_integration.py
@@ -4,11 +4,14 @@ Integration tests for the full parsing pipeline
 
 import pytest
 from bs4 import BeautifulSoup
-from src.songbook import (
+from parser import (
     StructureDetector,
     ContentExtractor,
-    ChordProGenerator
+    ChordProGenerator,
+    Song,
 )
+from validator import StructuralValidator
+from batch_process import BatchProcessor
 
 
 class TestParsingPipeline:
@@ -38,25 +41,23 @@ class TestParsingPipeline:
 class TestImports:
     """Verify package imports work correctly"""
 
-    def test_import_from_songbook(self):
-        """Should be able to import from src.songbook"""
-        from src.songbook import (
+    def test_import_parser_classes(self):
+        """Should be able to import parser classes"""
+        from parser import (
             Song,
             StructureDetector,
             ContentExtractor,
             ChordProGenerator,
-            StructuralValidator,
-            BatchProcessor,
         )
         assert Song is not None
         assert StructureDetector is not None
 
-    def test_import_from_parser_subpackage(self):
-        """Should be able to import from src.songbook.parser"""
-        from src.songbook.parser import (
-            Song,
-            StructureDetector,
-            ContentExtractor,
-            ChordProGenerator,
-        )
-        assert Song is not None
+    def test_import_validator(self):
+        """Should be able to import validator"""
+        from validator import StructuralValidator
+        assert StructuralValidator is not None
+
+    def test_import_batch_processor(self):
+        """Should be able to import batch processor"""
+        from batch_process import BatchProcessor
+        assert BatchProcessor is not None

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 [[package]]
 name = "bluegrass-songbook"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "flask" },


### PR DESCRIPTION
## Summary

Fixes test suite that was broken due to non-existent `src.songbook` imports.

## Changes

- **conftest.py**: Add source directories to Python path for test imports
- **test_detector.py**: Import from `parser` instead of `src.songbook`
- **test_integration.py**: Import from actual modules (`parser`, `validator`, `batch_process`)
- **pyproject.toml**: Remove invalid hatchling build config (project uses scripts, not an installable package)

## Test Results

```
7 passed, 1 skipped in 0.06s
```

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)