### PR TITLE
Add ABC notation support with TuneArch integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/tune-request.md
+++ b/.github/ISSUE_TEMPLATE/tune-request.md
@@ -1,0 +1,22 @@
+---
+name: Tune Request
+about: Request a fiddle tune or instrumental to be added from TuneArch
+title: 'Tune Request: '
+labels: tune-request
+assignees: ''
+---
+
+## Tune Information
+
+**Tune Name**: <!-- exact name as it appears on TuneArch -->
+
+**TuneArch URL** (if known):
+
+**Rhythm/Type**: <!-- e.g., Reel, Jig, Hornpipe, Waltz -->
+
+## Why Add This Tune?
+
+<!-- Optional: explain why this tune would be valuable for the collection -->
+
+---
+*After submission, a maintainer will review and approve if the tune is available on TuneArch.*

--- a/.github/workflows/process-tune-request.yml
+++ b/.github/workflows/process-tune-request.yml
@@ -1,0 +1,95 @@
+name: Process Tune Request
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  process-tune-request:
+    # Only run when 'approved' label is added to an issue with 'tune-request' label
+    if: github.event.label.name == 'approved' && contains(github.event.issue.labels.*.name, 'tune-request')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install requests beautifulsoup4
+
+      - name: Extract tune name from issue
+        id: extract
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          # Extract tune name from issue title (format: "Tune Request: <tune name>")
+          TUNE_NAME=$(echo "$ISSUE_TITLE" | sed 's/Tune Request: //')
+          echo "tune_name=$TUNE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Fetch tune from TuneArch
+        env:
+          TUNE_NAME: ${{ steps.extract.outputs.tune_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          python scripts/lib/fetch_tune.py \
+            --tune "$TUNE_NAME" \
+            --issue-number "$ISSUE_NUMBER" \
+            --author "$ISSUE_AUTHOR"
+
+      - name: Rebuild search index
+        run: |
+          pip install beautifulsoup4
+          python scripts/lib/build_index.py --no-tags
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sources/tunearch/parsed/
+          git add docs/data/index.jsonl
+          git diff --staged --quiet || git commit -m "Add tune from request #${{ github.event.issue.number }}
+
+          ${{ github.event.issue.title }}
+
+          🤖 Generated with [Claude Code](https://claude.ai/claude-code)"
+          git push
+
+      - name: Close issue with comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // Read the filename that was created
+            let filename = 'unknown';
+            try {
+              filename = fs.readFileSync('/tmp/tune_filename.txt', 'utf8').trim();
+            } catch (e) {
+              console.log('Could not read filename');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ **Tune added to the songbook!**\n\nFile: \`sources/tunearch/parsed/${filename}\`\n\nThe search index has been rebuilt. The tune should appear in search shortly.\n\nThank you for your suggestion!`
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed'
+            });

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -2400,3 +2400,221 @@ mark {
         align-items: center;
     }
 }
+
+/* ABC Notation Styles */
+.view-toggle {
+    display: flex;
+    gap: 0;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    width: fit-content;
+}
+
+.toggle-btn {
+    padding: 0.5rem 1rem;
+    background: var(--bg-secondary);
+    border: none;
+    cursor: pointer;
+    color: var(--text);
+    font-size: 0.9rem;
+    transition: background 0.2s, color 0.2s;
+}
+
+.toggle-btn:not(:last-child) {
+    border-right: 1px solid var(--border);
+}
+
+.toggle-btn.active {
+    background: var(--accent);
+    color: white;
+}
+
+.toggle-btn:hover:not(.active):not(:disabled) {
+    background: var(--bg);
+}
+
+.toggle-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.abc-view {
+    margin-bottom: 1rem;
+}
+
+.abc-notation {
+    background: var(--bg-secondary);
+    padding: 1rem 1rem 1.5rem 1rem;
+    border-radius: 8px;
+    margin: 0.5rem 0;
+    overflow: visible;
+}
+
+.abc-notation svg {
+    display: block;
+    height: auto;
+}
+
+/* Dark mode adjustments for ABC SVG */
+[data-theme="dark"] .abc-notation svg path {
+    stroke: var(--text);
+}
+
+[data-theme="dark"] .abc-notation svg text {
+    fill: var(--text);
+}
+
+/* Note highlighting during playback */
+.abcjs-playing path,
+.abcjs-playing rect,
+.abcjs-playing circle {
+    fill: #2563eb !important;
+    stroke: #2563eb !important;
+}
+
+[data-theme="dark"] .abcjs-playing path,
+[data-theme="dark"] .abcjs-playing rect,
+[data-theme="dark"] .abcjs-playing circle {
+    fill: #60a5fa !important;
+    stroke: #60a5fa !important;
+}
+
+
+.abc-btn {
+    padding: 0.5rem 1rem;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.2s;
+}
+
+.abc-btn:hover {
+    background: var(--accent-hover);
+}
+
+.abc-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+/* ABC render options */
+.abc-render-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+    align-items: stretch;
+}
+
+/* Control buckets - visually grouped controls */
+.abc-control-bucket {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    min-width: fit-content;
+}
+
+.abc-control-bucket .bucket-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+.abc-control-bucket .bucket-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+/* Playback bucket styling */
+.abc-playback-bucket {
+    margin-left: auto;
+    flex-direction: row;
+    align-items: center;
+}
+
+.abc-playback-bucket .bucket-controls {
+    gap: 0.5rem;
+}
+
+.abc-select {
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+    color: var(--text);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.abc-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.size-display {
+    font-size: 0.85rem;
+    min-width: 2.5rem;
+    text-align: center;
+    color: var(--text);
+    font-weight: 500;
+}
+
+.tempo-input {
+    width: 3.5rem;
+    padding: 0.2rem 0.3rem;
+    font-size: 0.85rem;
+    text-align: center;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text);
+    font-weight: 500;
+}
+
+.tempo-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* Hide number input spinners */
+.tempo-input::-webkit-outer-spin-button,
+.tempo-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+.tempo-input[type=number] {
+    -moz-appearance: textfield;
+}
+
+.abc-fallback {
+    font-family: monospace;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    background: var(--bg-secondary);
+    padding: 1rem;
+    border-radius: 4px;
+    color: var(--text);
+    overflow-x: auto;
+}
+
+.instrumental-notice {
+    text-align: center;
+    padding: 1rem;
+    color: var(--text-secondary);
+    font-style: italic;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,8 @@
     </script>
     <!-- Supabase SDK -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <!-- ABCJS for ABC notation rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/abcjs@6/dist/abcjs-basic-min.js"></script>
 </head>
 <body>
     <!-- Sidebar Navigation -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "flask>=3.0.0",
     "matplotlib>=3.10.7",
     "numpy>=2.2.6",
+    "requests>=2.32.5",
 ]
 
 [project.optional-dependencies]

--- a/scripts/lib/build_index.py
+++ b/scripts/lib/build_index.py
@@ -264,6 +264,26 @@ def compute_nashville_data(content: str) -> dict:
     }
 
 
+def extract_abc_content(content: str) -> Optional[str]:
+    """Extract ABC notation from ChordPro {start_of_abc} blocks."""
+    match = re.search(
+        r'\{start_of_abc\}\s*\n(.*?)\n\{end_of_abc\}',
+        content,
+        re.DOTALL | re.IGNORECASE
+    )
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def is_instrumental(content: str, lyrics: str) -> bool:
+    """Check if song is an instrumental (ABC present, minimal/no lyrics)."""
+    has_abc = '{start_of_abc}' in content.lower()
+    # Instrumental if has ABC and lyrics are very short or empty
+    has_minimal_lyrics = len(lyrics.strip()) < 50
+    return has_abc and has_minimal_lyrics
+
+
 def parse_chordpro_metadata(content: str) -> dict:
     """Extract metadata from ChordPro content."""
     metadata = {
@@ -280,6 +300,10 @@ def parse_chordpro_metadata(content: str) -> dict:
         'arrangement_by': None,
         'version_notes': None,
         'canonical_id': None,
+        # Instrumental metadata
+        'x_type': None,
+        'x_rhythm': None,
+        'x_tunearch_url': None,
     }
 
     # Match {meta: key value} directives (our format)
@@ -306,6 +330,12 @@ def parse_chordpro_metadata(content: str) -> dict:
             metadata['version_notes'] = value
         elif key == 'x_canonical_id':
             metadata['canonical_id'] = value
+        elif key == 'x_type':
+            metadata['x_type'] = value
+        elif key == 'x_rhythm':
+            metadata['x_rhythm'] = value
+        elif key == 'x_tunearch_url':
+            metadata['x_tunearch_url'] = value
         elif key in metadata:
             metadata[key] = value
 
@@ -386,16 +416,28 @@ def extract_lyrics(content: str) -> str:
     """Extract plain lyrics (without chords) from ChordPro content."""
     lines = []
     in_verse = False
+    in_abc = False
 
     for line in content.split('\n'):
         line = line.strip()
 
-        # Skip directives
+        # Skip directives and track ABC blocks
         if line.startswith('{') and line.endswith('}'):
-            if line == '{sov}':
+            lower_line = line.lower()
+            if lower_line == '{start_of_abc}':
+                in_abc = True
+                continue
+            elif lower_line == '{end_of_abc}':
+                in_abc = False
+                continue
+            elif line == '{sov}':
                 in_verse = True
             elif line == '{eov}':
                 in_verse = False
+            continue
+
+        # Skip ABC notation content
+        if in_abc:
             continue
 
         # Skip empty lines
@@ -455,6 +497,15 @@ def build_index(parsed_dirs: list[Path], output_file: Path, enrich_tags: bool = 
         lyrics = extract_lyrics(content)
         first_line = get_first_line(lyrics)
 
+        # Extract ABC content for instrumentals
+        abc_content = extract_abc_content(content)
+        is_tune = is_instrumental(content, lyrics)
+
+        # For instrumentals, use rhythm as first line if no lyrics
+        if is_tune and not first_line and metadata.get('x_rhythm'):
+            key_str = metadata.get('key') or 'Unknown key'
+            first_line = f"{metadata['x_rhythm']} in {key_str}"
+
         # Skip songs without title
         if not metadata['title']:
             continue
@@ -485,6 +536,16 @@ def build_index(parsed_dirs: list[Path], output_file: Path, enrich_tags: bool = 
             'group_id': group_id,  # For version grouping
             'lyrics_hash': lyrics_hash,  # For similarity detection
         }
+
+        # Add ABC content for instrumentals (omit if not present to save space)
+        if abc_content:
+            song['abc_content'] = abc_content
+        if is_tune:
+            song['is_instrumental'] = True
+        if metadata.get('x_rhythm'):
+            song['rhythm'] = metadata['x_rhythm']
+        if metadata.get('x_tunearch_url'):
+            song['tunearch_url'] = metadata['x_tunearch_url']
 
         # Add version/provenance metadata if present (omit null fields to save space)
         if metadata['book']:
@@ -567,6 +628,7 @@ def main():
         Path('sources/classic-country/parsed'),
         Path('sources/golden-standard/parsed'),
         Path('sources/manual/parsed'),
+        Path('sources/tunearch/parsed'),
     ]
     output_file = Path('docs/data/index.jsonl')
 

--- a/scripts/lib/fetch_tune.py
+++ b/scripts/lib/fetch_tune.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Fetch a single tune from TuneArch for GitHub Actions
+
+Usage:
+    python fetch_tune.py --tune "Salt Creek" --issue-number 42 --author username
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from datetime import date
+
+# Add tunearch src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'sources' / 'tunearch' / 'src'))
+
+from scraper import TuneArchScraper
+from chordpro_generator import abc_to_chordpro, save_chordpro
+
+
+def add_request_metadata(chordpro: str, issue_number: str, author: str) -> str:
+    """Add request provenance metadata to ChordPro content"""
+    lines = chordpro.split('\n')
+
+    # Find insertion point (after existing metadata)
+    insert_idx = 0
+    for i, line in enumerate(lines):
+        if line.startswith('{meta:') or line.startswith('{key:') or line.startswith('{time:'):
+            insert_idx = i + 1
+
+    today = date.today().isoformat()
+    metadata = [
+        f'{{meta: x_requested_by github:{author}}}',
+        f'{{meta: x_requested {today}}}',
+        f'{{meta: x_request_issue {issue_number}}}',
+    ]
+
+    for j, meta_line in enumerate(metadata):
+        lines.insert(insert_idx + j, meta_line)
+
+    return '\n'.join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Fetch a tune from TuneArch')
+    parser.add_argument('--tune', required=True, help='Tune name to fetch')
+    parser.add_argument('--issue-number', required=True, help='GitHub issue number')
+    parser.add_argument('--author', required=True, help='GitHub username of requester')
+    args = parser.parse_args()
+
+    # Import here to avoid issues when tunearch src isn't available
+    from scraper import TuneArchScraper
+    from chordpro_generator import abc_to_chordpro, save_chordpro
+
+    scraper = TuneArchScraper()
+
+    print(f"Fetching: {args.tune}")
+    tune = scraper.fetch_tune(args.tune)
+
+    if not tune:
+        print(f"Error: Could not fetch tune '{args.tune}' from TuneArch")
+        sys.exit(1)
+
+    if not tune.abc_notation:
+        print(f"Error: No ABC notation found for '{args.tune}'")
+        sys.exit(1)
+
+    # Generate ChordPro
+    chordpro = abc_to_chordpro(tune)
+    chordpro = add_request_metadata(chordpro, args.issue_number, args.author)
+
+    # Determine output path
+    output_dir = Path(__file__).parent.parent.parent / 'sources' / 'tunearch' / 'parsed'
+    output_path = save_chordpro(chordpro, output_dir, tune.metadata.title)
+
+    print(f"Created: {output_path}")
+
+    # Write filename for workflow to read
+    Path('/tmp/tune_filename.txt').write_text(output_path.name)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/utility
+++ b/scripts/utility
@@ -29,6 +29,15 @@ show_help() {
     echo "      Refresh artist tags from MusicBrainz (requires local MB database)"
     echo "      and rebuild the index"
     echo ""
+    echo "  fetch-tune <name>"
+    echo "      Fetch a single tune from TuneArch by name and rebuild the index"
+    echo ""
+    echo "  bulk-fetch-tunes [limit]"
+    echo "      Fetch multiple tunes from TuneArch curated list (default: 10)"
+    echo ""
+    echo "  search-tunes <query> [limit]"
+    echo "      Search TuneArch for tunes matching query and fetch results"
+    echo ""
 }
 
 case "$COMMAND" in
@@ -46,6 +55,46 @@ case "$COMMAND" in
         uv run python3 scripts/lib/build_index.py
         echo ""
         echo "Done! Tags refreshed and index rebuilt."
+        ;;
+    fetch-tune)
+        if [ -z "$1" ]; then
+            echo "Error: tune name required"
+            echo "Usage: ./scripts/utility fetch-tune \"Tune Name\""
+            exit 1
+        fi
+        echo "Fetching tune: $1"
+        uv run python3 sources/tunearch/src/batch_fetch.py --tune "$1"
+        echo ""
+        echo "Rebuilding index..."
+        uv run python3 scripts/lib/build_index.py --no-tags
+        echo ""
+        echo "Done! Tune fetched and index rebuilt."
+        ;;
+    bulk-fetch-tunes)
+        LIMIT="${1:-10}"
+        echo "Fetching up to $LIMIT tunes from TuneArch..."
+        uv run python3 sources/tunearch/src/batch_fetch.py --limit "$LIMIT"
+        echo ""
+        echo "Rebuilding index..."
+        uv run python3 scripts/lib/build_index.py --no-tags
+        echo ""
+        echo "Done! Tunes fetched and index rebuilt."
+        ;;
+    search-tunes)
+        if [ -z "$1" ]; then
+            echo "Error: search query required"
+            echo "Usage: ./scripts/utility search-tunes \"query\" [limit]"
+            exit 1
+        fi
+        QUERY="$1"
+        LIMIT="${2:-10}"
+        echo "Searching TuneArch for: $QUERY"
+        uv run python3 sources/tunearch/src/batch_fetch.py --search "$QUERY" --limit "$LIMIT"
+        echo ""
+        echo "Rebuilding index..."
+        uv run python3 scripts/lib/build_index.py --no-tags
+        echo ""
+        echo "Done! Tunes fetched and index rebuilt."
         ;;
     help|--help|-h|"")
         show_help

