### PR TITLE
Use more screen width for lyrics and fix chord wrapping

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -74,20 +74,10 @@ body {
     padding: 1rem;
 }
 
-/* Use more width on larger screens for song view and editor */
-@media (min-width: 1000px) {
-    .container:has(.song-view:not(.hidden)),
-    .container:has(.editor-panel:not(.hidden)) {
-        max-width: 1200px;
-    }
-}
-
-@media (min-width: 1400px) {
-    .container:has(.song-view:not(.hidden)),
-    .container:has(.editor-panel:not(.hidden)) {
-        max-width: 1400px;
-        padding: 1rem 2rem;
-    }
+/* Song view and editor use available width with comfortable margins */
+.container:has(.song-view:not(.hidden)),
+.container:has(.editor-panel:not(.hidden)) {
+    max-width: min(100% - 4rem, 1800px);
 }
 
 /* Header */
@@ -2683,11 +2673,6 @@ h1 {
     overflow: hidden;
 }
 
-.song-body.two-column .chord-line,
-.song-body.two-column .lyrics-line {
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
 
 .song-section {
     margin-bottom: 1.5rem;
@@ -2725,6 +2710,45 @@ h1 {
 
 .lyrics-line {
     white-space: pre;
+}
+
+/* Inline chord-lyrics segments: each chord wraps with its lyrics */
+.cl-line {
+    line-height: 1.4;
+    overflow-wrap: break-word;
+}
+
+.cl-segment {
+    display: inline-block;
+    vertical-align: bottom;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: normal;
+}
+
+.cl-chord {
+    display: block;
+    color: var(--chord);
+    font-weight: 600;
+    line-height: 1.3;
+    min-height: 1.3em;
+}
+
+/* Wrap indicator: subtle arrow when a chord-lyrics line wraps */
+.cl-line.wrapped {
+    position: relative;
+    padding-right: 1.5em;
+}
+
+.cl-line.wrapped::after {
+    content: '↩';
+    position: absolute;
+    top: 1.3em;
+    right: 0;
+    color: var(--text-secondary);
+    opacity: 0.4;
+    font-size: 0.8em;
+    line-height: 1.3;
 }
 
 /* Legacy styles */
@@ -6270,62 +6294,39 @@ a.focus-nav-btn {
     color: var(--text-secondary);
 }
 
-/* Fixed corner nav buttons for list navigation in fullscreen */
-.focus-corner-nav {
-    display: none;  /* Hidden by default */
-    position: fixed;
-    bottom: 2rem;
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    background: var(--bg-secondary);
-    border: 2px solid var(--border);
-    color: var(--text-primary);
-    font-size: 1.5rem;
+/* Inline list nav buttons in focus header */
+.focus-list-nav {
+    display: none;  /* Hidden by default, shown when in list context */
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 6px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 1.1rem;
     cursor: pointer;
-    z-index: 1001;
-    transition: background 0.15s ease, transform 0.15s ease;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    flex-shrink: 0;
+    transition: background 0.15s ease;
 }
 
-.focus-corner-nav:hover {
-    background: var(--bg-tertiary);
-    transform: scale(1.05);
+.focus-list-nav:hover {
+    background: var(--bg-secondary);
 }
 
-.focus-corner-nav:active {
-    transform: scale(0.95);
-}
-
-.focus-corner-nav:disabled {
-    opacity: 0.4;
+.focus-list-nav:disabled {
+    opacity: 0.3;
     cursor: not-allowed;
 }
 
-.focus-corner-nav:disabled:hover {
-    transform: none;
-    background: var(--bg-secondary);
+.focus-list-nav:disabled:hover {
+    background: var(--bg);
 }
 
-.focus-corner-prev {
-    left: 1.5rem;
-}
-
-.focus-corner-next {
-    right: 1.5rem;
-}
-
-.corner-nav-arrow {
+/* Show list nav buttons in fullscreen with list context */
+body.fullscreen-mode.has-list-context .focus-list-nav {
     display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-/* Show corner nav buttons in fullscreen with list context */
-body.fullscreen-mode.has-list-context .focus-corner-nav {
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 /* Fullscreen mode - hide everything except song */
@@ -6359,7 +6360,7 @@ body.fullscreen-mode .song-view {
 }
 
 body.fullscreen-mode .song-content {
-    max-width: 900px;
+    max-width: min(100% - 4rem, 1800px);
     margin: 0 auto;
     border: none;
     border-radius: 0;

--- a/docs/js/work-view.js
+++ b/docs/js/work-view.js
@@ -498,18 +498,20 @@ function renderWorkHeader() {
     // Focus header - shown in fullscreen mode
     const focusHeaderHtml = `
         <div class="focus-header">
-            <button id="focus-exit-btn" class="focus-nav-btn" title="Exit focus mode">
-                <span>✕</span>
-                <span class="focus-btn-label">Exit</span>
-            </button>
+            <button id="focus-prev-btn" class="focus-list-nav" title="Previous song (←)">←</button>
             <div class="focus-title-area">
                 <span class="focus-title">${escapeHtml(title)}</span>
                 <span id="focus-position" class="focus-position"></span>
             </div>
+            <button id="focus-exit-btn" class="focus-nav-btn" title="Exit focus mode">
+                <span>✕</span>
+                <span class="focus-btn-label">Exit</span>
+            </button>
             <button id="focus-controls-toggle" class="focus-nav-btn" title="Toggle controls">
                 <span>⚙️</span>
                 <span class="focus-btn-label">Controls</span>
             </button>
+            <button id="focus-next-btn" class="focus-list-nav" title="Next song (→)">→</button>
         </div>
     `;
 
@@ -538,15 +540,6 @@ function renderWorkHeader() {
         </div>
     `;
 
-    // Corner nav buttons for focus mode list navigation
-    const cornerNavHtml = `
-        <button id="focus-prev-btn" class="focus-corner-nav focus-corner-prev" title="Previous song (←)">
-            <span class="corner-nav-arrow">←</span>
-        </button>
-        <button id="focus-next-btn" class="focus-corner-nav focus-corner-next" title="Next song (→)">
-            <span class="corner-nav-arrow">→</span>
-        </button>
-    `;
 
     header.innerHTML = `
         ${focusHeaderHtml}
@@ -565,7 +558,6 @@ function renderWorkHeader() {
             <!-- Controls are injected here by renderTablaturePart or renderChordProPart -->
         </div>
         ${infoContentHtml}
-        ${cornerNavHtml}
     `;
 
     // Wire up version button click handler


### PR DESCRIPTION
## Summary
- **Fluid container width**: Replace stacked media-query breakpoints with `min(100% - 4rem, 1800px)` so song view reactively fills available screen space
- **Inline chord-lyrics wrapping**: Refactor rendering so each chord is paired with its lyrics segment as an `inline-block` — when a long line wraps, chords stay above their associated lyrics instead of wrapping independently
- **Focus header nav arrows**: Move prev/next list navigation from fixed bottom-corner buttons into the sticky header bar, with Exit button safely separated from the arrows
- **Wrap indicator**: Subtle ↩ on lyrics lines that wrap, so users know the line continues

## Test plan
- [ ] Open a song in two-column mode on a wide screen — container should use available width
- [ ] Increase font size (Aa +) until lines wrap — chords should stay above their lyrics
- [ ] Check ↩ indicator appears on wrapped lines at the lyrics level
- [ ] Open a song from a list in focus mode — ← and → arrows in header bar, no bottom-corner overlap
- [ ] Verify Exit button is not adjacent to arrow buttons
- [ ] Test on narrow viewport / mobile — no horizontal overflow

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)