--- a/sources/tunearch/CLAUDE.md
+++ b/sources/tunearch/CLAUDE.md
@@ -1,0 +1,65 @@
+# TuneArch Source
+
+ABC notation for fiddle tunes and instrumentals sourced from [The Traditional Tune Archive](https://tunearch.org/).
+
+## Structure
+
+```
+tunearch/
+├── src/
+│   ├── scraper.py           # TuneArch HTTP client with rate limiting
+│   ├── abc_parser.py        # ABC extraction from wiki pages
+│   ├── chordpro_generator.py # Convert to .pro format
+│   ├── batch_fetch.py       # CLI for fetching tunes
+│   └── tune_list.py         # Curated list of ~100 popular instrumentals
+├── parsed/                   # Output .pro files with ABC blocks
+├── raw/                      # Cached HTML (gitignored)
+└── tune_catalog.json         # Tracks fetch status
+```
+
+## Usage
+
+```bash
+# Fetch a single tune by name
+uv run python sources/tunearch/src/batch_fetch.py --tune "Salt Creek"
+
+# Batch fetch from curated list (limit 10)
+uv run python sources/tunearch/src/batch_fetch.py --limit 10
+
+# Search TuneArch and fetch results
+uv run python sources/tunearch/src/batch_fetch.py --search "bluegrass reel" --limit 20
+
+# After fetching, rebuild the index
+uv run python scripts/lib/build_index.py
+```
+
+## Output Format
+
+Tunes are saved as ChordPro files with embedded ABC notation:
+
+```chordpro
+{meta: title Salt Creek}
+{meta: artist Traditional}
+{meta: x_source tunearch}
+{meta: x_type instrumental}
+{meta: x_rhythm Reel}
+{key: A}
+{time: 4/4}
+
+{start_of_abc}
+X:1
+T:Salt Creek
+M:4/4
+L:1/8
+K:A
+|: E2AB c2BA | E2AB c2Bc | d2fd c2ec | BAGB A2AB :|
+{end_of_abc}
+```
+
+## Rate Limiting
+
+The scraper enforces 1 request/second to be respectful to TuneArch servers. Cached HTML is stored in `raw/` to avoid re-fetching.
+
+## Attribution
+
+All content from TuneArch.org is used for educational purposes. Each tune includes `x_tunearch_url` metadata linking back to the original page.

--- a/sources/tunearch/parsed/blackberryblossom.pro
+++ b/sources/tunearch/parsed/blackberryblossom.pro
@@ -1,0 +1,26 @@
+{meta: title Blackberry Blossom}
+{meta: artist Traditional}
+{key: G}
+{time: 4/4}
+{meta: x_source tunearch}
+{meta: x_type instrumental}
+{meta: x_tunearch_url https://tunearch.org/wiki/Blackberry_Blossom_%284%29}
+{meta: x_rhythm Reel (single/double)}
+{meta: x_genre Old-Time}
+{meta: x_mode Dorian}
+{meta: x_region United States}
+{meta: x_structure AABBCC}
+{meta: x_theme_code 1H1H7b7b 53b47bL}
+{meta: x_alt_title Garfield's Blackberry Blossom}
+
+{start_of_abc}
+X: 1
+T:Garfield's Blackberry Blossom
+M:4/4
+L:1/8
+K:G
+|:gagf gagf|dcBd cB G2|gagf gagf|d2 [B2g2] [B2g2] ga|
+|b2 a2 gagf|dcBd cB G2|GDBc d2 cB|A G2 G G4:|
+|:{D}G2 Bc d2 [B2g2]|dcBd cB G2|{D}[G,2G2] Bc d2 cd|G2 GF G4|
+{D}[G,2G2] Bc d2 g2|dcBd cB G2|GAGF DCB,C|[B,2D2] GF G4 :|
+{end_of_abc}

--- a/sources/tunearch/parsed/saltcreek.pro
+++ b/sources/tunearch/parsed/saltcreek.pro
@@ -1,0 +1,31 @@
+{meta: title Salt Creek}
+{meta: artist Traditional}
+{key: AMix}
+{time: 2/2}
+{meta: x_source tunearch}
+{meta: x_type instrumental}
+{meta: x_tunearch_url https://tunearch.org/wiki/Salt_Creek}
+{meta: x_rhythm Reel (single/double)}
+{meta: x_genre Bluegrass}
+{meta: x_mode Ionian (Major)}
+{meta: x_region United States}
+{meta: x_structure AABB}
+{meta: x_theme_code 7L111 2244}
+{meta: x_alt_title Pateroller (1)}
+{meta: x_alt_title Salt River (2)}
+
+{start_of_abc}
+X: 1
+T: Salt Creek [1]
+C: Traditional
+S: MandoZine TablEdit Archives
+S:
+Z: TablEdited by Mike Stangeland for MandoZine
+L: 1/8
+M: C|
+K: Amix
+"A"A2 AA A2 AB | "A"cA Bc "D"d2 A2 | "G"BA =GA BA =GA | "G"BA =GF "E"E2 E2 |
+"A"A2 AA A2 AB | "A"cA Bc "D"d2 ed | "G"ce fg af ed | "E"cA Bc "A"A4 :|
+|: "A"a2 aa a2 ab | c'e be ab ae | "G"=ga =gf ef =ga | =gf ed cB A2 |
+"A"a2 aa a2 ab | c'e be ab ae | "G"=ga =gf ef ed | "E"cA Bc "A"A4 :|
+{end_of_abc}

--- a/sources/tunearch/raw/blackberry_blossom__4_.html
+++ b/sources/tunearch/raw/blackberry_blossom__4_.html
@@ -1,0 +1,803 @@
+<!DOCTYPE html>
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<title>Blackberry Blossom (4) – Reel (single/double) from United States – The Traditional Tune Archive</title>
+<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available";var cookie=document.cookie.match(/(?:^|; )tunearch_wikidbmwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],
+"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"aVCd3npC41HB6-T1ijzFOwAAARU","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Blackberry_Blossom_(4)","wgTitle":"Blackberry Blossom (4)","wgCurRevisionId":551096,"wgRevisionId":551096,"wgArticleId":3581,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Tune"],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Blackberry_Blossom_(4)","wgRelevantArticleId":3581,"wgIsProbablyEditable":false,"wgRelevantPageIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgPageFormsTargetName":null,"wgPageFormsAutocompleteValues":[],"wgPageFormsAutocompleteOnAllChars":true,"wgPageFormsFieldProperties":[],"wgPageFormsCargoFields":[],
+"wgPageFormsDependentFields":[],"wgPageFormsCalendarValues":[],"wgPageFormsCalendarParams":[],"wgPageFormsCalendarHTML":null,"wgPageFormsGridValues":[],"wgPageFormsGridParams":[],"wgPageFormsContLangYes":null,"wgPageFormsContLangNo":null,"wgPageFormsContLangMonths":[],"wgPageFormsHeightForMinimizingInstances":800,"wgPageFormsDelayReload":false,"wgPageFormsShowOnSelect":[],"wgPageFormsScriptPath":"/w/extensions/PageForms","edgValues":[],"wgPageFormsEDSettings":null,"wgAmericanDates":false,"wgTinyMCETagList":
+"gallery|indicator|langconvert|randomuserswithavatars|newusers|headertabs|notabtoc|htmlet|youtube|aovideo|aoaudio|nicovideo|siteactivity|randomfeatureduser|editinline|vote|dynamicpagelist|categorytree|ref|references|imagemap|inputbox|poem|source|syntaxhighlight|comment-streams|no-comment-streams|comment-streams-initially-collapsed|section|embedvideo|evlplayer|vplayer|archiveorg|bandcamp|bilibili|ccc|dailymotion|externalvideo|kakaotv|loom|navertv|niconico|sharepoint|soundcloud|spotifyalbum|spotifyartist|spotifyshow|spotifyepisode|spotifytrack|twitch|twitchclip|twitchvod|videolink|vimeo|wistia|youtubeoembed|youtubeplaylist|youtubevideolist|score|templatestyles|seo|mobileonly|nomobile|pagelist|pages|pagequality|info|smwdoc|includeonly|onlyinclude|noinclude|nowiki","wgTinyMCELanguage":"en","wgTinyMCEDirectionality":"ltr","wgCheckFileExtensions":true,"wgStrictFileExtensions":true,"wgFileExtensions":["png","gif","jpg","jpeg","webp","pdf","ogg","djvu","svg","mp3","mp4","mm","abc","musicxml",
+"mscz","mus","sib","ly","webm","flac","mkv","mov","mp3","mp4","oga","ogg","ogv","wav","webm"],"wgFileBlacklist":["html","htm","js","jsb","mhtml","mht","xhtml","xht","php","phtml","php3","php4","php5","phps","phar","shtml","jhtml","pl","py","cgi","exe","scr","dll","msi","vbs","bat","com","pif","cmd","vxd","cpl","xml"],"wgEnableUploads":true,"wgTinyMCEVersion":"1.1.2","wgTinyMCEUserMayUpload":false,"wgTinyMCEUserMayUploadFromURL":false,"wgTinyMCEUserIsBlocked":false,"wgTinyMCESettings":null,"wgWsTinyMCEModals":null,"wgServer":"https://tunearch.org","wgScript":"/w/index.php","wgMetrolookEnabledModules":{"collapsiblenav":true},"wgCiteReferencePreviewsActive":true,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgMFDisplayWikibaseDescriptions":{"search":false,"watchlist":false,"tagline":false},"srfFilteredConfig":null,"networkExcludeTalkPages":true,"prpProofreadPageBookNamespaces":[0],"wgIsMobile":false};RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready",
+"user.options":"loading","ext.smw.styles":"ready","ext.smw.tooltip.styles":"ready","ext.NoTitle":"ready","ext.proofreadpage.base":"ready","ext.proofreadpage.article":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","jquery.makeCollapsible.styles":"ready","ext.socialprofile.responsive":"ready","ext.SearchThumbs":"ready","ext.embedVideo.styles":"ready","oojs-ui-core.styles":"ready","oojs-ui.styles.indicators":"ready","mediawiki.widgets.styles":"ready","oojs-ui-core.icons":"ready","ext.MobileDetect.nomobile":"ready","ext.srf.styles":"ready"};RLPAGEMODULES=["ext.smw.styles","oojs-ui.styles.icons-movement","ext.smw.tooltip","ext.network","ext.tinymce","smw.entityexaminer","site","mediawiki.page.ready","jquery.makeCollapsible","skins.vector.js","ext.createPage","ext.SimpleTooltip","ext.abcHoverPreview","ext.gadget.ProfessionalTunebookPDF","ext.gadget.TuneBook","ext.gadget.ttaPlaylist","ext.gadget.ttaPlaylistManager",
+"ext.gadget.ttaPlaylistLibrary","ext.gadget.CommunityPortalTalkTab","mmv.bootstrap","ext.embedVideo.overlay","ext.CookieConsent","ext.addPersonalUrls","ext.smw.purge"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+}];});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.MobileDetect.nomobile%7Cext.NoTitle%2CSearchThumbs%7Cext.embedVideo.styles%7Cext.proofreadpage.article%2Cbase%7Cext.smw.styles%7Cext.smw.tooltip.styles%7Cext.socialprofile.responsive%7Cext.srf.styles%7Cjquery.makeCollapsible.styles%7Cmediawiki.widgets.styles%7Coojs-ui-core.icons%2Cstyles%7Coojs-ui.styles.indicators%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles&amp;only=styles&amp;skin=vector-2022">
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
+<style>#mw-indicator-mw-helplink {display:none;}</style>
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">
+<meta name="generator" content="MediaWiki 1.43.0">
+<meta name="robots" content="max-image-preview:standard">
+<meta name="format-detection" content="telephone=no">
+<meta name="google-site-verification" content="krO8QFzwmzrdm3epW25GRfSvDsKnyBzIXTONRqwqQqY">
+<meta name="msvalidate.01" content="14D63D178522A365E3CE5C63B5AB243D">
+<meta name="yandex-verification" content="6f2e53bf8f8205e7">
+<meta name="p:domain_verify" content="0e8457e9a76fa77a665556543311c158">
+<meta name="description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta name="keywords" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="viewport" content="width=1120">
+<link rel="alternate" type="application/rdf+xml" title="Blackberry Blossom (4)" href="/w/index.php?title=Special:ExportRDF/Blackberry_Blossom_(4)&amp;xmlmime=rdf">
+<link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="The Traditional Tune Archive (en)">
+<link rel="EditURI" type="application/rsd+xml" href="https://tunearch.org/w/api.php?action=rsd">
+<link rel="canonical" href="https://tunearch.org/wiki/Blackberry_Blossom_(4)">
+<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+<link rel="alternate" type="application/atom+xml" title="The Traditional Tune Archive Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom">
+<meta property="og:title" content="Blackberry Blossom (4) – Reel (single/double) from United States – The Traditional Tune Archive">
+<meta property="og:site_name" content="The Traditional Tune Archive">
+<meta property="og:url" content="https://tunearch.org/wiki/Blackberry_Blossom_(4)">
+<meta property="article:author" content="https://www.tunearch.org/wiki/User:WikiSysop">
+<meta property="og:description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta property="article:tag" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta property="article:modified_time" content="2025-05-13">
+<meta property="article:published_time" content="2025-05-13">
+<meta property="og:type" content="article">
+<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"article","name":"Blackberry Blossom (4) \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","headline":"Blackberry Blossom (4) \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","mainEntityOfPage":"Blackberry Blossom (4)","identifier":"https:\/\/tunearch.org\/wiki\/Blackberry_Blossom_(4)","url":"https:\/\/tunearch.org\/wiki\/Blackberry_Blossom_(4)","description":"Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations","keywords":"traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection","dateModified":"2025-05-13","datePublished":"2025-05-13","image":{"@type":"ImageObject"},"author":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"publisher":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"potentialAction":{"@type":"SearchAction","target":"https:\/\/tunearch.org\/w\/index.php?title=Special:Search&search={search_term}","query-input":"required name=search_term"}}</script>
+</head>
+<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Blackberry_Blossom_4 rootpage-Blackberry_Blossom_4 skin-vector-2022 action-view"><a class="mw-jump-link" href="#bodyContent">Jump to content</a>
+<div class="vector-header-container">
+	<header class="vector-header mw-header">
+		<div class="vector-header-start">
+			<nav class="vector-main-menu-landmark" aria-label="Site">
+				
+<div id="vector-main-menu-dropdown" class="vector-dropdown vector-main-menu-dropdown vector-button-flush-left vector-button-flush-right"  >
+	<input type="checkbox" id="vector-main-menu-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-main-menu-dropdown" class="vector-dropdown-checkbox "  aria-label="Main menu"  >
+	<label id="vector-main-menu-dropdown-label" for="vector-main-menu-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-menu mw-ui-icon-wikimedia-menu"></span>
+
+<span class="vector-dropdown-label-text">Main menu</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+				<div id="vector-main-menu-unpinned-container" class="vector-unpinned-container">
+		
+<div id="vector-main-menu" class="vector-main-menu vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="main-menu-pinned"
+	data-pinnable-element-id="vector-main-menu"
+	data-pinned-container-id="vector-main-menu-pinned-container"
+	data-unpinned-container-id="vector-main-menu-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Main menu</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-main-menu.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-main-menu.unpin">hide</button>
+</div>
+
+	
+<div id="p-navigation" class="vector-menu mw-portlet mw-portlet-navigation"  >
+	<div class="vector-menu-heading">
+		Navigation
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-login" class="mw-list-item"><a href="/wiki/Special:UserLogin"><span>Login</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	
+<div id="p-" class="vector-menu mw-portlet mw-portlet- emptyPortlet"  >
+	<div class="vector-menu-heading">
+		
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☞_Welcome" class="vector-menu mw-portlet mw-portlet-☞_Welcome"  >
+	<div class="vector-menu-heading">
+		☞ Welcome
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Community-Portal" class="mw-list-item"><a href="/wiki/TTA:Community_portal"><span>Community Portal</span></a></li><li id="n-What" class="mw-list-item"><a href="/wiki/A_collection_of_tunes"><span>What</span></a></li><li id="n-Acknowledgments" class="mw-list-item"><a href="/wiki/Acknowledgments"><span>Acknowledgments</span></a></li><li id="n-New-&amp;-Noteworthy" class="mw-list-item"><a href="/wiki/TTA:New_Features_2026"><span>New &amp; Noteworthy</span></a></li><li id="n-Donate-to-TTA" class="mw-list-item"><a href="/wiki/TTA:Donate"><span>Donate to TTA</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-ⓘ_Help" class="vector-menu mw-portlet mw-portlet-ⓘ_Help"  >
+	<div class="vector-menu-heading">
+		ⓘ Help
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-User-Guide" class="mw-list-item"><a href="/wiki/TTA:Help"><span>User Guide</span></a></li><li id="n-Search-Help" class="mw-list-item"><a href="/wiki/TTA:Getting_started/Search"><span>Search Help</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☰_The_Archive" class="vector-menu mw-portlet mw-portlet-☰_The_Archive"  >
+	<div class="vector-menu-heading">
+		☰ The Archive
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-The-Index" class="mw-list-item"><a href="/wiki/Category:Tune"><span>The Index</span></a></li><li id="n-Query-the-Archive" class="mw-list-item"><a href="/wiki/Special:RunQuery/TuneQuery"><span>Query the Archive</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-✐_Publications" class="vector-menu mw-portlet mw-portlet-✐_Publications"  >
+	<div class="vector-menu-heading">
+		✐ Publications
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Magazines" class="mw-list-item"><a href="/wiki/Tune_History_Articles"><span>Magazines</span></a></li><li id="n-Tune-Books" class="mw-list-item"><a href="/wiki/Tune_books"><span>Tune Books</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+				</div>
+
+	</div>
+</div>
+
+		</nav>
+			
+<a href="/wiki/TTA" class="mw-logo">
+	<img class="mw-logo-icon" src="/w/resources/assets/TUC-160x120.png" alt="" aria-hidden="true" height="50" width="50">
+	<span class="mw-logo-container skin-invert">
+		<img class="mw-logo-wordmark" alt="The Traditional Tune Archive" src="/w/resources/assets/Centered-TTA-WordMark.svg" style="width: 11.25em; height: 1.5625em;">
+		<img class="mw-logo-tagline" alt="" src="/w/resources/assets/TTA-tagline.svg" width="135" height="20" style="width: 8.4375em; height: 1.25em;">
+	</span>
+</a>
+
+		</div>
+		<div class="vector-header-end">
+			
+<div id="p-search" role="search" class="vector-search-box-vue  vector-search-box-collapses vector-search-box-show-thumbnail vector-search-box-auto-expand-width vector-search-box">
+	<a href="/wiki/Special:Search" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only search-toggle" title="Search The Traditional Tune Archive [f]" accesskey="f"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+	</a>
+	<div class="vector-typeahead-search-container">
+		<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail cdx-typeahead-search--auto-expand-width">
+			<form action="/w/index.php" id="searchform" class="cdx-search-input cdx-search-input--has-end-button">
+				<div id="simpleSearch" class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+					<div class="cdx-text-input cdx-text-input--has-start-icon">
+						<input
+							class="cdx-text-input__input"
+							 type="search" name="search" placeholder="Search The Traditional Tune Archive" aria-label="Search The Traditional Tune Archive" autocapitalize="sentences" title="Search The Traditional Tune Archive [f]" accesskey="f" id="searchInput"
+							>
+						<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+					</div>
+					<input type="hidden" name="title" value="Special:Search">
+				</div>
+				<button class="cdx-button cdx-search-input__end-button">Search</button>
+			</form>
+		</div>
+	</div>
+</div>
+
+			<nav class="vector-user-links vector-user-links-wide" aria-label="Personal tools">
+	<div class="vector-user-links-main">
+	
+<div id="p-vector-user-menu-preferences" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-userpage" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	<nav class="vector-appearance-landmark" aria-label="Appearance">
+		
+<div id="vector-appearance-dropdown" class="vector-dropdown "  title="Change the appearance of the page&#039;s font size, width, and color" >
+	<input type="checkbox" id="vector-appearance-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-appearance-dropdown" class="vector-dropdown-checkbox "  aria-label="Appearance"  >
+	<label id="vector-appearance-dropdown-label" for="vector-appearance-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-appearance mw-ui-icon-wikimedia-appearance"></span>
+
+<span class="vector-dropdown-label-text">Appearance</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+			<div id="vector-appearance-unpinned-container" class="vector-unpinned-container">
+				
+			</div>
+		
+	</div>
+</div>
+
+	</nav>
+	
+<div id="p-vector-user-menu-notifications" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-overflow" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/w/index.php?title=Special:UserLogin&amp;returnto=Blackberry+Blossom+%284%29" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o" class=""><span>Log in</span></a>
+</li>
+<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory" class=""><span>Request account</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	</div>
+	
+<div id="vector-user-links-dropdown" class="vector-dropdown vector-user-menu vector-button-flush-right vector-user-menu-logged-out user-links-collapsible-item"  title="More options" >
+	<input type="checkbox" id="vector-user-links-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-user-links-dropdown" class="vector-dropdown-checkbox "  aria-label="Personal tools"  >
+	<label id="vector-user-links-dropdown-label" for="vector-user-links-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-ellipsis mw-ui-icon-wikimedia-ellipsis"></span>
+
+<span class="vector-dropdown-label-text">Personal tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+		
+<div id="p-personal" class="vector-menu mw-portlet mw-portlet-personal user-links-collapsible-item"  title="User menu" >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=Blackberry+Blossom+%284%29" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Log in</span></a></li><li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory"><span>Request account</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	</div>
+</div>
+
+</nav>
+
+		</div>
+	</header>
+
+<!-- Google tag (gtag.js) -->
+<!--<script async src="https://www.googletagmanager.com/gtag/js?id=G-YFX3N1E17F"></script> -->
+<!--<script> -->
+<!--  window.dataLayer = window.dataLayer || []; -->
+<!--  function gtag(){dataLayer.push(arguments);} -->
+<!--  gtag('js', new Date()); -->
+
+<!--  gtag('config', 'G-YFX3N1E17F'); -->
+
+<!--</script> -->
+
+            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+            <link rel="stylesheet" type="text/css" href="/w/JavaScript/resources/abcjs-midi.css">
+            <script src="/w/JavaScript/abcjs-plugin-min.js" type="text/javascript"></script>
+<!-- abcjs_plugin_5.9.0-min.js-->
+               <script type="text/javascript">
+                                window.ABCJS.plugin.hide_abc = false;
+                                window.ABCJS.plugin.render_before = true;
+                                window.ABCJS.plugin.auto_render_threshold = 50;
+                                window.ABCJS.plugin.oneSvgPerLine = true;
+                                window.ABCJS.plugin.render_options = {scale: 0.9,paddingtop: 0, paddingbottom: 0, paddingright: 0, paddingleft: 0,}
+               </script>
+               <style>
+                 .print-only {
+                 max-height: 0;
+                 overflow: hidden;
+                 }
+
+                 @media print {
+                 .render-abc {
+                 overflow: inherit !important;
+                 break-after: page;
+                 page-break-after: always;
+                 }
+                 .no-print {
+                 display: none !important;
+                  }
+                  .print-only {
+                  max-height: inherit;
+                  overflow: inherit;
+                  }
+                 </style>
+
+</div>
+<div class="mw-page-container">
+	<div class="mw-page-container-inner">
+		<div class="vector-sitenotice-container">
+			<div id="siteNotice"><div id="mw-dismissablenotice-anonplace"></div><script>(function(){var node=document.getElementById("mw-dismissablenotice-anonplace");if(node){node.outerHTML="\u003Cdiv id=\"localNotice\" data-nosnippet=\"\"\u003E\u003Cdiv class=\"sitenotice\" lang=\"en\" dir=\"ltr\"\u003E\u003Cdiv style=\"text-align:center; font-size:95%; background:#f4f5f9; border-bottom:1px solid #ddd; padding:4px 0;\"\u003E\n\u003Cp\u003E\u003Cspan typeof=\"mw:File\"\u003E\u003Cspan\u003E\u003Cimg alt=\"Universal Clef\" src=\"/w/images/thumb/7/7d/TUC-160x120.png/20px-TUC-160x120.png\" decoding=\"async\" width=\"20\" height=\"18\" class=\"mw-file-element\" srcset=\"/w/images/thumb/7/7d/TUC-160x120.png/30px-TUC-160x120.png 1.5x, /w/images/thumb/7/7d/TUC-160x120.png/40px-TUC-160x120.png 2x\" data-file-width=\"132\" data-file-height=\"120\" /\u003E\u003C/span\u003E\u003C/span\u003E\n\u003Cb\u003EThe TTA now offers the new \u003Ca href=\"/wiki/ABCSandbox\" title=\"ABCSandbox\"\u003E ABC Sandbox (Editor)\u003C/a\u003E, music-score printing, tunebook creation tools, an \u003Ca href=\"/wiki/TTA:TestAi\" title=\"TTA:TestAi\"\u003E AI assistant\u003C/a\u003E, and a new \u003Ca href=\"/wiki/Featured_Tunes_Music_Library\" title=\"Featured Tunes Music Library\"\u003E \u003Cspan style=\"color:#50C878;\"\u003E\u003Ci\u003EPlaylist system\u003C/i\u003E\u003C/span\u003E\u003C/a\u003E.  \u003Cbr /\u003E☞ see\u003C/b\u003E\n\u003Ca href=\"/wiki/TTA:New_Features_2026\" title=\"TTA:New Features 2026\"\u003ELatest additions \u0026amp; improvements\u003C/a\u003E\n\u003Cb\u003Eto learn more.\u003C/b\u003E\n\u003C/p\u003E\n\u003C/div\u003E\u003C/div\u003E\u003C/div\u003E";}}());</script></div>
+		</div>
+		<div class="vector-column-start">
+			<div class="vector-main-menu-container">
+		<div id="mw-navigation">
+			<nav id="mw-panel" class="vector-main-menu-landmark" aria-label="Site">
+				<div id="vector-main-menu-pinned-container" class="vector-pinned-container">
+				
+				</div>
+		</nav>
+		</div>
+	</div>
+</div>
+		<div class="mw-content-container">
+			<main id="content" class="mw-body">
+				<header class="mw-body-header vector-page-titlebar">
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">Blackberry Blossom (4)</span></h1>
+				</header>
+				<div class="vector-page-toolbar">
+					<div class="vector-page-toolbar-container">
+						<div id="left-navigation">
+							<nav aria-label="Namespaces">
+								
+<div id="p-associated-pages" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-associated-pages"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Blackberry_Blossom_(4)" title="View the content page [c]" accesskey="c"><span>Page</span></a></li><li id="ca-talk" class="new vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Talk:Blackberry_Blossom_(4)&amp;action=edit&amp;redlink=1" rel="discussion" class="new" title="Discussion about the content page (page does not exist) [t]" accesskey="t"><span>Discussion</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+								
+<div id="vector-variants-dropdown" class="vector-dropdown emptyPortlet"  >
+	<input type="checkbox" id="vector-variants-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-variants-dropdown" class="vector-dropdown-checkbox " aria-label="Change language variant"   >
+	<label id="vector-variants-dropdown-label" for="vector-variants-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">English</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+					
+<div id="p-variants" class="vector-menu mw-portlet mw-portlet-variants emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+						<div id="right-navigation" class="vector-collapsible">
+							<nav aria-label="Views">
+								
+<div id="p-views" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-views"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Blackberry_Blossom_(4)"><span>Read</span></a></li><li id="ca-formedit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=formedit" title="Edit this page with a form [&amp;]" accesskey="&amp;"><span>View form</span></a></li><li id="ca-viewsource" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=edit" title="This page is protected.&#10;You can view its source [e]" accesskey="e"><span>View source</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=history" title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+							</nav>
+				
+							<nav class="vector-page-tools-landmark" aria-label="Page tools">
+								
+<div id="vector-page-tools-dropdown" class="vector-dropdown vector-page-tools-dropdown"  >
+	<input type="checkbox" id="vector-page-tools-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-tools-dropdown" class="vector-dropdown-checkbox "  aria-label="Tools"  >
+	<label id="vector-page-tools-dropdown-label" for="vector-page-tools-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">Tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+									<div id="vector-page-tools-unpinned-container" class="vector-unpinned-container">
+						
+<div id="vector-page-tools" class="vector-page-tools vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-page-tools-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="page-tools-pinned"
+	data-pinnable-element-id="vector-page-tools"
+	data-pinned-container-id="vector-page-tools-pinned-container"
+	data-unpinned-container-id="vector-page-tools-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Tools</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-page-tools.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-page-tools.unpin">hide</button>
+</div>
+
+	
+<div id="p-cactions" class="vector-menu mw-portlet mw-portlet-cactions vector-has-collapsible-items"  title="More options" >
+	<div class="vector-menu-heading">
+		Actions
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/Blackberry_Blossom_(4)"><span>Read</span></a></li><li id="ca-more-formedit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=formedit"><span>View form</span></a></li><li id="ca-more-viewsource" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=edit"><span>View source</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=history"><span>View history</span></a></li><li id="ca-purge" class="is-disabled mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=purge"><span>Refresh</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-tb" class="vector-menu mw-portlet mw-portlet-tb"  >
+	<div class="vector-menu-heading">
+		General
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/Blackberry_Blossom_(4)" title="A list of all wiki pages that link here [j]" accesskey="j"><span>What links here</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Special:RecentChangesLinked/Blackberry_Blossom_(4)" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related changes</span></a></li><li id="t-upload" class="mw-list-item"><a href="/wiki/Special:UploadWizard" title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li><li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a></li><li id="t-print" class="mw-list-item"><a href="javascript:print();" rel="alternate" title="Printable version of this page [p]" accesskey="p"><span>Printable version</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;oldid=551096" title="Permanent link to this revision of this page"><span>Permanent link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Blackberry_Blossom_(4)&amp;action=info" title="More information about this page"><span>Page information</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=Blackberry_Blossom_%284%29&amp;id=551096&amp;wpFormIdentifier=titleform" title="Information on how to cite this page"><span>Cite this page</span></a></li><li id="t-smwbrowselink" class="mw-list-item"><a href="/wiki/Special:Browse/:Blackberry-5FBlossom-5F(4)" rel="search"><span>Browse properties</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+									</div>
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+					</div>
+				</div>
+				<div class="vector-column-end">
+					<div class="vector-sticky-pinned-container">
+						<nav class="vector-page-tools-landmark" aria-label="Page tools">
+							<div id="vector-page-tools-pinned-container" class="vector-pinned-container">
+				
+							</div>
+		</nav>
+						<nav class="vector-appearance-landmark" aria-label="Appearance">
+							<div id="vector-appearance-pinned-container" class="vector-pinned-container">
+				<div id="vector-appearance" class="vector-appearance vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-appearance-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="appearance-pinned"
+	data-pinnable-element-id="vector-appearance"
+	data-pinned-container-id="vector-appearance-pinned-container"
+	data-unpinned-container-id="vector-appearance-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Appearance</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-appearance.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-appearance.unpin">hide</button>
+</div>
+
+
+</div>
+
+							</div>
+		</nav>
+					</div>
+				</div>
+				<div id="bodyContent" class="vector-body" aria-labelledby="firstHeading" data-mw-ve-target-container>
+					<div class="vector-body-before-content">
+							<div class="mw-indicators">
+		<div id="mw-indicator-smw-entity-examiner" class="mw-indicator"><div class="smw-entity-examiner smw-indicator-vertical-bar-loader" data-subject="Blackberry_Blossom_(4)#0##" data-dir="ltr" data-uselang="" title="Running an examiner in the background"></div></div>
+		</div>
+
+						<div id="siteSub" class="noprint">Find traditional instrumental music</div>
+					</div>
+					<div id="contentSub"><div id="mw-content-subtitle"></div></div>
+					
+					
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr"><p><br />
+</p>
+<div class="noprint">
+<div class="mw-collapsible" data-expandtext="Show TuneInfoBox" data-collapsetext="Hide TuneInfoBox">
+<table style="width: 100%; font-size: 100.1%; border: 1px solid #aaaaaa; color: black; margin-bottom: 1em; margin-left: 0em; padding: 0.2em; text-align:left;">
+<tbody><tr>
+<th style="text-align: center; vertical-align: top; border: 1px solid #aaaaaa; background-color:#efefef;" colspan="2"><span style="font-family:sans-serif;font-size:17px;color:black;background-color:transparent;;"><b><a href="/wiki/Annotation:Blackberry_Blossom_(4)" title="Annotation:Blackberry Blossom (4)">Blackberry Blossom (4)</a></b></span>&#160; <span class="smw-highlighter" data-type="8" data-state="inline" data-title="Note" title="Click on the tune title to see or modify Blackberry Blossom (4)s annotations. If the link is red you can create them using the form provided."><span class="smwtticon note"></span><span class="smwttcontent">Click on the tune title to see or modify Blackberry Blossom (4)'s annotations. If the link is red you can create them using the form provided.</span></span><span class="smw-highlighter" data-type="6" data-state="persistent" data-title="Information" title="Browse Properties Special:Browse/:Blackberry Blossom (4)"><span class="smwtticon info"></span><span class="smwttcontent">Browse Properties &lt;br/&gt;<a href="/wiki/Special:Browse/:Blackberry_Blossom_(4)" title="Special:Browse/:Blackberry Blossom (4)">Special:Browse/:Blackberry Blossom (4)</a></span></span><figure class="mw-halign-right" typeof="mw:File"><a href="/wiki/Special:RunQuery/TuneQuery" title="Query the Archive"><img alt="Query the Archive" src="/w/images/thumb/c/c8/HSContribs.svg.png/35px-HSContribs.svg.png" decoding="async" width="35" height="35" class="mw-file-element" srcset="/w/images/c/c8/HSContribs.svg.png 1.5x" data-file-width="38" data-file-height="38" /></a><figcaption>Query the Archive</figcaption></figure>
+</th></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Theme code Index</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:#7f5620;background-color:transparent;;">1H1H7b7b 53b47bL</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Also known as</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Garfield%27s_Blackberry_Blossom" title="Garfield&#39;s Blackberry Blossom">Garfield&#39;s Blackberry Blossom</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Composer/Core Source</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Region</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">United States</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Genre/Style</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Old-Time</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Meter/Rhythm</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Reel (single/double)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Key/Tonic of</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">G</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Accidental</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1 flat</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Mode</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Dorian</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Time signature</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">4/4</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>History</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">USA(Upland South)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Structure</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">AABBCC</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Editor/Compiler</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/People_form/Biography:Stacy_Phillips" class="new" target="_self">Biography:Stacy Phillips</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Book/Manuscript title</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/Book/Book:Traditional_American_Fiddle_Tunes_vol._1" class="new" target="_self">Book:Traditional American Fiddle Tunes vol. 1</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Tune and/or Page number</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">p. 27</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year of publication/Date of MS</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1994</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Artist</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/People_form/Biography:Dick_Burnett_and_Oscar_Ruttledge" class="new" target="_self">Biography:Dick Burnett and Oscar Ruttledge</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Title of recording</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Record label/Catalogue nr.</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/w/index.php?title=Columbia_15567-D_(78_RPM)&amp;action=edit&amp;redlink=1" class="new" title="Columbia 15567-D (78 RPM) (page does not exist)">Columbia 15567-D (78 RPM)</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year recorded</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1930</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Media</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Score</b></span> &#160;&#160;(<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1</span>)
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;
+</td></tr></tbody></table>
+</div>
+</div>
+<div class="noprint">
+<div class="mw-collapsible mw-collapsed" data-expandtext="Show Tune Graph" data-collapsetext="Hide Tune Graph">
+<div id="network-viz-1" class="network-visualization" data-pages="[&quot;Blackberry Blossom (4)&quot;]" data-excludedpages="[&quot;TTA&quot;,&quot;Featured Tunes Music Library&quot;,&quot;Featured content&quot;]" data-excludednamespaces="[&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;12&quot;,&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;10&quot;,&quot;12&quot;,&quot;200&quot;,&quot;202&quot;,&quot;3002&quot;]" data-options="{&quot;layout&quot;:{&quot;randomSeed&quot;:42},&quot;physics&quot;:{&quot;barnesHut&quot;:{&quot;gravitationalConstant&quot;:-5000,&quot;damping&quot;:0.242}},&quot;nodes&quot;:{&quot;color&quot;:{&quot;background&quot;:&quot;white&quot;,&quot;highlight&quot;:{&quot;background&quot;:&quot;white&quot;}},&quot;borderWidth&quot;:1,&quot;shape&quot;:&quot;box&quot;,&quot;size&quot;:10,&quot;shapeProperties&quot;:{&quot;useBorderWithImage&quot;:true},&quot;borderWidthSelected&quot;:2},&quot;groups&quot;:{&quot;bluelink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/article-rtl-progressive.svg&quot;},&quot;redlink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/articleNotFound-ltr.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;#ba0000&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;#ba0000&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;#ba0000&quot;}},&quot;externallink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/linkExternal-ltr-progressive.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;grey&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;grey&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;grey&quot;}}},&quot;clickToUse&quot;:true}" data-enabledisplaytitle="true" data-labelmaxlength="0"></div>
+</div>
+</div>
+<p><br />
+</p><p><br />
+</p><p><font face="sans-serif" size="4">
+</font></p><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Blackberry_Blossom_(4)" title="Annotation:Blackberry Blossom (4)">Blackberry Blossom (4): Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+<font face="sans-serif" size="2">
+</font></p><font face="sans-serif" size="2"><hr /></font><font face="sans-serif" size="2"><p class="mw-empty-elt"></p><section></section></font><p><font face="sans-serif" size="2">
+X: 1
+T:Garfield's Blackberry Blossom
+M:4/4
+L:1/8
+K:G
+|:gagf gagf|dcBd cB G2|gagf gagf|d2 [B2g2] [B2g2] ga|
+|b2 a2 gagf|dcBd cB G2|GDBc d2 cB|A G2 G G4:|
+|:{D}G2 Bc d2 [B2g2]|dcBd cB G2|{D}[G,2G2] Bc d2 cd|G2 GF G4|
+{D}[G,2G2] Bc d2 g2|dcBd cB G2|GAGF DCB,C|[B,2D2] GF G4&#160;:|
+</font></p><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><p><font face="sans-serif" size="2">
+</font>
+</p><font face="sans-serif" size="4"><p class="mw-empty-elt"></p></font><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Blackberry_Blossom_(4)" title="Annotation:Blackberry Blossom (4)">Blackberry Blossom (4): Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+</p>
+<!-- 
+NewPP limit report
+Cached time: 20251219014647
+Cache expiry: 1209600
+Reduced expiry: false
+Complications: [vary‐user]
+[SMW] In‐text annotation parser time: 0.051 seconds
+CPU time usage: 0.201 seconds
+Real time usage: 0.287 seconds
+Preprocessor visited node count: 2076/1000000
+Post‐expand include size: 20601/2097152 bytes
+Template argument size: 2701/2097152 bytes
+Highest expansion depth: 8/100
+Expensive parser function count: 0/100
+Unstrip recursion depth: 0/20
+Unstrip post‐expand size: 2570/5000000 bytes
+Lua time usage: 0.040/7 seconds
+Lua virtual size: 5185536/52428800 bytes
+Lua estimated memory usage: 0 bytes
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  192.031      1 Template:Abctune
+100.00%  192.031      1 -total
+ 42.37%   81.365      1 Template:Break
+ 31.18%   59.871     45 Template:Font
+  0.93%    1.780      1 Template:F_score
+-->
+
+<!-- Saved in parser cache with key tunearch_wikidb:pcache:idhash:3581-0!canonical and timestamp 20251219014647 and revision id 551096. Rendering was triggered because: page-view
+ -->
+</div>
+<div class="printfooter" data-nosnippet="">Retrieved from "<a dir="ltr" href="https://tunearch.org/w/index.php?title=Blackberry_Blossom_(4)&amp;oldid=551096">https://tunearch.org/w/index.php?title=Blackberry_Blossom_(4)&amp;oldid=551096</a>"</div></div>
+					<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Special:Categories" title="Special:Categories">Category</a>: <ul><li><a href="/wiki/Category:Tune" title="Category:Tune">Tune</a></li></ul></div></div>
+				</div>
+			</main>
+			
+		</div>
+		<div class="mw-footer-container">
+			
+<footer id="footer" class="mw-footer" >
+	<ul id="footer-info">
+	<li id="footer-info-lastmod"> This page was last edited on 19 December 2025, at 02:46.</li>
+	<li id="footer-info-copyright">Content is available under <a class="external" rel="nofollow" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike</a> unless otherwise noted.</li>
+</ul>
+
+	<ul id="footer-places">
+	<li id="footer-places-privacy"><a href="/wiki/TTA:Privacy_policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/TTA:About">About The Traditional Tune Archive</a></li>
+	<li id="footer-places-disclaimers"><a href="/wiki/TTA:General_disclaimer">Disclaimers</a></li>
+	<li id="footer-places-mobileview"><a href="https://tunearch.org/w/index.php?title=Blackberry_Blossom_(4)&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+	<li id="footer-places-manage-cookie-preferences"><a href="#" id="manage-cookie-preferences">Manage cookie preferences</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://creativecommons.org/licenses/by-sa/4.0/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/licenses/cc-by-sa.png" alt="Creative Commons Attribution-ShareAlike" width="88" height="31" loading="lazy"></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/poweredby_mediawiki.svg" alt="Powered by MediaWiki" width="88" height="31" loading="lazy"></a><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/extensions/SemanticMediaWiki/res/smw/assets/logo_footer.svg" alt="Powered by Semantic MediaWiki" class="smw-footer" width="88" height="31" loading="lazy"></a></li>
+</ul>
+
+</footer>
+
+		</div>
+	</div> 
+
+<!-- WIDGET -->
+
+<!-- Bubble Widget -->
+
+<div id="bubbleWidget"
+     data-endpoint="https://tunearch.org/tta"
+     data-stream="true"
+     data-useweb="true"
+     data-session="widget">
+
+  <!-- Chat window -->
+  <div id="chatWidget" class="hidden">
+    <div class="chat-header">
+      <h3>Hello! Ask me anything about traditional music.</h3>
+    </div>
+    <div class="chat-container">
+      <div class="chat-box" id="chatBox"></div>
+      <div class="message-input">
+        <textarea id="widgetTextarea" placeholder="Your question here..."></textarea>
+        <button class="send-button">
+          <img src="/static/send-icon.png" alt="Send" />
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Floating button -->
+  <div id="bubbleButton">
+    <i class="fa fa-comments" style="color: white; font-size: 24px;"></i>
+  </div>
+</div>
+
+<link rel="stylesheet" href="/static/style.css?v=20251006-2">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+<script src="/static/widget.js?v=20251006-15" defer></script>
+
+<!-- EOFWIDGET -->
+
+</div> 
+<div class="vector-settings" id="p-dock-bottom">
+	<ul></ul>
+</div>
+<script src="/w/JavaScript/abcjs-basic.js"></script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":454,"wgPageParseReport":{"smw":{"limitreport-intext-parsertime":0.051},"limitreport":{"cputime":"0.201","walltime":"0.287","ppvisitednodes":{"value":2076,"limit":1000000},"postexpandincludesize":{"value":20601,"limit":2097152},"templateargumentsize":{"value":2701,"limit":2097152},"expansiondepth":{"value":8,"limit":100},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":2570,"limit":5000000},"timingprofile":["100.00%  192.031      1 Template:Abctune","100.00%  192.031      1 -total"," 42.37%   81.365      1 Template:Break"," 31.18%   59.871     45 Template:Font","  0.93%    1.780      1 Template:F_score"]},"scribunto":{"limitreport-timeusage":{"value":"0.040","limit":"7"},"limitreport-virtmemusage":{"value":5185536,"limit":52428800},"limitreport-estmemusage":0},"cachereport":{"timestamp":"20251219014647","ttl":1209600,"transientcontent":false}}});});</script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9b4dd24ccd8c0fd8',t:'MTc2Njg5MDk3NA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/sources/tunearch/raw/cricket_on_the_hearth.html
+++ b/sources/tunearch/raw/cricket_on_the_hearth.html
@@ -1,0 +1,812 @@
+<!DOCTYPE html>
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<title>Cricket on the Hearth – Reel (single/double) from United States – The Traditional Tune Archive</title>
+<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available";var cookie=document.cookie.match(/(?:^|; )tunearch_wikidbmwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],
+"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"aVCen1S2sAuBThxLuxhnzwAAAAA","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Cricket_on_the_Hearth","wgTitle":"Cricket on the Hearth","wgCurRevisionId":542205,"wgRevisionId":542205,"wgArticleId":6107,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Tune"],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Cricket_on_the_Hearth","wgRelevantArticleId":6107,"wgIsProbablyEditable":false,"wgRelevantPageIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgPageFormsTargetName":null,"wgPageFormsAutocompleteValues":[],"wgPageFormsAutocompleteOnAllChars":true,"wgPageFormsFieldProperties":[],"wgPageFormsCargoFields":[],
+"wgPageFormsDependentFields":[],"wgPageFormsCalendarValues":[],"wgPageFormsCalendarParams":[],"wgPageFormsCalendarHTML":null,"wgPageFormsGridValues":[],"wgPageFormsGridParams":[],"wgPageFormsContLangYes":null,"wgPageFormsContLangNo":null,"wgPageFormsContLangMonths":[],"wgPageFormsHeightForMinimizingInstances":800,"wgPageFormsDelayReload":false,"wgPageFormsShowOnSelect":[],"wgPageFormsScriptPath":"/w/extensions/PageForms","edgValues":[],"wgPageFormsEDSettings":null,"wgAmericanDates":false,"wgTinyMCETagList":
+"gallery|indicator|langconvert|randomuserswithavatars|newusers|headertabs|notabtoc|htmlet|youtube|aovideo|aoaudio|nicovideo|siteactivity|randomfeatureduser|editinline|vote|dynamicpagelist|categorytree|ref|references|imagemap|inputbox|poem|source|syntaxhighlight|comment-streams|no-comment-streams|comment-streams-initially-collapsed|section|embedvideo|evlplayer|vplayer|archiveorg|bandcamp|bilibili|ccc|dailymotion|externalvideo|kakaotv|loom|navertv|niconico|sharepoint|soundcloud|spotifyalbum|spotifyartist|spotifyshow|spotifyepisode|spotifytrack|twitch|twitchclip|twitchvod|videolink|vimeo|wistia|youtubeoembed|youtubeplaylist|youtubevideolist|score|templatestyles|seo|mobileonly|nomobile|pagelist|pages|pagequality|info|smwdoc|includeonly|onlyinclude|noinclude|nowiki","wgTinyMCELanguage":"en","wgTinyMCEDirectionality":"ltr","wgCheckFileExtensions":true,"wgStrictFileExtensions":true,"wgFileExtensions":["png","gif","jpg","jpeg","webp","pdf","ogg","djvu","svg","mp3","mp4","mm","abc","musicxml",
+"mscz","mus","sib","ly","webm","flac","mkv","mov","mp3","mp4","oga","ogg","ogv","wav","webm"],"wgFileBlacklist":["html","htm","js","jsb","mhtml","mht","xhtml","xht","php","phtml","php3","php4","php5","phps","phar","shtml","jhtml","pl","py","cgi","exe","scr","dll","msi","vbs","bat","com","pif","cmd","vxd","cpl","xml"],"wgEnableUploads":true,"wgTinyMCEVersion":"1.1.2","wgTinyMCEUserMayUpload":false,"wgTinyMCEUserMayUploadFromURL":false,"wgTinyMCEUserIsBlocked":false,"wgTinyMCESettings":null,"wgWsTinyMCEModals":null,"wgServer":"https://tunearch.org","wgScript":"/w/index.php","wgMetrolookEnabledModules":{"collapsiblenav":true},"wgCiteReferencePreviewsActive":true,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgMFDisplayWikibaseDescriptions":{"search":false,"watchlist":false,"tagline":false},"srfFilteredConfig":null,"networkExcludeTalkPages":true,"prpProofreadPageBookNamespaces":[0],"wgIsMobile":false};RLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready",
+"user.options":"loading","ext.smw.styles":"ready","ext.smw.tooltip.styles":"ready","ext.NoTitle":"ready","ext.proofreadpage.base":"ready","ext.proofreadpage.article":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","jquery.makeCollapsible.styles":"ready","ext.socialprofile.responsive":"ready","ext.SearchThumbs":"ready","ext.embedVideo.styles":"ready","oojs-ui-core.styles":"ready","oojs-ui.styles.indicators":"ready","mediawiki.widgets.styles":"ready","oojs-ui-core.icons":"ready","ext.MobileDetect.nomobile":"ready","ext.srf.styles":"ready"};RLPAGEMODULES=["ext.smw.styles","oojs-ui.styles.icons-movement","ext.smw.tooltip","ext.network","ext.tinymce","smw.entityexaminer","site","mediawiki.page.ready","jquery.makeCollapsible","skins.vector.js","ext.createPage","ext.SimpleTooltip","ext.abcHoverPreview","ext.gadget.ProfessionalTunebookPDF","ext.gadget.TuneBook","ext.gadget.ttaPlaylist","ext.gadget.ttaPlaylistManager",
+"ext.gadget.ttaPlaylistLibrary","ext.gadget.CommunityPortalTalkTab","mmv.bootstrap","ext.embedVideo.overlay","ext.CookieConsent","ext.addPersonalUrls","ext.smw.purge"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+}];});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.MobileDetect.nomobile%7Cext.NoTitle%2CSearchThumbs%7Cext.embedVideo.styles%7Cext.proofreadpage.article%2Cbase%7Cext.smw.styles%7Cext.smw.tooltip.styles%7Cext.socialprofile.responsive%7Cext.srf.styles%7Cjquery.makeCollapsible.styles%7Cmediawiki.widgets.styles%7Coojs-ui-core.icons%2Cstyles%7Coojs-ui.styles.indicators%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles&amp;only=styles&amp;skin=vector-2022">
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
+<style>#mw-indicator-mw-helplink {display:none;}</style>
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">
+<meta name="generator" content="MediaWiki 1.43.0">
+<meta name="robots" content="max-image-preview:standard">
+<meta name="format-detection" content="telephone=no">
+<meta name="google-site-verification" content="krO8QFzwmzrdm3epW25GRfSvDsKnyBzIXTONRqwqQqY">
+<meta name="msvalidate.01" content="14D63D178522A365E3CE5C63B5AB243D">
+<meta name="yandex-verification" content="6f2e53bf8f8205e7">
+<meta name="p:domain_verify" content="0e8457e9a76fa77a665556543311c158">
+<meta name="description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta name="keywords" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1091">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png">
+<meta property="og:image:width" content="800">
+<meta property="og:image:height" content="727">
+<meta property="og:image:width" content="640">
+<meta property="og:image:height" content="582">
+<meta name="viewport" content="width=1120">
+<link rel="alternate" type="application/rdf+xml" title="Cricket on the Hearth" href="/w/index.php?title=Special:ExportRDF/Cricket_on_the_Hearth&amp;xmlmime=rdf">
+<link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="The Traditional Tune Archive (en)">
+<link rel="EditURI" type="application/rsd+xml" href="https://tunearch.org/w/api.php?action=rsd">
+<link rel="canonical" href="https://tunearch.org/wiki/Cricket_on_the_Hearth">
+<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+<link rel="alternate" type="application/atom+xml" title="The Traditional Tune Archive Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom">
+<meta property="og:title" content="Cricket on the Hearth – Reel (single/double) from United States – The Traditional Tune Archive">
+<meta property="og:site_name" content="The Traditional Tune Archive">
+<meta property="og:url" content="https://tunearch.org/wiki/Cricket_on_the_Hearth">
+<meta property="article:author" content="https://www.tunearch.org/wiki/User:Andrew">
+<meta property="og:description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png?version=bf4cac7a8e2ab09d17a367772ce4b36d">
+<meta property="og:image:width" content="132">
+<meta property="og:image:height" content="120">
+<meta property="og:image:alt" content="Traditional universal music">
+<meta property="article:tag" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta property="article:modified_time" content="2025-02-04">
+<meta property="article:published_time" content="2025-02-04">
+<meta property="og:type" content="article">
+<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"article","name":"Cricket on the Hearth \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","headline":"Cricket on the Hearth \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","mainEntityOfPage":"Cricket on the Hearth","identifier":"https:\/\/tunearch.org\/wiki\/Cricket_on_the_Hearth","url":"https:\/\/tunearch.org\/wiki\/Cricket_on_the_Hearth","description":"Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations","keywords":"traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection","dateModified":"2025-02-04","datePublished":"2025-02-04","image":{"@type":"ImageObject","url":"https:\/\/tunearch.org\/w\/images\/7\/7d\/TUC-160x120.png?version=bf4cac7a8e2ab09d17a367772ce4b36d","width":132,"height":120},"author":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"publisher":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"potentialAction":{"@type":"SearchAction","target":"https:\/\/tunearch.org\/w\/index.php?title=Special:Search&search={search_term}","query-input":"required name=search_term"}}</script>
+</head>
+<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Cricket_on_the_Hearth rootpage-Cricket_on_the_Hearth skin-vector-2022 action-view"><a class="mw-jump-link" href="#bodyContent">Jump to content</a>
+<div class="vector-header-container">
+	<header class="vector-header mw-header">
+		<div class="vector-header-start">
+			<nav class="vector-main-menu-landmark" aria-label="Site">
+				
+<div id="vector-main-menu-dropdown" class="vector-dropdown vector-main-menu-dropdown vector-button-flush-left vector-button-flush-right"  >
+	<input type="checkbox" id="vector-main-menu-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-main-menu-dropdown" class="vector-dropdown-checkbox "  aria-label="Main menu"  >
+	<label id="vector-main-menu-dropdown-label" for="vector-main-menu-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-menu mw-ui-icon-wikimedia-menu"></span>
+
+<span class="vector-dropdown-label-text">Main menu</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+				<div id="vector-main-menu-unpinned-container" class="vector-unpinned-container">
+		
+<div id="vector-main-menu" class="vector-main-menu vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="main-menu-pinned"
+	data-pinnable-element-id="vector-main-menu"
+	data-pinned-container-id="vector-main-menu-pinned-container"
+	data-unpinned-container-id="vector-main-menu-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Main menu</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-main-menu.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-main-menu.unpin">hide</button>
+</div>
+
+	
+<div id="p-navigation" class="vector-menu mw-portlet mw-portlet-navigation"  >
+	<div class="vector-menu-heading">
+		Navigation
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-login" class="mw-list-item"><a href="/wiki/Special:UserLogin"><span>Login</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	
+<div id="p-" class="vector-menu mw-portlet mw-portlet- emptyPortlet"  >
+	<div class="vector-menu-heading">
+		
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☞_Welcome" class="vector-menu mw-portlet mw-portlet-☞_Welcome"  >
+	<div class="vector-menu-heading">
+		☞ Welcome
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Community-Portal" class="mw-list-item"><a href="/wiki/TTA:Community_portal"><span>Community Portal</span></a></li><li id="n-What" class="mw-list-item"><a href="/wiki/A_collection_of_tunes"><span>What</span></a></li><li id="n-Acknowledgments" class="mw-list-item"><a href="/wiki/Acknowledgments"><span>Acknowledgments</span></a></li><li id="n-New-&amp;-Noteworthy" class="mw-list-item"><a href="/wiki/TTA:New_Features_2026"><span>New &amp; Noteworthy</span></a></li><li id="n-Donate-to-TTA" class="mw-list-item"><a href="/wiki/TTA:Donate"><span>Donate to TTA</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-ⓘ_Help" class="vector-menu mw-portlet mw-portlet-ⓘ_Help"  >
+	<div class="vector-menu-heading">
+		ⓘ Help
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-User-Guide" class="mw-list-item"><a href="/wiki/TTA:Help"><span>User Guide</span></a></li><li id="n-Search-Help" class="mw-list-item"><a href="/wiki/TTA:Getting_started/Search"><span>Search Help</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☰_The_Archive" class="vector-menu mw-portlet mw-portlet-☰_The_Archive"  >
+	<div class="vector-menu-heading">
+		☰ The Archive
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-The-Index" class="mw-list-item"><a href="/wiki/Category:Tune"><span>The Index</span></a></li><li id="n-Query-the-Archive" class="mw-list-item"><a href="/wiki/Special:RunQuery/TuneQuery"><span>Query the Archive</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-✐_Publications" class="vector-menu mw-portlet mw-portlet-✐_Publications"  >
+	<div class="vector-menu-heading">
+		✐ Publications
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Magazines" class="mw-list-item"><a href="/wiki/Tune_History_Articles"><span>Magazines</span></a></li><li id="n-Tune-Books" class="mw-list-item"><a href="/wiki/Tune_books"><span>Tune Books</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+				</div>
+
+	</div>
+</div>
+
+		</nav>
+			
+<a href="/wiki/TTA" class="mw-logo">
+	<img class="mw-logo-icon" src="/w/resources/assets/TUC-160x120.png" alt="" aria-hidden="true" height="50" width="50">
+	<span class="mw-logo-container skin-invert">
+		<img class="mw-logo-wordmark" alt="The Traditional Tune Archive" src="/w/resources/assets/Centered-TTA-WordMark.svg" style="width: 11.25em; height: 1.5625em;">
+		<img class="mw-logo-tagline" alt="" src="/w/resources/assets/TTA-tagline.svg" width="135" height="20" style="width: 8.4375em; height: 1.25em;">
+	</span>
+</a>
+
+		</div>
+		<div class="vector-header-end">
+			
+<div id="p-search" role="search" class="vector-search-box-vue  vector-search-box-collapses vector-search-box-show-thumbnail vector-search-box-auto-expand-width vector-search-box">
+	<a href="/wiki/Special:Search" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only search-toggle" title="Search The Traditional Tune Archive [f]" accesskey="f"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+	</a>
+	<div class="vector-typeahead-search-container">
+		<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail cdx-typeahead-search--auto-expand-width">
+			<form action="/w/index.php" id="searchform" class="cdx-search-input cdx-search-input--has-end-button">
+				<div id="simpleSearch" class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+					<div class="cdx-text-input cdx-text-input--has-start-icon">
+						<input
+							class="cdx-text-input__input"
+							 type="search" name="search" placeholder="Search The Traditional Tune Archive" aria-label="Search The Traditional Tune Archive" autocapitalize="sentences" title="Search The Traditional Tune Archive [f]" accesskey="f" id="searchInput"
+							>
+						<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+					</div>
+					<input type="hidden" name="title" value="Special:Search">
+				</div>
+				<button class="cdx-button cdx-search-input__end-button">Search</button>
+			</form>
+		</div>
+	</div>
+</div>
+
+			<nav class="vector-user-links vector-user-links-wide" aria-label="Personal tools">
+	<div class="vector-user-links-main">
+	
+<div id="p-vector-user-menu-preferences" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-userpage" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	<nav class="vector-appearance-landmark" aria-label="Appearance">
+		
+<div id="vector-appearance-dropdown" class="vector-dropdown "  title="Change the appearance of the page&#039;s font size, width, and color" >
+	<input type="checkbox" id="vector-appearance-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-appearance-dropdown" class="vector-dropdown-checkbox "  aria-label="Appearance"  >
+	<label id="vector-appearance-dropdown-label" for="vector-appearance-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-appearance mw-ui-icon-wikimedia-appearance"></span>
+
+<span class="vector-dropdown-label-text">Appearance</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+			<div id="vector-appearance-unpinned-container" class="vector-unpinned-container">
+				
+			</div>
+		
+	</div>
+</div>
+
+	</nav>
+	
+<div id="p-vector-user-menu-notifications" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-overflow" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/w/index.php?title=Special:UserLogin&amp;returnto=Cricket+on+the+Hearth" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o" class=""><span>Log in</span></a>
+</li>
+<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory" class=""><span>Request account</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	</div>
+	
+<div id="vector-user-links-dropdown" class="vector-dropdown vector-user-menu vector-button-flush-right vector-user-menu-logged-out user-links-collapsible-item"  title="More options" >
+	<input type="checkbox" id="vector-user-links-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-user-links-dropdown" class="vector-dropdown-checkbox "  aria-label="Personal tools"  >
+	<label id="vector-user-links-dropdown-label" for="vector-user-links-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-ellipsis mw-ui-icon-wikimedia-ellipsis"></span>
+
+<span class="vector-dropdown-label-text">Personal tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+		
+<div id="p-personal" class="vector-menu mw-portlet mw-portlet-personal user-links-collapsible-item"  title="User menu" >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=Cricket+on+the+Hearth" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Log in</span></a></li><li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory"><span>Request account</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	</div>
+</div>
+
+</nav>
+
+		</div>
+	</header>
+
+<!-- Google tag (gtag.js) -->
+<!--<script async src="https://www.googletagmanager.com/gtag/js?id=G-YFX3N1E17F"></script> -->
+<!--<script> -->
+<!--  window.dataLayer = window.dataLayer || []; -->
+<!--  function gtag(){dataLayer.push(arguments);} -->
+<!--  gtag('js', new Date()); -->
+
+<!--  gtag('config', 'G-YFX3N1E17F'); -->
+
+<!--</script> -->
+
+            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+            <link rel="stylesheet" type="text/css" href="/w/JavaScript/resources/abcjs-midi.css">
+            <script src="/w/JavaScript/abcjs-plugin-min.js" type="text/javascript"></script>
+<!-- abcjs_plugin_5.9.0-min.js-->
+               <script type="text/javascript">
+                                window.ABCJS.plugin.hide_abc = false;
+                                window.ABCJS.plugin.render_before = true;
+                                window.ABCJS.plugin.auto_render_threshold = 50;
+                                window.ABCJS.plugin.oneSvgPerLine = true;
+                                window.ABCJS.plugin.render_options = {scale: 0.9,paddingtop: 0, paddingbottom: 0, paddingright: 0, paddingleft: 0,}
+               </script>
+               <style>
+                 .print-only {
+                 max-height: 0;
+                 overflow: hidden;
+                 }
+
+                 @media print {
+                 .render-abc {
+                 overflow: inherit !important;
+                 break-after: page;
+                 page-break-after: always;
+                 }
+                 .no-print {
+                 display: none !important;
+                  }
+                  .print-only {
+                  max-height: inherit;
+                  overflow: inherit;
+                  }
+                 </style>
+
+</div>
+<div class="mw-page-container">
+	<div class="mw-page-container-inner">
+		<div class="vector-sitenotice-container">
+			<div id="siteNotice"><div id="mw-dismissablenotice-anonplace"></div><script>(function(){var node=document.getElementById("mw-dismissablenotice-anonplace");if(node){node.outerHTML="\u003Cdiv id=\"localNotice\" data-nosnippet=\"\"\u003E\u003Cdiv class=\"sitenotice\" lang=\"en\" dir=\"ltr\"\u003E\u003Cdiv style=\"text-align:center; font-size:95%; background:#f4f5f9; border-bottom:1px solid #ddd; padding:4px 0;\"\u003E\n\u003Cp\u003E\u003Cspan typeof=\"mw:File\"\u003E\u003Cspan\u003E\u003Cimg alt=\"Universal Clef\" src=\"/w/images/thumb/7/7d/TUC-160x120.png/20px-TUC-160x120.png\" decoding=\"async\" width=\"20\" height=\"18\" class=\"mw-file-element\" srcset=\"/w/images/thumb/7/7d/TUC-160x120.png/30px-TUC-160x120.png 1.5x, /w/images/thumb/7/7d/TUC-160x120.png/40px-TUC-160x120.png 2x\" data-file-width=\"132\" data-file-height=\"120\" /\u003E\u003C/span\u003E\u003C/span\u003E\n\u003Cb\u003EThe TTA now offers the new \u003Ca href=\"/wiki/ABCSandbox\" title=\"ABCSandbox\"\u003E ABC Sandbox (Editor)\u003C/a\u003E, music-score printing, tunebook creation tools, an \u003Ca href=\"/wiki/TTA:TestAi\" title=\"TTA:TestAi\"\u003E AI assistant\u003C/a\u003E, and a new \u003Ca href=\"/wiki/Featured_Tunes_Music_Library\" title=\"Featured Tunes Music Library\"\u003E \u003Cspan style=\"color:#50C878;\"\u003E\u003Ci\u003EPlaylist system\u003C/i\u003E\u003C/span\u003E\u003C/a\u003E.  \u003Cbr /\u003E☞ see\u003C/b\u003E\n\u003Ca href=\"/wiki/TTA:New_Features_2026\" title=\"TTA:New Features 2026\"\u003ELatest additions \u0026amp; improvements\u003C/a\u003E\n\u003Cb\u003Eto learn more.\u003C/b\u003E\n\u003C/p\u003E\n\u003C/div\u003E\u003C/div\u003E\u003C/div\u003E";}}());</script></div>
+		</div>
+		<div class="vector-column-start">
+			<div class="vector-main-menu-container">
+		<div id="mw-navigation">
+			<nav id="mw-panel" class="vector-main-menu-landmark" aria-label="Site">
+				<div id="vector-main-menu-pinned-container" class="vector-pinned-container">
+				
+				</div>
+		</nav>
+		</div>
+	</div>
+</div>
+		<div class="mw-content-container">
+			<main id="content" class="mw-body">
+				<header class="mw-body-header vector-page-titlebar">
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">Cricket on the Hearth</span></h1>
+				</header>
+				<div class="vector-page-toolbar">
+					<div class="vector-page-toolbar-container">
+						<div id="left-navigation">
+							<nav aria-label="Namespaces">
+								
+<div id="p-associated-pages" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-associated-pages"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Cricket_on_the_Hearth" title="View the content page [c]" accesskey="c"><span>Page</span></a></li><li id="ca-talk" class="new vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Talk:Cricket_on_the_Hearth&amp;action=edit&amp;redlink=1" rel="discussion" class="new" title="Discussion about the content page (page does not exist) [t]" accesskey="t"><span>Discussion</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+								
+<div id="vector-variants-dropdown" class="vector-dropdown emptyPortlet"  >
+	<input type="checkbox" id="vector-variants-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-variants-dropdown" class="vector-dropdown-checkbox " aria-label="Change language variant"   >
+	<label id="vector-variants-dropdown-label" for="vector-variants-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">English</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+					
+<div id="p-variants" class="vector-menu mw-portlet mw-portlet-variants emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+						<div id="right-navigation" class="vector-collapsible">
+							<nav aria-label="Views">
+								
+<div id="p-views" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-views"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Cricket_on_the_Hearth"><span>Read</span></a></li><li id="ca-formedit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=formedit" title="Edit this page with a form [&amp;]" accesskey="&amp;"><span>View form</span></a></li><li id="ca-viewsource" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=edit" title="This page is protected.&#10;You can view its source [e]" accesskey="e"><span>View source</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=history" title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+							</nav>
+				
+							<nav class="vector-page-tools-landmark" aria-label="Page tools">
+								
+<div id="vector-page-tools-dropdown" class="vector-dropdown vector-page-tools-dropdown"  >
+	<input type="checkbox" id="vector-page-tools-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-tools-dropdown" class="vector-dropdown-checkbox "  aria-label="Tools"  >
+	<label id="vector-page-tools-dropdown-label" for="vector-page-tools-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">Tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+									<div id="vector-page-tools-unpinned-container" class="vector-unpinned-container">
+						
+<div id="vector-page-tools" class="vector-page-tools vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-page-tools-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="page-tools-pinned"
+	data-pinnable-element-id="vector-page-tools"
+	data-pinned-container-id="vector-page-tools-pinned-container"
+	data-unpinned-container-id="vector-page-tools-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Tools</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-page-tools.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-page-tools.unpin">hide</button>
+</div>
+
+	
+<div id="p-cactions" class="vector-menu mw-portlet mw-portlet-cactions vector-has-collapsible-items"  title="More options" >
+	<div class="vector-menu-heading">
+		Actions
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/Cricket_on_the_Hearth"><span>Read</span></a></li><li id="ca-more-formedit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=formedit"><span>View form</span></a></li><li id="ca-more-viewsource" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=edit"><span>View source</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=history"><span>View history</span></a></li><li id="ca-purge" class="is-disabled mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=purge"><span>Refresh</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-tb" class="vector-menu mw-portlet mw-portlet-tb"  >
+	<div class="vector-menu-heading">
+		General
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/Cricket_on_the_Hearth" title="A list of all wiki pages that link here [j]" accesskey="j"><span>What links here</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Special:RecentChangesLinked/Cricket_on_the_Hearth" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related changes</span></a></li><li id="t-upload" class="mw-list-item"><a href="/wiki/Special:UploadWizard" title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li><li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a></li><li id="t-print" class="mw-list-item"><a href="javascript:print();" rel="alternate" title="Printable version of this page [p]" accesskey="p"><span>Printable version</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;oldid=542205" title="Permanent link to this revision of this page"><span>Permanent link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Cricket_on_the_Hearth&amp;action=info" title="More information about this page"><span>Page information</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=Cricket_on_the_Hearth&amp;id=542205&amp;wpFormIdentifier=titleform" title="Information on how to cite this page"><span>Cite this page</span></a></li><li id="t-smwbrowselink" class="mw-list-item"><a href="/wiki/Special:Browse/:Cricket-5Fon-5Fthe-5FHearth" rel="search"><span>Browse properties</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+									</div>
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+					</div>
+				</div>
+				<div class="vector-column-end">
+					<div class="vector-sticky-pinned-container">
+						<nav class="vector-page-tools-landmark" aria-label="Page tools">
+							<div id="vector-page-tools-pinned-container" class="vector-pinned-container">
+				
+							</div>
+		</nav>
+						<nav class="vector-appearance-landmark" aria-label="Appearance">
+							<div id="vector-appearance-pinned-container" class="vector-pinned-container">
+				<div id="vector-appearance" class="vector-appearance vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-appearance-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="appearance-pinned"
+	data-pinnable-element-id="vector-appearance"
+	data-pinned-container-id="vector-appearance-pinned-container"
+	data-unpinned-container-id="vector-appearance-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Appearance</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-appearance.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-appearance.unpin">hide</button>
+</div>
+
+
+</div>
+
+							</div>
+		</nav>
+					</div>
+				</div>
+				<div id="bodyContent" class="vector-body" aria-labelledby="firstHeading" data-mw-ve-target-container>
+					<div class="vector-body-before-content">
+							<div class="mw-indicators">
+		<div id="mw-indicator-smw-entity-examiner" class="mw-indicator"><div class="smw-entity-examiner smw-indicator-vertical-bar-loader" data-subject="Cricket_on_the_Hearth#0##" data-dir="ltr" data-uselang="" title="Running an examiner in the background"></div></div>
+		</div>
+
+						<div id="siteSub" class="noprint">Find traditional instrumental music</div>
+					</div>
+					<div id="contentSub"><div id="mw-content-subtitle"></div></div>
+					
+					
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr"><p><br />
+</p>
+<div class="noprint">
+<div class="mw-collapsible" data-expandtext="Show TuneInfoBox" data-collapsetext="Hide TuneInfoBox">
+<table style="width: 100%; font-size: 100.1%; border: 1px solid #aaaaaa; color: black; margin-bottom: 1em; margin-left: 0em; padding: 0.2em; text-align:left;">
+<tbody><tr>
+<th style="text-align: center; vertical-align: top; border: 1px solid #aaaaaa; background-color:#efefef;" colspan="2"><span style="font-family:sans-serif;font-size:17px;color:black;background-color:transparent;;"><b><a href="/wiki/Annotation:Cricket_on_the_Hearth" title="Annotation:Cricket on the Hearth">Cricket on the Hearth</a></b></span>&#160; <span class="smw-highlighter" data-type="8" data-state="inline" data-title="Note" title="Click on the tune title to see or modify Cricket on the Hearths annotations. If the link is red you can create them using the form provided."><span class="smwtticon note"></span><span class="smwttcontent">Click on the tune title to see or modify Cricket on the Hearth's annotations. If the link is red you can create them using the form provided.</span></span><span class="smw-highlighter" data-type="6" data-state="persistent" data-title="Information" title="Browse Properties Special:Browse/:Cricket on the Hearth"><span class="smwtticon info"></span><span class="smwttcontent">Browse Properties &lt;br/&gt;<a href="/wiki/Special:Browse/:Cricket_on_the_Hearth" title="Special:Browse/:Cricket on the Hearth">Special:Browse/:Cricket on the Hearth</a></span></span><figure class="mw-halign-right" typeof="mw:File"><a href="/wiki/Special:RunQuery/TuneQuery" title="Query the Archive"><img alt="Query the Archive" src="/w/images/thumb/c/c8/HSContribs.svg.png/35px-HSContribs.svg.png" decoding="async" width="35" height="35" class="mw-file-element" srcset="/w/images/c/c8/HSContribs.svg.png 1.5x" data-file-width="38" data-file-height="38" /></a><figcaption>Query the Archive</figcaption></figure>
+</th></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Theme code Index</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:#7f5620;background-color:transparent;;">12H3H1H 444H4H</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Also known as</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/Abc_tune/Cricket_on_a_Hearth" class="new" target="_self">Cricket on a Hearth</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Composer/Core Source</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Region</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">United States</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Genre/Style</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Bluegrass, Old-Time</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Meter/Rhythm</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Reel (single/double)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Key/Tonic of</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">D</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Accidental</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">2 sharps</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Mode</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Ionian (Major)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Time signature</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">4/4</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>History</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">USA(Upland South), USA(Ozarks/Western Tenn)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Structure</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">AABB</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Editor/Compiler</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/People_form/Biography:David_Brody" class="new" target="_self">Biography:David Brody</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Book/Manuscript title</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/Book/Book:The_Fiddler&#39;s_Fakebook" class="new" target="_self">Book:The Fiddler's Fakebook</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Tune and/or Page number</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">p. 78</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year of publication/Date of MS</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1983</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Artist</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/People_form/Biography:Kenny_Baker" class="new" target="_self">Biography:Kenny Baker</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Title of recording</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/w/index.php?title=Portrait_of_a_Bluegrass_Fiddler&amp;action=edit&amp;redlink=1" class="new" title="Portrait of a Bluegrass Fiddler (page does not exist)">Portrait of a Bluegrass Fiddler</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Record label/Catalogue nr.</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/w/index.php?title=County_719&amp;action=edit&amp;redlink=1" class="new" title="County 719 (page does not exist)">County 719</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year recorded</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1968</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Media</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Score</b></span> &#160;&#160;(<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">0</span>)
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;
+</td></tr></tbody></table>
+</div>
+</div>
+<div class="noprint">
+<div class="mw-collapsible mw-collapsed" data-expandtext="Show Tune Graph" data-collapsetext="Hide Tune Graph">
+<div id="network-viz-1" class="network-visualization" data-pages="[&quot;Cricket on the Hearth&quot;]" data-excludedpages="[&quot;TTA&quot;,&quot;Featured Tunes Music Library&quot;,&quot;Featured content&quot;]" data-excludednamespaces="[&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;12&quot;,&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;10&quot;,&quot;12&quot;,&quot;200&quot;,&quot;202&quot;,&quot;3002&quot;]" data-options="{&quot;layout&quot;:{&quot;randomSeed&quot;:42},&quot;physics&quot;:{&quot;barnesHut&quot;:{&quot;gravitationalConstant&quot;:-5000,&quot;damping&quot;:0.242}},&quot;nodes&quot;:{&quot;color&quot;:{&quot;background&quot;:&quot;white&quot;,&quot;highlight&quot;:{&quot;background&quot;:&quot;white&quot;}},&quot;borderWidth&quot;:1,&quot;shape&quot;:&quot;box&quot;,&quot;size&quot;:10,&quot;shapeProperties&quot;:{&quot;useBorderWithImage&quot;:true},&quot;borderWidthSelected&quot;:2},&quot;groups&quot;:{&quot;bluelink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/article-rtl-progressive.svg&quot;},&quot;redlink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/articleNotFound-ltr.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;#ba0000&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;#ba0000&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;#ba0000&quot;}},&quot;externallink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/linkExternal-ltr-progressive.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;grey&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;grey&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;grey&quot;}}},&quot;clickToUse&quot;:true}" data-enabledisplaytitle="true" data-labelmaxlength="0"></div>
+</div>
+</div>
+<p><br />
+</p><p><br />
+</p><p><font face="sans-serif" size="4">
+</font></p><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Cricket_on_the_Hearth" title="Annotation:Cricket on the Hearth">Cricket on the Hearth: Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+<font face="sans-serif" size="2">
+</font></p><font face="sans-serif" size="2"><hr /></font><font face="sans-serif" size="2"><p class="mw-empty-elt"></p><section></section></font><p><font face="sans-serif" size="2">
+X:0
+T: No Score
+C: The Traditional Tune Archive
+M:
+K:
+x
+</font></p><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><p><font face="sans-serif" size="2">
+</font>    
+</p><font face="sans-serif" size="4"><p class="mw-empty-elt"></p></font><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Cricket_on_the_Hearth" title="Annotation:Cricket on the Hearth">Cricket on the Hearth: Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+</p>
+<!-- 
+NewPP limit report
+Cached time: 20251219043326
+Cache expiry: 1209600
+Reduced expiry: false
+Complications: [vary‐user]
+[SMW] In‐text annotation parser time: 0.022 seconds
+CPU time usage: 0.201 seconds
+Real time usage: 0.281 seconds
+Preprocessor visited node count: 2093/1000000
+Post‐expand include size: 21176/2097152 bytes
+Template argument size: 2849/2097152 bytes
+Highest expansion depth: 8/100
+Expensive parser function count: 0/100
+Unstrip recursion depth: 0/20
+Unstrip post‐expand size: 2470/5000000 bytes
+Lua time usage: 0.040/7 seconds
+Lua virtual size: 5226496/52428800 bytes
+Lua estimated memory usage: 0 bytes
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  193.528      1 Template:Abctune
+100.00%  193.528      1 -total
+ 41.14%   79.611      1 Template:Break
+ 33.47%   64.775     45 Template:Font
+  0.96%    1.849      1 Template:F_score
+-->
+
+<!-- Saved in parser cache with key tunearch_wikidb:pcache:idhash:6107-0!canonical and timestamp 20251219043326 and revision id 542205. Rendering was triggered because: page-view
+ -->
+</div>
+<div class="printfooter" data-nosnippet="">Retrieved from "<a dir="ltr" href="https://tunearch.org/w/index.php?title=Cricket_on_the_Hearth&amp;oldid=542205">https://tunearch.org/w/index.php?title=Cricket_on_the_Hearth&amp;oldid=542205</a>"</div></div>
+					<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Special:Categories" title="Special:Categories">Category</a>: <ul><li><a href="/wiki/Category:Tune" title="Category:Tune">Tune</a></li></ul></div></div>
+				</div>
+			</main>
+			
+		</div>
+		<div class="mw-footer-container">
+			
+<footer id="footer" class="mw-footer" >
+	<ul id="footer-info">
+	<li id="footer-info-lastmod"> This page was last edited on 19 December 2025, at 05:33.</li>
+	<li id="footer-info-copyright">Content is available under <a class="external" rel="nofollow" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike</a> unless otherwise noted.</li>
+</ul>
+
+	<ul id="footer-places">
+	<li id="footer-places-privacy"><a href="/wiki/TTA:Privacy_policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/TTA:About">About The Traditional Tune Archive</a></li>
+	<li id="footer-places-disclaimers"><a href="/wiki/TTA:General_disclaimer">Disclaimers</a></li>
+	<li id="footer-places-mobileview"><a href="https://tunearch.org/w/index.php?title=Cricket_on_the_Hearth&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+	<li id="footer-places-manage-cookie-preferences"><a href="#" id="manage-cookie-preferences">Manage cookie preferences</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://creativecommons.org/licenses/by-sa/4.0/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/licenses/cc-by-sa.png" alt="Creative Commons Attribution-ShareAlike" width="88" height="31" loading="lazy"></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/poweredby_mediawiki.svg" alt="Powered by MediaWiki" width="88" height="31" loading="lazy"></a><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/extensions/SemanticMediaWiki/res/smw/assets/logo_footer.svg" alt="Powered by Semantic MediaWiki" class="smw-footer" width="88" height="31" loading="lazy"></a></li>
+</ul>
+
+</footer>
+
+		</div>
+	</div> 
+
+<!-- WIDGET -->
+
+<!-- Bubble Widget -->
+
+<div id="bubbleWidget"
+     data-endpoint="https://tunearch.org/tta"
+     data-stream="true"
+     data-useweb="true"
+     data-session="widget">
+
+  <!-- Chat window -->
+  <div id="chatWidget" class="hidden">
+    <div class="chat-header">
+      <h3>Hello! Ask me anything about traditional music.</h3>
+    </div>
+    <div class="chat-container">
+      <div class="chat-box" id="chatBox"></div>
+      <div class="message-input">
+        <textarea id="widgetTextarea" placeholder="Your question here..."></textarea>
+        <button class="send-button">
+          <img src="/static/send-icon.png" alt="Send" />
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Floating button -->
+  <div id="bubbleButton">
+    <i class="fa fa-comments" style="color: white; font-size: 24px;"></i>
+  </div>
+</div>
+
+<link rel="stylesheet" href="/static/style.css?v=20251006-2">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+<script src="/static/widget.js?v=20251006-15" defer></script>
+
+<!-- EOFWIDGET -->
+
+</div> 
+<div class="vector-settings" id="p-dock-bottom">
+	<ul></ul>
+</div>
+<script src="/w/JavaScript/abcjs-basic.js"></script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":310,"wgPageParseReport":{"smw":{"limitreport-intext-parsertime":0.022},"limitreport":{"cputime":"0.201","walltime":"0.281","ppvisitednodes":{"value":2093,"limit":1000000},"postexpandincludesize":{"value":21176,"limit":2097152},"templateargumentsize":{"value":2849,"limit":2097152},"expansiondepth":{"value":8,"limit":100},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":2470,"limit":5000000},"timingprofile":["100.00%  193.528      1 Template:Abctune","100.00%  193.528      1 -total"," 41.14%   79.611      1 Template:Break"," 33.47%   64.775     45 Template:Font","  0.96%    1.849      1 Template:F_score"]},"scribunto":{"limitreport-timeusage":{"value":"0.040","limit":"7"},"limitreport-virtmemusage":{"value":5226496,"limit":52428800},"limitreport-estmemusage":0},"cachereport":{"timestamp":"20251219043326","ttl":1209600,"transientcontent":false}}});});</script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9b4dd7022e830fd1',t:'MTc2Njg5MTE2Nw=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/sources/tunearch/raw/salt_creek.html
+++ b/sources/tunearch/raw/salt_creek.html
@@ -1,0 +1,848 @@
+<!DOCTYPE html>
+<html class="client-nojs vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<title>Salt Creek – Reel (single/double) from United States – The Traditional Tune Archive</title>
+<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-0 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-toc-not-available";var cookie=document.cookie.match(/(?:^|; )tunearch_wikidbmwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\w+$|[^\w-]+/g,'')+'-clientpref-\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":false,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],
+"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"aVChBuSfHncP2U0y2U4NkAAAAMs","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Salt_Creek_(1)","wgTitle":"Salt Creek (1)","wgCurRevisionId":433277,"wgRevisionId":433277,"wgArticleId":88854,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Tune"],"wgPageViewLanguage":"en","wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"Salt_Creek_(1)","wgRelevantArticleId":88854,"wgIsProbablyEditable":false,"wgRelevantPageIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgRedirectedFrom":"Salt_Creek","wgPageFormsTargetName":null,"wgPageFormsAutocompleteValues":[],"wgPageFormsAutocompleteOnAllChars":true,"wgPageFormsFieldProperties":[],"wgPageFormsCargoFields":[],
+"wgPageFormsDependentFields":[],"wgPageFormsCalendarValues":[],"wgPageFormsCalendarParams":[],"wgPageFormsCalendarHTML":null,"wgPageFormsGridValues":[],"wgPageFormsGridParams":[],"wgPageFormsContLangYes":null,"wgPageFormsContLangNo":null,"wgPageFormsContLangMonths":[],"wgPageFormsHeightForMinimizingInstances":800,"wgPageFormsDelayReload":false,"wgPageFormsShowOnSelect":[],"wgPageFormsScriptPath":"/w/extensions/PageForms","edgValues":[],"wgPageFormsEDSettings":null,"wgAmericanDates":false,"wgTinyMCETagList":
+"gallery|indicator|langconvert|randomuserswithavatars|newusers|headertabs|notabtoc|htmlet|youtube|aovideo|aoaudio|nicovideo|siteactivity|randomfeatureduser|editinline|vote|dynamicpagelist|categorytree|ref|references|imagemap|inputbox|poem|source|syntaxhighlight|comment-streams|no-comment-streams|comment-streams-initially-collapsed|section|embedvideo|evlplayer|vplayer|archiveorg|bandcamp|bilibili|ccc|dailymotion|externalvideo|kakaotv|loom|navertv|niconico|sharepoint|soundcloud|spotifyalbum|spotifyartist|spotifyshow|spotifyepisode|spotifytrack|twitch|twitchclip|twitchvod|videolink|vimeo|wistia|youtubeoembed|youtubeplaylist|youtubevideolist|score|templatestyles|seo|mobileonly|nomobile|pagelist|pages|pagequality|info|smwdoc|includeonly|onlyinclude|noinclude|nowiki","wgTinyMCELanguage":"en","wgTinyMCEDirectionality":"ltr","wgCheckFileExtensions":true,"wgStrictFileExtensions":true,"wgFileExtensions":["png","gif","jpg","jpeg","webp","pdf","ogg","djvu","svg","mp3","mp4","mm","abc","musicxml",
+"mscz","mus","sib","ly","webm","flac","mkv","mov","mp3","mp4","oga","ogg","ogv","wav","webm"],"wgFileBlacklist":["html","htm","js","jsb","mhtml","mht","xhtml","xht","php","phtml","php3","php4","php5","phps","phar","shtml","jhtml","pl","py","cgi","exe","scr","dll","msi","vbs","bat","com","pif","cmd","vxd","cpl","xml"],"wgEnableUploads":true,"wgTinyMCEVersion":"1.1.2","wgTinyMCEUserMayUpload":false,"wgTinyMCEUserMayUploadFromURL":false,"wgTinyMCEUserIsBlocked":false,"wgTinyMCESettings":null,"wgWsTinyMCEModals":null,"wgServer":"https://tunearch.org","wgScript":"/w/index.php","wgMetrolookEnabledModules":{"collapsiblenav":true},"wgCiteReferencePreviewsActive":true,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgMFDisplayWikibaseDescriptions":{"search":false,"watchlist":false,"tagline":false},"srfFilteredConfig":null,"wgInternalRedirectTargetUrl":"/wiki/Salt_Creek_(1)","networkExcludeTalkPages":true,"prpProofreadPageBookNamespaces":[0],"wgIsMobile":false};RLSTATE={
+"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","ext.smw.styles":"ready","ext.smw.tooltip.styles":"ready","ext.NoTitle":"ready","ext.proofreadpage.base":"ready","ext.proofreadpage.article":"ready","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","jquery.makeCollapsible.styles":"ready","ext.socialprofile.responsive":"ready","ext.SearchThumbs":"ready","ext.embedVideo.styles":"ready","oojs-ui-core.styles":"ready","oojs-ui.styles.indicators":"ready","mediawiki.widgets.styles":"ready","oojs-ui-core.icons":"ready","ext.MobileDetect.nomobile":"ready","ext.srf.styles":"ready"};RLPAGEMODULES=["mediawiki.action.view.redirect","ext.smw.styles","oojs-ui.styles.icons-movement","ext.smw.tooltip","ext.network","ext.tinymce","smw.entityexaminer","site","mediawiki.page.ready","jquery.makeCollapsible","skins.vector.js","ext.createPage","ext.SimpleTooltip","ext.abcHoverPreview","ext.gadget.ProfessionalTunebookPDF",
+"ext.gadget.TuneBook","ext.gadget.ttaPlaylist","ext.gadget.ttaPlaylistManager","ext.gadget.ttaPlaylistLibrary","ext.gadget.CommunityPortalTalkTab","mmv.bootstrap","ext.embedVideo.overlay","ext.CookieConsent","ext.addPersonalUrls","ext.smw.purge"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+}];});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.MobileDetect.nomobile%7Cext.NoTitle%2CSearchThumbs%7Cext.embedVideo.styles%7Cext.proofreadpage.article%2Cbase%7Cext.smw.styles%7Cext.smw.tooltip.styles%7Cext.socialprofile.responsive%7Cext.srf.styles%7Cjquery.makeCollapsible.styles%7Cmediawiki.widgets.styles%7Coojs-ui-core.icons%2Cstyles%7Coojs-ui.styles.indicators%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles&amp;only=styles&amp;skin=vector-2022">
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>
+<style>#mw-indicator-mw-helplink {display:none;}</style>
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">
+<meta name="generator" content="MediaWiki 1.43.0">
+<meta name="robots" content="max-image-preview:standard">
+<meta name="format-detection" content="telephone=no">
+<meta name="google-site-verification" content="krO8QFzwmzrdm3epW25GRfSvDsKnyBzIXTONRqwqQqY">
+<meta name="msvalidate.01" content="14D63D178522A365E3CE5C63B5AB243D">
+<meta name="yandex-verification" content="6f2e53bf8f8205e7">
+<meta name="p:domain_verify" content="0e8457e9a76fa77a665556543311c158">
+<meta name="description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta name="keywords" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="1091">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png">
+<meta property="og:image:width" content="800">
+<meta property="og:image:height" content="727">
+<meta property="og:image:width" content="640">
+<meta property="og:image:height" content="582">
+<meta name="viewport" content="width=1120">
+<link rel="alternate" type="application/rdf+xml" title="Salt Creek (1)" href="/w/index.php?title=Special:ExportRDF/Salt_Creek_(1)&amp;xmlmime=rdf">
+<link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="The Traditional Tune Archive (en)">
+<link rel="EditURI" type="application/rsd+xml" href="https://tunearch.org/w/api.php?action=rsd">
+<link rel="canonical" href="https://tunearch.org/wiki/Salt_Creek_(1)">
+<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+<link rel="alternate" type="application/atom+xml" title="The Traditional Tune Archive Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom">
+<meta property="og:title" content="Salt Creek – Reel (single/double) from United States – The Traditional Tune Archive">
+<meta property="og:site_name" content="The Traditional Tune Archive">
+<meta property="og:url" content="https://tunearch.org/wiki/Salt_Creek_(1)">
+<meta property="article:author" content="https://www.tunearch.org/wiki/User:Andrew">
+<meta property="og:description" content="Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations">
+<meta property="og:image" content="https://tunearch.org/w/images/7/7d/TUC-160x120.png?version=bf4cac7a8e2ab09d17a367772ce4b36d">
+<meta property="og:image:width" content="132">
+<meta property="og:image:height" content="120">
+<meta property="og:image:alt" content="Traditional universal music">
+<meta property="article:tag" content="traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection">
+<meta property="article:modified_time" content="2021-01-18">
+<meta property="article:published_time" content="2021-01-18">
+<meta property="og:type" content="article">
+<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"article","name":"Salt Creek \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","headline":"Salt Creek \u2013 Reel (single\/double) from United States \u2013 The Traditional Tune Archive","mainEntityOfPage":"Salt Creek (1)","identifier":"https:\/\/tunearch.org\/wiki\/Salt_Creek_(1)","url":"https:\/\/tunearch.org\/wiki\/Salt_Creek_(1)","description":"Explore a searchable archive of traditional Irish, Scottish, and North American tunes, with free sheet music and detailed annotations","keywords":"traditional tune archive, fiddle tune search, abc music archive, british irish and scottish folk music, free sheet music, free annotated tunes, old-time music collection","dateModified":"2021-01-18","datePublished":"2021-01-18","image":{"@type":"ImageObject","url":"https:\/\/tunearch.org\/w\/images\/7\/7d\/TUC-160x120.png?version=bf4cac7a8e2ab09d17a367772ce4b36d","width":132,"height":120},"author":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"publisher":{"@type":"Organization","name":"The Traditional Tune Archive","url":"https:\/\/tunearch.org","logo":{"@type":"ImageObject","caption":"The Traditional Tune Archive"}},"potentialAction":{"@type":"SearchAction","target":"https:\/\/tunearch.org\/w\/index.php?title=Special:Search&search={search_term}","query-input":"required name=search_term"}}</script>
+</head>
+<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Salt_Creek_1 rootpage-Salt_Creek_1 skin-vector-2022 action-view"><a class="mw-jump-link" href="#bodyContent">Jump to content</a>
+<div class="vector-header-container">
+	<header class="vector-header mw-header">
+		<div class="vector-header-start">
+			<nav class="vector-main-menu-landmark" aria-label="Site">
+				
+<div id="vector-main-menu-dropdown" class="vector-dropdown vector-main-menu-dropdown vector-button-flush-left vector-button-flush-right"  >
+	<input type="checkbox" id="vector-main-menu-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-main-menu-dropdown" class="vector-dropdown-checkbox "  aria-label="Main menu"  >
+	<label id="vector-main-menu-dropdown-label" for="vector-main-menu-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-menu mw-ui-icon-wikimedia-menu"></span>
+
+<span class="vector-dropdown-label-text">Main menu</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+				<div id="vector-main-menu-unpinned-container" class="vector-unpinned-container">
+		
+<div id="vector-main-menu" class="vector-main-menu vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-main-menu-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="main-menu-pinned"
+	data-pinnable-element-id="vector-main-menu"
+	data-pinned-container-id="vector-main-menu-pinned-container"
+	data-unpinned-container-id="vector-main-menu-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Main menu</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-main-menu.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-main-menu.unpin">hide</button>
+</div>
+
+	
+<div id="p-navigation" class="vector-menu mw-portlet mw-portlet-navigation"  >
+	<div class="vector-menu-heading">
+		Navigation
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-login" class="mw-list-item"><a href="/wiki/Special:UserLogin"><span>Login</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	
+<div id="p-" class="vector-menu mw-portlet mw-portlet- emptyPortlet"  >
+	<div class="vector-menu-heading">
+		
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☞_Welcome" class="vector-menu mw-portlet mw-portlet-☞_Welcome"  >
+	<div class="vector-menu-heading">
+		☞ Welcome
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Community-Portal" class="mw-list-item"><a href="/wiki/TTA:Community_portal"><span>Community Portal</span></a></li><li id="n-What" class="mw-list-item"><a href="/wiki/A_collection_of_tunes"><span>What</span></a></li><li id="n-Acknowledgments" class="mw-list-item"><a href="/wiki/Acknowledgments"><span>Acknowledgments</span></a></li><li id="n-New-&amp;-Noteworthy" class="mw-list-item"><a href="/wiki/TTA:New_Features_2026"><span>New &amp; Noteworthy</span></a></li><li id="n-Donate-to-TTA" class="mw-list-item"><a href="/wiki/TTA:Donate"><span>Donate to TTA</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-ⓘ_Help" class="vector-menu mw-portlet mw-portlet-ⓘ_Help"  >
+	<div class="vector-menu-heading">
+		ⓘ Help
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-User-Guide" class="mw-list-item"><a href="/wiki/TTA:Help"><span>User Guide</span></a></li><li id="n-Search-Help" class="mw-list-item"><a href="/wiki/TTA:Getting_started/Search"><span>Search Help</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-☰_The_Archive" class="vector-menu mw-portlet mw-portlet-☰_The_Archive"  >
+	<div class="vector-menu-heading">
+		☰ The Archive
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-The-Index" class="mw-list-item"><a href="/wiki/Category:Tune"><span>The Index</span></a></li><li id="n-Query-the-Archive" class="mw-list-item"><a href="/wiki/Special:RunQuery/TuneQuery"><span>Query the Archive</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-✐_Publications" class="vector-menu mw-portlet mw-portlet-✐_Publications"  >
+	<div class="vector-menu-heading">
+		✐ Publications
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="n-Magazines" class="mw-list-item"><a href="/wiki/Tune_History_Articles"><span>Magazines</span></a></li><li id="n-Tune-Books" class="mw-list-item"><a href="/wiki/Tune_books"><span>Tune Books</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+				</div>
+
+	</div>
+</div>
+
+		</nav>
+			
+<a href="/wiki/TTA" class="mw-logo">
+	<img class="mw-logo-icon" src="/w/resources/assets/TUC-160x120.png" alt="" aria-hidden="true" height="50" width="50">
+	<span class="mw-logo-container skin-invert">
+		<img class="mw-logo-wordmark" alt="The Traditional Tune Archive" src="/w/resources/assets/Centered-TTA-WordMark.svg" style="width: 11.25em; height: 1.5625em;">
+		<img class="mw-logo-tagline" alt="" src="/w/resources/assets/TTA-tagline.svg" width="135" height="20" style="width: 8.4375em; height: 1.25em;">
+	</span>
+</a>
+
+		</div>
+		<div class="vector-header-end">
+			
+<div id="p-search" role="search" class="vector-search-box-vue  vector-search-box-collapses vector-search-box-show-thumbnail vector-search-box-auto-expand-width vector-search-box">
+	<a href="/wiki/Special:Search" class="cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only search-toggle" title="Search The Traditional Tune Archive [f]" accesskey="f"><span class="vector-icon mw-ui-icon-search mw-ui-icon-wikimedia-search"></span>
+
+<span>Search</span>
+	</a>
+	<div class="vector-typeahead-search-container">
+		<div class="cdx-typeahead-search cdx-typeahead-search--show-thumbnail cdx-typeahead-search--auto-expand-width">
+			<form action="/w/index.php" id="searchform" class="cdx-search-input cdx-search-input--has-end-button">
+				<div id="simpleSearch" class="cdx-search-input__input-wrapper"  data-search-loc="header-moved">
+					<div class="cdx-text-input cdx-text-input--has-start-icon">
+						<input
+							class="cdx-text-input__input"
+							 type="search" name="search" placeholder="Search The Traditional Tune Archive" aria-label="Search The Traditional Tune Archive" autocapitalize="sentences" title="Search The Traditional Tune Archive [f]" accesskey="f" id="searchInput"
+							>
+						<span class="cdx-text-input__icon cdx-text-input__start-icon"></span>
+					</div>
+					<input type="hidden" name="title" value="Special:Search">
+				</div>
+				<button class="cdx-button cdx-search-input__end-button">Search</button>
+			</form>
+		</div>
+	</div>
+</div>
+
+			<nav class="vector-user-links vector-user-links-wide" aria-label="Personal tools">
+	<div class="vector-user-links-main">
+	
+<div id="p-vector-user-menu-preferences" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-userpage" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	<nav class="vector-appearance-landmark" aria-label="Appearance">
+		
+<div id="vector-appearance-dropdown" class="vector-dropdown "  title="Change the appearance of the page&#039;s font size, width, and color" >
+	<input type="checkbox" id="vector-appearance-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-appearance-dropdown" class="vector-dropdown-checkbox "  aria-label="Appearance"  >
+	<label id="vector-appearance-dropdown-label" for="vector-appearance-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-appearance mw-ui-icon-wikimedia-appearance"></span>
+
+<span class="vector-dropdown-label-text">Appearance</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+			<div id="vector-appearance-unpinned-container" class="vector-unpinned-container">
+				
+			</div>
+		
+	</div>
+</div>
+
+	</nav>
+	
+<div id="p-vector-user-menu-notifications" class="vector-menu mw-portlet emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+	
+<div id="p-vector-user-menu-overflow" class="vector-menu mw-portlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			<li id="pt-login-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/w/index.php?title=Special:UserLogin&amp;returnto=Salt+Creek+%281%29" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o" class=""><span>Log in</span></a>
+</li>
+<li id="pt-createaccount-2" class="user-links-collapsible-item mw-list-item user-links-collapsible-item"><a data-mw="interface" href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory" class=""><span>Request account</span></a>
+</li>
+
+			
+		</ul>
+		
+	</div>
+</div>
+
+	</div>
+	
+<div id="vector-user-links-dropdown" class="vector-dropdown vector-user-menu vector-button-flush-right vector-user-menu-logged-out user-links-collapsible-item"  title="More options" >
+	<input type="checkbox" id="vector-user-links-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-user-links-dropdown" class="vector-dropdown-checkbox "  aria-label="Personal tools"  >
+	<label id="vector-user-links-dropdown-label" for="vector-user-links-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet cdx-button--icon-only " aria-hidden="true"  ><span class="vector-icon mw-ui-icon-ellipsis mw-ui-icon-wikimedia-ellipsis"></span>
+
+<span class="vector-dropdown-label-text">Personal tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+		
+<div id="p-personal" class="vector-menu mw-portlet mw-portlet-personal user-links-collapsible-item"  title="User menu" >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="pt-login" class="user-links-collapsible-item mw-list-item"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=Salt+Creek+%281%29" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o"><span class="vector-icon mw-ui-icon-logIn mw-ui-icon-wikimedia-logIn"></span> <span>Log in</span></a></li><li id="pt-createaccount" class="user-links-collapsible-item mw-list-item"><a href="/wiki/Special:RequestAccount" title="You are encouraged to create an account and log in; however, it is not mandatory"><span>Request account</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+	
+	</div>
+</div>
+
+</nav>
+
+		</div>
+	</header>
+
+<!-- Google tag (gtag.js) -->
+<!--<script async src="https://www.googletagmanager.com/gtag/js?id=G-YFX3N1E17F"></script> -->
+<!--<script> -->
+<!--  window.dataLayer = window.dataLayer || []; -->
+<!--  function gtag(){dataLayer.push(arguments);} -->
+<!--  gtag('js', new Date()); -->
+
+<!--  gtag('config', 'G-YFX3N1E17F'); -->
+
+<!--</script> -->
+
+            <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="icon" href="/favicon.ico" type="image/x-icon">
+            <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+            <link rel="stylesheet" type="text/css" href="/w/JavaScript/resources/abcjs-midi.css">
+            <script src="/w/JavaScript/abcjs-plugin-min.js" type="text/javascript"></script>
+<!-- abcjs_plugin_5.9.0-min.js-->
+               <script type="text/javascript">
+                                window.ABCJS.plugin.hide_abc = false;
+                                window.ABCJS.plugin.render_before = true;
+                                window.ABCJS.plugin.auto_render_threshold = 50;
+                                window.ABCJS.plugin.oneSvgPerLine = true;
+                                window.ABCJS.plugin.render_options = {scale: 0.9,paddingtop: 0, paddingbottom: 0, paddingright: 0, paddingleft: 0,}
+               </script>
+               <style>
+                 .print-only {
+                 max-height: 0;
+                 overflow: hidden;
+                 }
+
+                 @media print {
+                 .render-abc {
+                 overflow: inherit !important;
+                 break-after: page;
+                 page-break-after: always;
+                 }
+                 .no-print {
+                 display: none !important;
+                  }
+                  .print-only {
+                  max-height: inherit;
+                  overflow: inherit;
+                  }
+                 </style>
+
+</div>
+<div class="mw-page-container">
+	<div class="mw-page-container-inner">
+		<div class="vector-sitenotice-container">
+			<div id="siteNotice"><div id="mw-dismissablenotice-anonplace"></div><script>(function(){var node=document.getElementById("mw-dismissablenotice-anonplace");if(node){node.outerHTML="\u003Cdiv id=\"localNotice\" data-nosnippet=\"\"\u003E\u003Cdiv class=\"sitenotice\" lang=\"en\" dir=\"ltr\"\u003E\u003Cdiv style=\"text-align:center; font-size:95%; background:#f4f5f9; border-bottom:1px solid #ddd; padding:4px 0;\"\u003E\n\u003Cp\u003E\u003Cspan typeof=\"mw:File\"\u003E\u003Cspan\u003E\u003Cimg alt=\"Universal Clef\" src=\"/w/images/thumb/7/7d/TUC-160x120.png/20px-TUC-160x120.png\" decoding=\"async\" width=\"20\" height=\"18\" class=\"mw-file-element\" srcset=\"/w/images/thumb/7/7d/TUC-160x120.png/30px-TUC-160x120.png 1.5x, /w/images/thumb/7/7d/TUC-160x120.png/40px-TUC-160x120.png 2x\" data-file-width=\"132\" data-file-height=\"120\" /\u003E\u003C/span\u003E\u003C/span\u003E\n\u003Cb\u003EThe TTA now offers the new \u003Ca href=\"/wiki/ABCSandbox\" title=\"ABCSandbox\"\u003E ABC Sandbox (Editor)\u003C/a\u003E, music-score printing, tunebook creation tools, an \u003Ca href=\"/wiki/TTA:TestAi\" title=\"TTA:TestAi\"\u003E AI assistant\u003C/a\u003E, and a new \u003Ca href=\"/wiki/Featured_Tunes_Music_Library\" title=\"Featured Tunes Music Library\"\u003E \u003Cspan style=\"color:#50C878;\"\u003E\u003Ci\u003EPlaylist system\u003C/i\u003E\u003C/span\u003E\u003C/a\u003E.  \u003Cbr /\u003E☞ see\u003C/b\u003E\n\u003Ca href=\"/wiki/TTA:New_Features_2026\" title=\"TTA:New Features 2026\"\u003ELatest additions \u0026amp; improvements\u003C/a\u003E\n\u003Cb\u003Eto learn more.\u003C/b\u003E\n\u003C/p\u003E\n\u003C/div\u003E\u003C/div\u003E\u003C/div\u003E";}}());</script></div>
+		</div>
+		<div class="vector-column-start">
+			<div class="vector-main-menu-container">
+		<div id="mw-navigation">
+			<nav id="mw-panel" class="vector-main-menu-landmark" aria-label="Site">
+				<div id="vector-main-menu-pinned-container" class="vector-pinned-container">
+				
+				</div>
+		</nav>
+		</div>
+	</div>
+</div>
+		<div class="mw-content-container">
+			<main id="content" class="mw-body">
+				<header class="mw-body-header vector-page-titlebar">
+					<h1 id="firstHeading" class="firstHeading mw-first-heading"><span class="mw-page-title-main">Salt Creek (1)</span></h1>
+				</header>
+				<div class="vector-page-toolbar">
+					<div class="vector-page-toolbar-container">
+						<div id="left-navigation">
+							<nav aria-label="Namespaces">
+								
+<div id="p-associated-pages" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-associated-pages"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-nstab-main" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Salt_Creek_(1)" title="View the content page [c]" accesskey="c"><span>Page</span></a></li><li id="ca-talk" class="new vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Talk:Salt_Creek_(1)&amp;action=edit&amp;redlink=1" rel="discussion" class="new" title="Discussion about the content page (page does not exist) [t]" accesskey="t"><span>Discussion</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+								
+<div id="vector-variants-dropdown" class="vector-dropdown emptyPortlet"  >
+	<input type="checkbox" id="vector-variants-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-variants-dropdown" class="vector-dropdown-checkbox " aria-label="Change language variant"   >
+	<label id="vector-variants-dropdown-label" for="vector-variants-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">English</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+					
+<div id="p-variants" class="vector-menu mw-portlet mw-portlet-variants emptyPortlet"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			
+		</ul>
+		
+	</div>
+</div>
+
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+						<div id="right-navigation" class="vector-collapsible">
+							<nav aria-label="Views">
+								
+<div id="p-views" class="vector-menu vector-menu-tabs mw-portlet mw-portlet-views"  >
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-view" class="selected vector-tab-noicon mw-list-item"><a href="/wiki/Salt_Creek_(1)"><span>Read</span></a></li><li id="ca-formedit" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=formedit" title="Edit this page with a form [&amp;]" accesskey="&amp;"><span>View form</span></a></li><li id="ca-viewsource" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=edit" title="This page is protected.&#10;You can view its source [e]" accesskey="e"><span>View source</span></a></li><li id="ca-history" class="vector-tab-noicon mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=history" title="Past revisions of this page [h]" accesskey="h"><span>View history</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+							</nav>
+				
+							<nav class="vector-page-tools-landmark" aria-label="Page tools">
+								
+<div id="vector-page-tools-dropdown" class="vector-dropdown vector-page-tools-dropdown"  >
+	<input type="checkbox" id="vector-page-tools-dropdown-checkbox" role="button" aria-haspopup="true" data-event-name="ui.dropdown-vector-page-tools-dropdown" class="vector-dropdown-checkbox "  aria-label="Tools"  >
+	<label id="vector-page-tools-dropdown-label" for="vector-page-tools-dropdown-checkbox" class="vector-dropdown-label cdx-button cdx-button--fake-button cdx-button--fake-button--enabled cdx-button--weight-quiet" aria-hidden="true"  ><span class="vector-dropdown-label-text">Tools</span>
+	</label>
+	<div class="vector-dropdown-content">
+
+
+									<div id="vector-page-tools-unpinned-container" class="vector-unpinned-container">
+						
+<div id="vector-page-tools" class="vector-page-tools vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-page-tools-pinnable-header vector-pinnable-header-unpinned"
+	data-feature-name="page-tools-pinned"
+	data-pinnable-element-id="vector-page-tools"
+	data-pinned-container-id="vector-page-tools-pinned-container"
+	data-unpinned-container-id="vector-page-tools-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Tools</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-page-tools.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-page-tools.unpin">hide</button>
+</div>
+
+	
+<div id="p-cactions" class="vector-menu mw-portlet mw-portlet-cactions vector-has-collapsible-items"  title="More options" >
+	<div class="vector-menu-heading">
+		Actions
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="ca-more-view" class="selected vector-more-collapsible-item mw-list-item"><a href="/wiki/Salt_Creek_(1)"><span>Read</span></a></li><li id="ca-more-formedit" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=formedit"><span>View form</span></a></li><li id="ca-more-viewsource" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=edit"><span>View source</span></a></li><li id="ca-more-history" class="vector-more-collapsible-item mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=history"><span>View history</span></a></li><li id="ca-purge" class="is-disabled mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=purge"><span>Refresh</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+<div id="p-tb" class="vector-menu mw-portlet mw-portlet-tb"  >
+	<div class="vector-menu-heading">
+		General
+	</div>
+	<div class="vector-menu-content">
+		
+		<ul class="vector-menu-content-list">
+			
+			<li id="t-whatlinkshere" class="mw-list-item"><a href="/wiki/Special:WhatLinksHere/Salt_Creek_(1)" title="A list of all wiki pages that link here [j]" accesskey="j"><span>What links here</span></a></li><li id="t-recentchangeslinked" class="mw-list-item"><a href="/wiki/Special:RecentChangesLinked/Salt_Creek_(1)" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k"><span>Related changes</span></a></li><li id="t-upload" class="mw-list-item"><a href="/wiki/Special:UploadWizard" title="Upload files [u]" accesskey="u"><span>Upload file</span></a></li><li id="t-specialpages" class="mw-list-item"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q"><span>Special pages</span></a></li><li id="t-print" class="mw-list-item"><a href="javascript:print();" rel="alternate" title="Printable version of this page [p]" accesskey="p"><span>Printable version</span></a></li><li id="t-permalink" class="mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;oldid=433277" title="Permanent link to this revision of this page"><span>Permanent link</span></a></li><li id="t-info" class="mw-list-item"><a href="/w/index.php?title=Salt_Creek_(1)&amp;action=info" title="More information about this page"><span>Page information</span></a></li><li id="t-cite" class="mw-list-item"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=Salt_Creek_%281%29&amp;id=433277&amp;wpFormIdentifier=titleform" title="Information on how to cite this page"><span>Cite this page</span></a></li><li id="t-smwbrowselink" class="mw-list-item"><a href="/wiki/Special:Browse/:Salt-5FCreek-5F(1)" rel="search"><span>Browse properties</span></a></li>
+		</ul>
+		
+	</div>
+</div>
+
+</div>
+
+									</div>
+				
+	</div>
+</div>
+
+							</nav>
+						</div>
+					</div>
+				</div>
+				<div class="vector-column-end">
+					<div class="vector-sticky-pinned-container">
+						<nav class="vector-page-tools-landmark" aria-label="Page tools">
+							<div id="vector-page-tools-pinned-container" class="vector-pinned-container">
+				
+							</div>
+		</nav>
+						<nav class="vector-appearance-landmark" aria-label="Appearance">
+							<div id="vector-appearance-pinned-container" class="vector-pinned-container">
+				<div id="vector-appearance" class="vector-appearance vector-pinnable-element">
+	<div
+	class="vector-pinnable-header vector-appearance-pinnable-header vector-pinnable-header-pinned"
+	data-feature-name="appearance-pinned"
+	data-pinnable-element-id="vector-appearance"
+	data-pinned-container-id="vector-appearance-pinned-container"
+	data-unpinned-container-id="vector-appearance-unpinned-container"
+>
+	<div class="vector-pinnable-header-label">Appearance</div>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-pin-button" data-event-name="pinnable-header.vector-appearance.pin">move to sidebar</button>
+	<button class="vector-pinnable-header-toggle-button vector-pinnable-header-unpin-button" data-event-name="pinnable-header.vector-appearance.unpin">hide</button>
+</div>
+
+
+</div>
+
+							</div>
+		</nav>
+					</div>
+				</div>
+				<div id="bodyContent" class="vector-body" aria-labelledby="firstHeading" data-mw-ve-target-container>
+					<div class="vector-body-before-content">
+							<div class="mw-indicators">
+		<div id="mw-indicator-smw-entity-examiner" class="mw-indicator"><div class="smw-entity-examiner smw-indicator-vertical-bar-loader" data-subject="Salt_Creek_(1)#0##" data-dir="ltr" data-uselang="" title="Running an examiner in the background"></div></div>
+		</div>
+
+						<div id="siteSub" class="noprint">Find traditional instrumental music</div>
+					</div>
+					<div id="contentSub"><div id="mw-content-subtitle"><span class="mw-redirectedfrom">(Redirected from <a href="/w/index.php?title=Salt_Creek&amp;redirect=no" class="mw-redirect" title="Salt Creek">Salt Creek</a>)</span></div></div>
+					
+					
+					<div id="mw-content-text" class="mw-body-content"><div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr"><p><br />
+</p>
+<div class="noprint">
+<div class="mw-collapsible" data-expandtext="Show TuneInfoBox" data-collapsetext="Hide TuneInfoBox">
+<table style="width: 100%; font-size: 100.1%; border: 1px solid #aaaaaa; color: black; margin-bottom: 1em; margin-left: 0em; padding: 0.2em; text-align:left;">
+<tbody><tr>
+<th style="text-align: center; vertical-align: top; border: 1px solid #aaaaaa; background-color:#efefef;" colspan="2"><span style="font-family:sans-serif;font-size:17px;color:black;background-color:transparent;;"><b><a href="/wiki/Annotation:Salt_Creek_(1)" title="Annotation:Salt Creek (1)">Salt Creek (1)</a></b></span>&#160; <span class="smw-highlighter" data-type="8" data-state="inline" data-title="Note" title="Click on the tune title to see or modify Salt Creek (1)s annotations. If the link is red you can create them using the form provided."><span class="smwtticon note"></span><span class="smwttcontent">Click on the tune title to see or modify Salt Creek (1)'s annotations. If the link is red you can create them using the form provided.</span></span><span class="smw-highlighter" data-type="6" data-state="persistent" data-title="Information" title="Browse Properties Special:Browse/:Salt Creek (1)"><span class="smwtticon info"></span><span class="smwttcontent">Browse Properties &lt;br/&gt;<a href="/wiki/Special:Browse/:Salt_Creek_(1)" title="Special:Browse/:Salt Creek (1)">Special:Browse/:Salt Creek (1)</a></span></span><figure class="mw-halign-right" typeof="mw:File"><a href="/wiki/Special:RunQuery/TuneQuery" title="Query the Archive"><img alt="Query the Archive" src="/w/images/thumb/c/c8/HSContribs.svg.png/35px-HSContribs.svg.png" decoding="async" width="35" height="35" class="mw-file-element" srcset="/w/images/c/c8/HSContribs.svg.png 1.5x" data-file-width="38" data-file-height="38" /></a><figcaption>Query the Archive</figcaption></figure>
+</th></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Theme code Index</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:#7f5620;background-color:transparent;;">7L111 2244</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Also known as</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Annotation:Salt_Creek" class="mw-redirect" title="Annotation:Salt Creek">Salt Creek</a>, <a href="/wiki/Special:FormEdit/Abc_tune/Pateroller_(1)" class="new" target="_self">Pateroller (1)</a>, <a href="/wiki/Salt_River_(2)" title="Salt River (2)">Salt River (2)</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Composer/Core Source</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Region</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">United States</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Genre/Style</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Bluegrass</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Meter/Rhythm</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Reel (single/double)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Key/Tonic of</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">A</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Accidental</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">3 sharps</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Mode</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">Ionian (Major)</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Time signature</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">2/2</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>History</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Structure</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">AABB</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Editor/Compiler</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/People_form/Biography:Gene_Lowinger" class="new" target="_self">Biography:Gene Lowinger</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Book/Manuscript title</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><a href="/wiki/Special:FormEdit/Book/Book:Bluegrass_Fiddle" class="new" target="_self">Book:Bluegrass Fiddle</a></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Tune and/or Page number</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">p. 15</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year of publication/Date of MS</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1974</span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Artist</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Title of recording</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Record label/Catalogue nr.</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Year recorded</b></span>&#160;
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Media</b></span>&#160;
+</td>
+<td style="width:70%;">&#160;&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"></span>
+</td></tr>
+<tr>
+<td style="width:30%; background:#E6E6FA; text-align:left;">&#160;<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;"><b>Score</b></span> &#160;&#160;(<span style="font-family:sans-serif;font-size:13px;color:black;background-color:transparent;;">1</span>)
+</td>
+<td style="width:70%; background:#F5F5F5;">&#160;&#160;
+</td></tr></tbody></table>
+</div>
+</div>
+<div class="noprint">
+<div class="mw-collapsible mw-collapsed" data-expandtext="Show Tune Graph" data-collapsetext="Hide Tune Graph">
+<div id="network-viz-1" class="network-visualization" data-pages="[&quot;Salt Creek (1)&quot;]" data-excludedpages="[&quot;TTA&quot;,&quot;Featured Tunes Music Library&quot;,&quot;Featured content&quot;]" data-excludednamespaces="[&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;12&quot;,&quot;2&quot;,&quot;4&quot;,&quot;8&quot;,&quot;10&quot;,&quot;12&quot;,&quot;200&quot;,&quot;202&quot;,&quot;3002&quot;]" data-options="{&quot;layout&quot;:{&quot;randomSeed&quot;:42},&quot;physics&quot;:{&quot;barnesHut&quot;:{&quot;gravitationalConstant&quot;:-5000,&quot;damping&quot;:0.242}},&quot;nodes&quot;:{&quot;color&quot;:{&quot;background&quot;:&quot;white&quot;,&quot;highlight&quot;:{&quot;background&quot;:&quot;white&quot;}},&quot;borderWidth&quot;:1,&quot;shape&quot;:&quot;box&quot;,&quot;size&quot;:10,&quot;shapeProperties&quot;:{&quot;useBorderWithImage&quot;:true},&quot;borderWidthSelected&quot;:2},&quot;groups&quot;:{&quot;bluelink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/article-rtl-progressive.svg&quot;},&quot;redlink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/articleNotFound-ltr.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;#ba0000&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;#ba0000&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;#ba0000&quot;}},&quot;externallink&quot;:{&quot;image&quot;:&quot;resources\/lib\/ooui\/themes\/wikimediaui\/images\/icons\/linkExternal-ltr-progressive.svg&quot;,&quot;color&quot;:{&quot;border&quot;:&quot;grey&quot;,&quot;highlight&quot;:{&quot;border&quot;:&quot;grey&quot;}},&quot;font&quot;:{&quot;color&quot;:&quot;grey&quot;}}},&quot;clickToUse&quot;:true}" data-enabledisplaytitle="true" data-labelmaxlength="0"></div>
+</div>
+</div>
+<p><br />
+</p><p><br />
+</p><p><font face="sans-serif" size="4">
+</font></p><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Salt_Creek_(1)" title="Annotation:Salt Creek (1)">Salt Creek (1): Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+<font face="sans-serif" size="2">
+</font></p><font face="sans-serif" size="2"><hr /></font><font face="sans-serif" size="2"><p class="mw-empty-elt"></p><section></section></font><p><font face="sans-serif" size="2">
+X: 1
+T: Salt Creek [1]
+C: Traditional
+S: MandoZine TablEdit Archives
+S: <a rel="nofollow" class="external free" href="http://www.mandozine.com/music/tabledit_files/SaltCreek3-A-Trad.tef">http://www.mandozine.com/music/tabledit_files/SaltCreek3-A-Trad.tef</a>
+Z: TablEdited by Mike Stangeland for MandoZine
+L: 1/8
+M: C|
+K: Amix
+"A"A2 AA A2 AB | "A"cA Bc "D"d2 A2 | "G"BA =GA BA =GA | "G"BA =GF "E"E2 E2 |
+"A"A2 AA A2 AB | "A"cA Bc "D"d2 ed | "G"ce fg af ed | "E"cA Bc "A"A4&#160;:|
+|: "A"a2 aa a2 ab | c'e be ab ae | "G"=ga =gf ef =ga | =gf ed cB A2 |
+"A"a2 aa a2 ab | c'e be ab ae | "G"=ga =gf ef ed | "E"cA Bc "A"A4&#160;:|
+</font></p><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><p><font face="sans-serif" size="2">
+X: 1
+T: Salt Creek [1]
+C: Traditional - Bill Monroe Solo
+Z: TablEdited by John Baldry for MandoZine
+S: MandoZine TablEdit Archives
+L: 1/8
+M: C|
+K: A
+z6 E2 |: "A"[A=G][AA] z[AA] [AA][AA] [AA][AA] | BA Bc "D"d2 dd | "G"BA =GA BA =GA |
+BA =GF "E"E2 EE | "A"E[AA] z[AA] [AA][AA] [AA][AA] | BA Bc "D"d2 ef | "G"=ga =gf ef ed |
+|1 c"E"A Bc "A"A2 [eA][eA]&#160;:|2 c"E"A Bc "A"A2 B=c |: "A"c[ac] z[ac] [ac][ac] [ac][ac] |
+[g=c][a^c] ^z[ac] [ac][ac] [ac][ac] | "G"[=g2B2] [=g2B2] [=gB][=gB] [=gB][=gB] | [=g2B2] [=g2B2] [=gB][=gB] [=gB][=gB] |
+"A"[=gB][ac] z[ac] [ac][ac] [ac][ac] | ef =gf e2 ef | "G"=ga =gf ef ed |1 c"E"A Bc "A"A2 B=c&#160;:|2 c"E"A Bc "A"A2 E2 |
+</font></p><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><p><font face="sans-serif" size="2">
+X: 1
+T: Salt Creek [1]
+R: reel
+Z: 2014 John Chambers &lt;jc:trillian.mit.edu&gt;
+S: handwritten MS by John Chambers (1970s)
+M: 2/4
+L: 1/16
+K: Amix
+|:\
+"A"(GA)AA A2AA | "A7"BABc "D"d4  | "G"BAG2 BAG2  | ABAG "E7"E4 |
+"A"(GA)AA A2AA | "A7"BABc "D"d3f | "G"gagf ecd^d | "E7"ecB2 "A"A4&#160;:|
+|:\
+"A"a2aa a2aa | c'aba faef | "G"gagf efga | gfed cde2 |
+"A"a2aa a2aa | c'aba faef | "G"gagf edcA | "E7"B^GEF "A"A4&#160;:|
+</font></p><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><font face="sans-serif" size="2"><section></section></font><p><font face="sans-serif" size="2">
+</font>    
+</p><font face="sans-serif" size="4"><p class="mw-empty-elt"></p></font><font face="sans-serif" size="4"><div class="noprint">
+<p><a href="/wiki/Annotation:Salt_Creek_(1)" title="Annotation:Salt Creek (1)">Salt Creek (1): Annotations</a>
+</p>
+</div></font><font face="sans-serif" size="4"></font><p><font face="sans-serif" size="4"></font>
+</p>
+<!-- 
+NewPP limit report
+Cached time: 20251218202349
+Cache expiry: 1209600
+Reduced expiry: false
+Complications: [vary‐user]
+[SMW] In‐text annotation parser time: 0.017 seconds
+CPU time usage: 0.179 seconds
+Real time usage: 0.290 seconds
+Preprocessor visited node count: 2092/1000000
+Post‐expand include size: 20158/2097152 bytes
+Template argument size: 2496/2097152 bytes
+Highest expansion depth: 8/100
+Expensive parser function count: 0/100
+Unstrip recursion depth: 0/20
+Unstrip post‐expand size: 2550/5000000 bytes
+Lua time usage: 0.040/7 seconds
+Lua virtual size: 5222400/52428800 bytes
+Lua estimated memory usage: 0 bytes
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  209.948      1 Template:Abctune
+100.00%  209.948      1 -total
+ 40.67%   85.376     45 Template:Font
+ 37.57%   78.874      1 Template:Break
+  0.55%    1.152      1 Template:F_score
+-->
+
+<!-- Saved in parser cache with key tunearch_wikidb:pcache:idhash:88854-0!canonical and timestamp 20251218202349 and revision id 433277. Rendering was triggered because: page-view
+ -->
+</div>
+<div class="printfooter" data-nosnippet="">Retrieved from "<a dir="ltr" href="https://tunearch.org/w/index.php?title=Salt_Creek_(1)&amp;oldid=433277">https://tunearch.org/w/index.php?title=Salt_Creek_(1)&amp;oldid=433277</a>"</div></div>
+					<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Special:Categories" title="Special:Categories">Category</a>: <ul><li><a href="/wiki/Category:Tune" title="Category:Tune">Tune</a></li></ul></div></div>
+				</div>
+			</main>
+			
+		</div>
+		<div class="mw-footer-container">
+			
+<footer id="footer" class="mw-footer" >
+	<ul id="footer-info">
+	<li id="footer-info-lastmod"> This page was last edited on 18 December 2025, at 21:23.</li>
+	<li id="footer-info-copyright">Content is available under <a class="external" rel="nofollow" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike</a> unless otherwise noted.</li>
+</ul>
+
+	<ul id="footer-places">
+	<li id="footer-places-privacy"><a href="/wiki/TTA:Privacy_policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/TTA:About">About The Traditional Tune Archive</a></li>
+	<li id="footer-places-disclaimers"><a href="/wiki/TTA:General_disclaimer">Disclaimers</a></li>
+	<li id="footer-places-mobileview"><a href="https://tunearch.org/w/index.php?title=Salt_Creek_(1)&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+	<li id="footer-places-manage-cookie-preferences"><a href="#" id="manage-cookie-preferences">Manage cookie preferences</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://creativecommons.org/licenses/by-sa/4.0/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/licenses/cc-by-sa.png" alt="Creative Commons Attribution-ShareAlike" width="88" height="31" loading="lazy"></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/resources/assets/poweredby_mediawiki.svg" alt="Powered by MediaWiki" width="88" height="31" loading="lazy"></a><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki" class="cdx-button cdx-button--fake-button cdx-button--size-large cdx-button--fake-button--enabled"><img src="/w/extensions/SemanticMediaWiki/res/smw/assets/logo_footer.svg" alt="Powered by Semantic MediaWiki" class="smw-footer" width="88" height="31" loading="lazy"></a></li>
+</ul>
+
+</footer>
+
+		</div>
+	</div> 
+
+<!-- WIDGET -->
+
+<!-- Bubble Widget -->
+
+<div id="bubbleWidget"
+     data-endpoint="https://tunearch.org/tta"
+     data-stream="true"
+     data-useweb="true"
+     data-session="widget">
+
+  <!-- Chat window -->
+  <div id="chatWidget" class="hidden">
+    <div class="chat-header">
+      <h3>Hello! Ask me anything about traditional music.</h3>
+    </div>
+    <div class="chat-container">
+      <div class="chat-box" id="chatBox"></div>
+      <div class="message-input">
+        <textarea id="widgetTextarea" placeholder="Your question here..."></textarea>
+        <button class="send-button">
+          <img src="/static/send-icon.png" alt="Send" />
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Floating button -->
+  <div id="bubbleButton">
+    <i class="fa fa-comments" style="color: white; font-size: 24px;"></i>
+  </div>
+</div>
+
+<link rel="stylesheet" href="/static/style.css?v=20251006-2">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+<script src="/static/widget.js?v=20251006-15" defer></script>
+
+<!-- EOFWIDGET -->
+
+</div> 
+<div class="vector-settings" id="p-dock-bottom">
+	<ul></ul>
+</div>
+<script src="/w/JavaScript/abcjs-basic.js"></script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":372,"wgPageParseReport":{"smw":{"limitreport-intext-parsertime":0.017},"limitreport":{"cputime":"0.179","walltime":"0.290","ppvisitednodes":{"value":2092,"limit":1000000},"postexpandincludesize":{"value":20158,"limit":2097152},"templateargumentsize":{"value":2496,"limit":2097152},"expansiondepth":{"value":8,"limit":100},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":2550,"limit":5000000},"timingprofile":["100.00%  209.948      1 Template:Abctune","100.00%  209.948      1 -total"," 40.67%   85.376     45 Template:Font"," 37.57%   78.874      1 Template:Break","  0.55%    1.152      1 Template:F_score"]},"scribunto":{"limitreport-timeusage":{"value":"0.040","limit":"7"},"limitreport-virtmemusage":{"value":5222400,"limit":52428800},"limitreport-estmemusage":0},"cachereport":{"timestamp":"20251218202349","ttl":1209600,"transientcontent":false}}});});</script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9b4de6093898cc65',t:'MTc2Njg5MTc4Mg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/sources/tunearch/src/__init__.py
+++ b/sources/tunearch/src/__init__.py
@@ -1,0 +1,1 @@
+# TuneArch scraper package

--- a/sources/tunearch/src/abc_parser.py
+++ b/sources/tunearch/src/abc_parser.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+ABC Parser - Extract ABC notation and metadata from TuneArch HTML pages
+"""
+
+import re
+from typing import List, Optional, TYPE_CHECKING
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    try:
+        from .scraper import TuneMetadata
+    except ImportError:
+        from scraper import TuneMetadata
+
+
+def extract_abc_blocks(soup: BeautifulSoup) -> List[str]:
+    """Extract ABC notation blocks from a TuneArch page"""
+    abc_blocks = []
+
+    # Method 1: Look for <pre> blocks containing ABC notation
+    for pre in soup.find_all('pre'):
+        text = pre.get_text()
+        # ABC notation always has X: (index) and K: (key) fields
+        if 'X:' in text and ('K:' in text or 'M:' in text):
+            abc_blocks.append(clean_abc_notation(text))
+
+    # Method 2: Look for divs with ABC class or data attributes
+    for div in soup.find_all('div', class_=re.compile(r'abc', re.I)):
+        abc_content = div.get('data-abc') or div.get_text()
+        if abc_content and 'X:' in abc_content:
+            abc_blocks.append(clean_abc_notation(abc_content))
+
+    # Method 3: Look for ABC in page content text (TuneArch often has it inline)
+    if not abc_blocks:
+        content_div = soup.find('div', {'id': 'mw-content-text'})
+        if content_div:
+            # Get the full text content with newlines preserved
+            text = content_div.get_text(separator='\n')
+
+            # Find ALL ABC blocks on the page (there may be multiple versions)
+            # ABC block starts with X: and continues until we hit a non-ABC line
+            lines = text.split('\n')
+            current_abc = []
+            in_abc = False
+            found_key = False
+
+            for line in lines:
+                line = line.strip()
+
+                # Start of new ABC block
+                if re.match(r'^X:\s*\d+', line):
+                    # Save previous block if it had notation
+                    if current_abc and has_notation(current_abc):
+                        abc_blocks.append(clean_abc_notation('\n'.join(current_abc)))
+                    current_abc = [line]
+                    in_abc = True
+                    found_key = False
+                    continue
+
+                if not in_abc:
+                    continue
+
+                # ABC header fields (A-Z followed by colon)
+                if re.match(r'^[A-Za-z]:', line):
+                    # Clean URL lines (S: field often has http links)
+                    if line.startswith('S:') and 'http' in line:
+                        # Extract just the URL reference
+                        line = re.sub(r'http\S+', '', line).strip()
+                        if line == 'S:':
+                            continue
+                    current_abc.append(line)
+                    if line.startswith('K:'):
+                        found_key = True
+                    continue
+
+                # After K: line, look for actual notation
+                if found_key:
+                    # ABC notation lines contain measure bars, notes, etc.
+                    # They typically start with |, :, ", or contain notes and bars
+                    if line.startswith('|') or line.startswith(':') or line.startswith('"'):
+                        current_abc.append(line)
+                    elif '|' in line and re.search(r'[a-gA-G]', line):
+                        # Contains both bars and notes - it's notation
+                        current_abc.append(line)
+                    elif re.match(r'^[\|\:\[\]a-gA-GzZ0-9\s\'\,\(\)\{\}\-\#\^\_\<\>\~\.\"\=\!]+$', line) and line:
+                        # Looks like ABC notation characters
+                        current_abc.append(line)
+                    elif not line:
+                        # Empty line - might be end of block
+                        continue
+                    else:
+                        # Non-ABC line - end of this block
+                        if has_notation(current_abc):
+                            abc_blocks.append(clean_abc_notation('\n'.join(current_abc)))
+                        current_abc = []
+                        in_abc = False
+                        found_key = False
+
+            # Don't forget the last block
+            if current_abc and has_notation(current_abc):
+                abc_blocks.append(clean_abc_notation('\n'.join(current_abc)))
+
+    return abc_blocks
+
+
+def has_notation(abc_lines: List[str]) -> bool:
+    """Check if ABC lines contain actual music notation (not just headers)"""
+    for line in abc_lines:
+        # Skip header lines
+        if re.match(r'^[A-Za-z]:', line):
+            continue
+        # Look for notation: bars with notes
+        if '|' in line and re.search(r'[a-gA-G]', line):
+            return True
+    return False
+
+
+def clean_abc_notation(abc: str) -> str:
+    """Clean up ABC notation text"""
+    # Normalize line endings
+    abc = abc.replace('\r\n', '\n').replace('\r', '\n')
+
+    # Remove leading/trailing whitespace
+    abc = abc.strip()
+
+    # Ensure proper ABC header if missing X:
+    lines = abc.split('\n')
+    has_x_field = any(line.strip().startswith('X:') for line in lines)
+
+    if not has_x_field:
+        # Add X:1 at the beginning
+        abc = 'X:1\n' + abc
+
+    return abc
+
+
+def extract_key_from_abc(abc: str) -> Optional[str]:
+    """Extract key from ABC K: field"""
+    match = re.search(r'^K:\s*([A-G][#b]?)\s*(.*?)$', abc, re.MULTILINE | re.IGNORECASE)
+    if match:
+        key = match.group(1).upper()
+        mode_str = match.group(2).strip().lower()
+
+        # Handle minor modes
+        if 'min' in mode_str or mode_str == 'm':
+            key += 'm'
+        elif 'dor' in mode_str:
+            key += 'Dor'  # Dorian
+        elif 'mix' in mode_str:
+            key += 'Mix'  # Mixolydian
+
+        return key
+    return None
+
+
+def extract_time_from_abc(abc: str) -> Optional[str]:
+    """Extract time signature from ABC M: field"""
+    match = re.search(r'^M:\s*(\d+/\d+|C\|?)', abc, re.MULTILINE)
+    if match:
+        ts = match.group(1)
+        if ts == 'C':
+            return '4/4'
+        if ts == 'C|':
+            return '2/2'
+        return ts
+    return None
+
+
+def extract_title_from_abc(abc: str) -> Optional[str]:
+    """Extract title from ABC T: field"""
+    match = re.search(r'^T:\s*(.+)$', abc, re.MULTILINE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def extract_metadata_from_page(soup: BeautifulSoup, title: str, url: str) -> 'TuneMetadata':
+    """Extract metadata from tune page tables and infoboxes"""
+    try:
+        from .scraper import TuneMetadata
+    except ImportError:
+        from scraper import TuneMetadata
+
+    metadata = TuneMetadata(
+        title=title,
+        tunearch_url=url
+    )
+
+    # Parse infobox-style tables
+    for row in soup.find_all('tr'):
+        cells = row.find_all(['th', 'td'])
+        if len(cells) >= 2:
+            label = cells[0].get_text().strip().lower()
+            value = cells[1].get_text().strip()
+
+            if not value:
+                continue
+
+            if 'key' in label and 'accidental' not in label:
+                metadata.key = value
+            elif 'accidental' in label:
+                # Combine with key if present
+                if metadata.key:
+                    metadata.key = f"{metadata.key} ({value})"
+            elif 'time' in label or ('meter' in label and 'rhythm' not in label):
+                metadata.time_signature = value
+            elif 'mode' in label:
+                metadata.mode = value
+            elif 'rhythm' in label or 'type' in label:
+                metadata.meter_rhythm = value
+            elif 'genre' in label or 'style' in label:
+                metadata.genre = value
+            elif 'region' in label or 'country' in label or 'origin' in label:
+                metadata.region = value
+            elif 'composer' in label or 'author' in label:
+                metadata.composer = value
+            elif 'theme' in label and 'code' in label:
+                metadata.theme_code = value
+            elif 'structure' in label or 'form' in label:
+                metadata.structure = value
+            elif 'also known' in label or 'alternate' in label or 'alias' in label:
+                alts = [t.strip() for t in value.split(',') if t.strip()]
+                metadata.alt_titles.extend(alts)
+
+    # Also check for bold labels followed by values (common wiki format)
+    for bold in soup.find_all('b'):
+        label = bold.get_text().strip().lower()
+        next_sibling = bold.next_sibling
+        if next_sibling:
+            value = str(next_sibling).strip().lstrip(':').strip()
+            if value and len(value) < 100:
+                if 'rhythm' in label or 'type' in label:
+                    metadata.meter_rhythm = value
+                elif 'region' in label:
+                    metadata.region = value
+
+    return metadata

--- a/sources/tunearch/src/batch_fetch.py
+++ b/sources/tunearch/src/batch_fetch.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Batch fetch tunes from TuneArch
+
+Usage:
+    uv run python batch_fetch.py --limit 100
+    uv run python batch_fetch.py --tune "Salt Creek"
+    uv run python batch_fetch.py --search "bluegrass reel"
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add parent to path for imports when run directly
+sys.path.insert(0, str(Path(__file__).parent))
+
+from scraper import TuneArchScraper
+from chordpro_generator import abc_to_chordpro, save_chordpro
+from tune_list import get_tune_list, load_catalog, save_catalog, add_to_catalog
+
+
+def fetch_single_tune(scraper: TuneArchScraper, tune_name: str, output_dir: Path, verbose: bool = True) -> bool:
+    """Fetch a single tune and save as ChordPro. Returns True if successful."""
+    if verbose:
+        print(f"Fetching: {tune_name}")
+
+    tune = scraper.fetch_tune(tune_name)
+
+    if not tune:
+        if verbose:
+            print(f"  -> Could not fetch page")
+        return False
+
+    if not tune.abc_notation:
+        if verbose:
+            print(f"  -> No ABC notation found")
+        return False
+
+    # Convert to ChordPro
+    chordpro = abc_to_chordpro(tune)
+
+    # Save to file
+    output_path = save_chordpro(chordpro, output_dir, tune.metadata.title)
+    if verbose:
+        print(f"  -> Saved: {output_path.name}")
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Fetch ABC notation from TuneArch')
+    parser.add_argument('--limit', type=int, default=10,
+                        help='Maximum tunes to fetch (default: 10)')
+    parser.add_argument('--tune', type=str,
+                        help='Fetch single tune by name')
+    parser.add_argument('--search', type=str,
+                        help='Search TuneArch and fetch results')
+    parser.add_argument('--output-dir', type=Path,
+                        default=Path(__file__).parent.parent / 'parsed',
+                        help='Output directory for .pro files')
+    parser.add_argument('--cache-dir', type=Path,
+                        default=Path(__file__).parent.parent / 'raw',
+                        help='Cache directory for raw HTML')
+    parser.add_argument('--no-cache', action='store_true',
+                        help='Skip cache, always fetch fresh')
+    parser.add_argument('--quiet', '-q', action='store_true',
+                        help='Minimal output')
+    args = parser.parse_args()
+
+    output_dir = args.output_dir
+    cache_dir = None if args.no_cache else args.cache_dir
+
+    scraper = TuneArchScraper(cache_dir=cache_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    catalog_path = Path(__file__).parent.parent / 'tune_catalog.json'
+    catalog = load_catalog(catalog_path)
+
+    success_count = 0
+    fail_count = 0
+
+    if args.tune:
+        # Fetch single tune
+        if fetch_single_tune(scraper, args.tune, output_dir, verbose=not args.quiet):
+            add_to_catalog(catalog, args.tune, 'fetched')
+            success_count = 1
+        else:
+            add_to_catalog(catalog, args.tune, 'not_found')
+            fail_count = 1
+
+    elif args.search:
+        # Search and fetch results
+        if not args.quiet:
+            print(f"Searching TuneArch for: {args.search}")
+
+        results = scraper.search_tunes(args.search, limit=args.limit)
+        if not args.quiet:
+            print(f"Found {len(results)} results")
+
+        for tune_name in results:
+            if fetch_single_tune(scraper, tune_name, output_dir, verbose=not args.quiet):
+                add_to_catalog(catalog, tune_name, 'fetched')
+                success_count += 1
+            else:
+                add_to_catalog(catalog, tune_name, 'not_found')
+                fail_count += 1
+
+    else:
+        # Batch fetch from curated list
+        all_tunes = get_tune_list()
+        already_fetched = set(catalog.get('fetched', []))
+
+        # Filter out already fetched and known failures
+        tunes_to_fetch = [
+            t for t in all_tunes
+            if t not in already_fetched and t not in catalog.get('not_found', [])
+        ][:args.limit]
+
+        if not args.quiet:
+            print(f"Fetching {len(tunes_to_fetch)} tunes (skipping {len(already_fetched)} already fetched)")
+
+        for tune_name in tunes_to_fetch:
+            if fetch_single_tune(scraper, tune_name, output_dir, verbose=not args.quiet):
+                add_to_catalog(catalog, tune_name, 'fetched')
+                success_count += 1
+            else:
+                add_to_catalog(catalog, tune_name, 'not_found')
+                fail_count += 1
+
+            # Save catalog after each tune (for resume on error)
+            save_catalog(catalog, catalog_path)
+
+    # Final save
+    save_catalog(catalog, catalog_path)
+
+    if not args.quiet:
+        print(f"\nResults: {success_count} fetched, {fail_count} failed/not found")
+        print(f"Total in catalog: {len(catalog.get('fetched', []))} fetched, {len(catalog.get('not_found', []))} not found")
+
+
+if __name__ == '__main__':
+    main()

--- a/sources/tunearch/src/chordpro_generator.py
+++ b/sources/tunearch/src/chordpro_generator.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Generate ChordPro files from ABC tunes
+
+Wraps ABC notation in {start_of_abc}/{end_of_abc} blocks with metadata.
+"""
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+try:
+    from .abc_parser import extract_key_from_abc, extract_time_from_abc, extract_title_from_abc
+except ImportError:
+    from abc_parser import extract_key_from_abc, extract_time_from_abc, extract_title_from_abc
+
+if TYPE_CHECKING:
+    try:
+        from .scraper import ABCTune
+    except ImportError:
+        from scraper import ABCTune
+
+
+def abc_to_chordpro(tune: 'ABCTune') -> str:
+    """Convert an ABCTune to ChordPro format with embedded ABC"""
+
+    lines = []
+
+    # Title from metadata or ABC
+    title = tune.metadata.title
+    abc_title = extract_title_from_abc(tune.abc_notation)
+    if abc_title and not title:
+        title = abc_title
+    lines.append(f"{{meta: title {title}}}")
+
+    # Artist/composer
+    if tune.metadata.composer:
+        lines.append(f"{{meta: composer {tune.metadata.composer}}}")
+    lines.append("{meta: artist Traditional}")
+
+    # Key from ABC or metadata
+    key = extract_key_from_abc(tune.abc_notation) or tune.metadata.key
+    if key:
+        lines.append(f"{{key: {key}}}")
+
+    # Time signature
+    time_sig = extract_time_from_abc(tune.abc_notation) or tune.metadata.time_signature
+    if time_sig:
+        lines.append(f"{{time: {time_sig}}}")
+
+    # Source metadata
+    lines.append("{meta: x_source tunearch}")
+    lines.append("{meta: x_type instrumental}")
+
+    if tune.metadata.tunearch_url:
+        lines.append(f"{{meta: x_tunearch_url {tune.metadata.tunearch_url}}}")
+
+    if tune.metadata.meter_rhythm:
+        lines.append(f"{{meta: x_rhythm {tune.metadata.meter_rhythm}}}")
+
+    if tune.metadata.genre:
+        lines.append(f"{{meta: x_genre {tune.metadata.genre}}}")
+
+    if tune.metadata.mode:
+        lines.append(f"{{meta: x_mode {tune.metadata.mode}}}")
+
+    if tune.metadata.region:
+        lines.append(f"{{meta: x_region {tune.metadata.region}}}")
+
+    if tune.metadata.structure:
+        lines.append(f"{{meta: x_structure {tune.metadata.structure}}}")
+
+    if tune.metadata.theme_code:
+        lines.append(f"{{meta: x_theme_code {tune.metadata.theme_code}}}")
+
+    # Alt titles (limit to 3)
+    for alt in tune.metadata.alt_titles[:3]:
+        if alt and alt != title:
+            lines.append(f"{{meta: x_alt_title {alt}}}")
+
+    # Blank line before ABC
+    lines.append("")
+
+    # ABC notation block
+    lines.append("{start_of_abc}")
+    lines.append(tune.abc_notation)
+    lines.append("{end_of_abc}")
+
+    return '\n'.join(lines) + '\n'
+
+
+def generate_filename(title: str) -> str:
+    """Generate safe filename from tune title"""
+    # Remove special characters, lowercase, limit length
+    safe = re.sub(r'[^a-z0-9]', '', title.lower())
+    if not safe:
+        safe = 'untitled'
+    return f"{safe[:50]}.pro"
+
+
+def save_chordpro(chordpro: str, output_dir: Path, title: str) -> Path:
+    """Save ChordPro content to file, handling duplicates"""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = generate_filename(title)
+    output_path = output_dir / filename
+
+    # Handle duplicates by adding counter
+    counter = 1
+    while output_path.exists():
+        base = filename.rsplit('.', 1)[0]
+        output_path = output_dir / f"{base}_{counter}.pro"
+        counter += 1
+
+    output_path.write_text(chordpro, encoding='utf-8')
+    return output_path

--- a/sources/tunearch/src/scraper.py
+++ b/sources/tunearch/src/scraper.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+TuneArch Scraper - Fetches ABC notation from tunearch.org
+
+Respects rate limits and provides both batch and single-tune fetching.
+"""
+
+import re
+import time
+import requests
+from pathlib import Path
+from bs4 import BeautifulSoup
+from dataclasses import dataclass, field
+from typing import Optional, List
+from urllib.parse import quote, urljoin
+
+try:
+    from .abc_parser import extract_abc_blocks, extract_metadata_from_page
+except ImportError:
+    from abc_parser import extract_abc_blocks, extract_metadata_from_page
+
+
+@dataclass
+class TuneMetadata:
+    """Metadata extracted from a TuneArch tune page"""
+    title: str
+    alt_titles: List[str] = field(default_factory=list)
+    key: Optional[str] = None
+    time_signature: Optional[str] = None
+    mode: Optional[str] = None
+    meter_rhythm: Optional[str] = None  # e.g., "Reel", "Jig", "Hornpipe"
+    genre: Optional[str] = None  # e.g., "Bluegrass, Old-Time"
+    region: Optional[str] = None
+    composer: Optional[str] = None
+    source: Optional[str] = None  # Publication source
+    theme_code: Optional[str] = None
+    structure: Optional[str] = None  # e.g., "AABB"
+    tunearch_url: str = ""
+
+
+@dataclass
+class ABCTune:
+    """A single ABC tune with metadata"""
+    metadata: TuneMetadata
+    abc_notation: str
+    raw_html: Optional[str] = None
+
+
+class TuneArchScraper:
+    """Scraper for TuneArch.org tune pages"""
+
+    BASE_URL = "https://tunearch.org"
+    WIKI_BASE = f"{BASE_URL}/wiki/"
+    SEARCH_URL = f"{BASE_URL}/w/index.php"
+    RATE_LIMIT_SECONDS = 1.0  # Be polite
+
+    def __init__(self, cache_dir: Optional[Path] = None):
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'BluegrassSongbook/1.0 (educational project; https://github.com/Jollyhrothgar/Bluegrass-Songbook)'
+        })
+        self.cache_dir = cache_dir
+        self.last_request_time = 0.0
+
+    def _rate_limit(self):
+        """Ensure minimum time between requests"""
+        elapsed = time.time() - self.last_request_time
+        if elapsed < self.RATE_LIMIT_SECONDS:
+            time.sleep(self.RATE_LIMIT_SECONDS - elapsed)
+        self.last_request_time = time.time()
+
+    def _get_cached(self, tune_name: str) -> Optional[str]:
+        """Check cache for previously fetched HTML"""
+        if not self.cache_dir:
+            return None
+        cache_file = self.cache_dir / f"{self._safe_filename(tune_name)}.html"
+        if cache_file.exists():
+            return cache_file.read_text(encoding='utf-8')
+        return None
+
+    def _save_cache(self, tune_name: str, html: str):
+        """Save HTML to cache"""
+        if not self.cache_dir:
+            return
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = self.cache_dir / f"{self._safe_filename(tune_name)}.html"
+        cache_file.write_text(html, encoding='utf-8')
+
+    def _safe_filename(self, name: str) -> str:
+        """Convert tune name to safe filename"""
+        return re.sub(r'[^a-z0-9]', '_', name.lower())[:80]
+
+    def fetch_tune_page(self, tune_name: str, use_cache: bool = True) -> Optional[str]:
+        """Fetch raw HTML for a tune page"""
+        # Check cache first
+        if use_cache:
+            cached = self._get_cached(tune_name)
+            if cached:
+                return cached
+
+        self._rate_limit()
+
+        # URL-encode the tune name for wiki URL
+        url = f"{self.WIKI_BASE}{quote(tune_name.replace(' ', '_'))}"
+
+        try:
+            response = self.session.get(url, timeout=30)
+            response.raise_for_status()
+            html = response.text
+
+            # Cache the result
+            self._save_cache(tune_name, html)
+
+            return html
+        except requests.RequestException as e:
+            print(f"Error fetching {tune_name}: {e}")
+            return None
+
+    def search_tunes(self, query: str, limit: int = 20) -> List[str]:
+        """Search TuneArch for tunes matching query, return list of tune names"""
+        self._rate_limit()
+
+        params = {
+            'search': query,
+            'title': 'Special:Search',
+            'profile': 'default',
+            'fulltext': '1'
+        }
+
+        try:
+            response = self.session.get(self.SEARCH_URL, params=params, timeout=30)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, 'html.parser')
+            results = []
+
+            # Parse search results - look for result links
+            for result in soup.select('.mw-search-result-heading a'):
+                title = result.get('title', '')
+                if title and not title.startswith('Special:'):
+                    results.append(title)
+                    if len(results) >= limit:
+                        break
+
+            return results
+        except requests.RequestException as e:
+            print(f"Error searching for '{query}': {e}")
+            return []
+
+    def parse_tune_page(self, html: str, url: str) -> Optional[ABCTune]:
+        """Parse a TuneArch tune page to extract ABC and metadata"""
+        soup = BeautifulSoup(html, 'html.parser')
+
+        # Extract title from page heading
+        title_elem = soup.find('h1', {'id': 'firstHeading'})
+        title = title_elem.get_text().strip() if title_elem else "Unknown"
+
+        # Remove disambiguation suffix like "(1)" from title
+        title = re.sub(r'\s*\(\d+\)\s*$', '', title)
+
+        # Extract ABC notation blocks
+        abc_blocks = extract_abc_blocks(soup)
+        if not abc_blocks:
+            return None
+
+        # Extract metadata from info tables
+        metadata = extract_metadata_from_page(soup, title, url)
+
+        return ABCTune(
+            metadata=metadata,
+            abc_notation=abc_blocks[0],  # Primary notation
+            raw_html=html
+        )
+
+    def fetch_tune(self, tune_name: str, use_cache: bool = True) -> Optional[ABCTune]:
+        """Fetch and parse a single tune by name"""
+        html = self.fetch_tune_page(tune_name, use_cache=use_cache)
+        if not html:
+            return None
+
+        url = f"{self.WIKI_BASE}{quote(tune_name.replace(' ', '_'))}"
+        return self.parse_tune_page(html, url)

--- a/sources/tunearch/src/tune_list.py
+++ b/sources/tunearch/src/tune_list.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Manage the catalog of popular bluegrass/old-time instrumentals to fetch
+
+Includes curated list of popular fiddle tunes and instrumentals.
+"""
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+# Core bluegrass and old-time instrumentals - commonly played at jams
+# Organized by rhythm type for variety
+CORE_INSTRUMENTALS = [
+    # === REELS (4/4) ===
+    "Salt Creek",
+    "Blackberry Blossom",
+    "Whiskey Before Breakfast",
+    "Red Haired Boy",
+    "Billy in the Lowground",
+    "Arkansas Traveler",
+    "Turkey in the Straw",
+    "Temperance Reel",
+    "Fisher's Hornpipe",
+    "Soldier's Joy",
+    "Devil's Dream",
+    "Forked Deer",
+    "Liberty",
+    "Rickett's Hornpipe",
+    "Swallowtail Jig",
+    "Saint Anne's Reel",
+    "Beaumont Rag",
+    "Black Mountain Rag",
+    "Wheel Hoss",
+    "Gold Rush",
+    "Leather Britches",
+    "June Apple",
+    "Old Molly Hare",
+    "Flop Eared Mule",
+    "Grey Eagle",
+    "Cherokee Shuffle",
+    "Fire on the Mountain",
+    "Big Mon",
+    "Cotton Eyed Joe",
+    "Boil Them Cabbage Down",
+    "Old Joe Clark",
+    "Cripple Creek",
+    "Clinch Mountain Backstep",
+    "Raw Hide",
+    "Angeline the Baker",
+    "Kitchen Girl",
+    "Sail Away Ladies",
+    "Cluck Old Hen",
+    "Spotted Pony",
+    "Back Up and Push",
+    "Cumberland Gap",
+    "John Hardy",
+    "Way Downtown",
+    "Shady Grove",
+    "Little Maggie",
+    "Jerusalem Ridge",
+    "Road to Columbus",
+    "Pike County Breakdown",
+    "Dusty Miller",
+    "Growling Old Man and Grumbling Old Woman",
+
+    # === WALTZES (3/4) ===
+    "Tennessee Waltz",
+    "Kentucky Waltz",
+    "Westphalia Waltz",
+    "Ashokan Farewell",
+    "Midnight on the Water",
+    "Over the Waterfall",
+    "Festival Waltz",
+    "Flowers of Edinburgh",
+    "Margaret's Waltz",
+    "Old Spinning Wheel",
+    "Faded Love",
+
+    # === JIGS (6/8) ===
+    "Irish Washerwoman",
+    "Morrison's Jig",
+    "Swallowtail Jig",
+    "Kesh Jig",
+    "Banish Misfortune",
+    "Out on the Ocean",
+    "Harvest Home",
+
+    # === HORNPIPES ===
+    "Sunderland Hornpipe",
+    "Sailor's Hornpipe",
+    "President Garfield's Hornpipe",
+    "Rickett's Hornpipe",
+    "Liverpool Hornpipe",
+
+    # === BREAKDOWN/CONTEST TUNES ===
+    "Foggy Mountain Breakdown",
+    "Earl's Breakdown",
+    "Flint Hill Special",
+    "Bugle Call Rag",
+    "Orange Blossom Special",
+    "Fireball Mail",
+    "Randy Lynn Rag",
+    "Bluegrass Stomp",
+    "Rawhide",
+    "Home Sweet Home",
+    "Black and White Rag",
+    "Dixie Breakdown",
+    "Lonesome Road Blues",
+    "Nine Pound Hammer",
+    "John Henry",
+
+    # === SLOW/MODAL TUNES ===
+    "Bonaparte's Retreat",
+    "Last of Callahan",
+    "Sandy River Belle",
+    "East Tennessee Blues",
+    "Stoney Point",
+    "Cold Frosty Morning",
+    "Walking in My Sleep",
+    "Big Sciota",
+    "Little Rabbit",
+
+    # === CROOKED/UNUSUAL ===
+    "Snowflake Reel",
+    "Morrison's Jig",
+    "Devil Went Down to Georgia",
+]
+
+# Categories to search on TuneArch to find more tunes
+TUNEARCH_SEARCH_TERMS = [
+    "bluegrass",
+    "old-time",
+    "fiddle contest",
+    "breakdown",
+    "appalachian",
+    "country fiddle",
+]
+
+
+def get_tune_list() -> List[str]:
+    """Get list of tunes to fetch"""
+    return CORE_INSTRUMENTALS.copy()
+
+
+def load_catalog(catalog_path: Path) -> Dict[str, Any]:
+    """Load tune catalog from JSON file"""
+    if catalog_path.exists():
+        return json.loads(catalog_path.read_text(encoding='utf-8'))
+    return {
+        "tunes": [],
+        "fetched": [],
+        "failed": [],
+        "not_found": []
+    }
+
+
+def save_catalog(catalog: Dict[str, Any], catalog_path: Path):
+    """Save catalog state"""
+    catalog_path.write_text(
+        json.dumps(catalog, indent=2, ensure_ascii=False),
+        encoding='utf-8'
+    )
+
+
+def add_to_catalog(catalog: Dict[str, Any], tune_name: str, status: str):
+    """Update catalog with fetch result"""
+    # Remove from other lists first
+    for key in ['fetched', 'failed', 'not_found']:
+        if tune_name in catalog.get(key, []):
+            catalog[key].remove(tune_name)
+
+    # Add to appropriate list
+    if status == 'fetched':
+        catalog.setdefault('fetched', []).append(tune_name)
+    elif status == 'not_found':
+        catalog.setdefault('not_found', []).append(tune_name)
+    else:
+        catalog.setdefault('failed', []).append(tune_name)

--- a/sources/tunearch/tune_catalog.json
+++ b/sources/tunearch/tune_catalog.json
@@ -1,0 +1,15 @@
+{
+  "tunes": [],
+  "fetched": [
+    "Garfield's Blackberry Blossom",
+    "Blackberry Blossom (1)",
+    "Blackberry Quadrille (1)",
+    "Blackberry Blossom (6)",
+    "Blackberry Blossom (4)",
+    "Salt Creek"
+  ],
+  "failed": [],
+  "not_found": [
+    "Blackberry Blossom"
+  ]
+}

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -68,6 +69,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'search'", specifier = ">=1.24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "requests", specifier = ">=2.32.5" },
     { name = "sentence-transformers", marker = "extra == 'search'", specifier = ">=2.2.0" },
 ]
 provides-extras = ["dev", "analysis", "search"]


### PR DESCRIPTION
## Summary

- **TuneArch scraper**: Fetches instrumentals with ABC notation from TuneArch.org
- **ABCJS integration**: Renders sheet music in the browser with playback and note highlighting
- **Playback controls**: Transpose, size scaling, tempo (editable BPM input)
- **ChordPro support**: New `{start_of_abc}/{end_of_abc}` blocks for embedding ABC notation
- **Build pipeline**: Extracts ABC content, detects instrumentals, adds to index
- **Utility commands**: `fetch-tune` and `bulk-fetch-tunes` for populating content
- **GitHub Action**: Workflow for processing tune request issues

## Test plan

- [ ] Open an instrumental (e.g., Blackberry Blossom, Salt Creek)
- [ ] Verify sheet music renders and fills container width
- [ ] Test playback: play/stop toggle, note highlighting
- [ ] Test controls: transpose, size +/-, tempo input
- [ ] Verify tempo changes affect playback speed
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)