### PR TITLE
Fix shell injection via issue titles in content workflows

### DIFF
--- a/.github/workflows/process-song-correction.yml
+++ b/.github/workflows/process-song-correction.yml
@@ -46,17 +46,21 @@ jobs:
         run: uv run python scripts/lib/build_works_index.py --skip-fuzzy
 
       - name: Commit and push
+        env:
+          # Issue titles are attacker-controlled: anyone can open an issue. Never
+          # interpolate them into the script with ${{ }} — that substitutes text
+          # before the shell parses it, so a title containing a quote escapes the
+          # string and runs as code. Passed through env and quoted, it stays data.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add sources/*/parsed/
           git add sources/*/protected.txt
           git add works/
-          git diff --staged --quiet || git commit -m "Apply song correction from #${{ github.event.issue.number }}
-
-          ${{ github.event.issue.title }}
-
-          🤖 Generated with [Claude Code](https://claude.ai/claude-code)"
+          git diff --staged --quiet || \
+            git commit -m "Apply song correction from #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
           # Retry push with rebase in case of concurrent pushes
           for i in 1 2 3; do

--- a/.github/workflows/process-song-submission.yml
+++ b/.github/workflows/process-song-submission.yml
@@ -46,16 +46,20 @@ jobs:
         run: uv run python scripts/lib/build_works_index.py --skip-fuzzy
 
       - name: Commit and push
+        env:
+          # Issue titles are attacker-controlled: anyone can open an issue. Never
+          # interpolate them into the script with ${{ }} — that substitutes text
+          # before the shell parses it, so a title containing a quote escapes the
+          # string and runs as code. Passed through env and quoted, it stays data.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add sources/manual/parsed/
           git add works/
-          git diff --staged --quiet || git commit -m "Add song from submission #${{ github.event.issue.number }}
-
-          ${{ github.event.issue.title }}
-
-          🤖 Generated with [Claude Code](https://claude.ai/claude-code)"
+          git diff --staged --quiet || \
+            git commit -m "Add song from submission #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
           # Retry push with rebase in case of concurrent pushes
           for i in 1 2 3; do

--- a/.github/workflows/process-tune-request.yml
+++ b/.github/workflows/process-tune-request.yml
@@ -42,7 +42,14 @@ jobs:
         run: |
           # Extract tune name from issue title (format: "Tune Request: <tune name>")
           TUNE_NAME=$(echo "$ISSUE_TITLE" | sed 's/Tune Request: //')
-          echo "tune_name=$TUNE_NAME" >> $GITHUB_OUTPUT
+          # Write via a delimiter block, not "key=value": a value containing a
+          # newline would otherwise forge additional step outputs. GitHub strips
+          # newlines from issue titles today, so this is belt-and-braces.
+          {
+            echo "tune_name<<TUNE_NAME_EOF"
+            echo "$TUNE_NAME"
+            echo "TUNE_NAME_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch tune from TuneArch
         env:
@@ -59,16 +66,20 @@ jobs:
         run: uv run python scripts/lib/build_works_index.py --skip-fuzzy
 
       - name: Commit and push
+        env:
+          # Issue titles are attacker-controlled: anyone can open an issue. Never
+          # interpolate them into the script with ${{ }} — that substitutes text
+          # before the shell parses it, so a title containing a quote escapes the
+          # string and runs as code. Passed through env and quoted, it stays data.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add sources/tunearch/parsed/
           git add works/
-          git diff --staged --quiet || git commit -m "Add tune from request #${{ github.event.issue.number }}
-
-          ${{ github.event.issue.title }}
-
-          🤖 Generated with [Claude Code](https://claude.ai/claude-code)"
+          git diff --staged --quiet || \
+            git commit -m "Add tune from request #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
           # Retry push with rebase in case of concurrent pushes
           for i in 1 2 3; do


### PR DESCRIPTION
Security fix. `process-song-submission`, `process-song-correction`, and `process-tune-request` each interpolated `${{ github.event.issue.title }}` directly into the inline shell of their **Commit and push** step.

GitHub substitutes `${{ }}` as *text* before the shell parses the script, so a title containing a double quote closes the string and everything after it runs as code.

### Severity
Anyone can open an issue, so the title is fully attacker-controlled. These jobs run with `contents: write` and push to `main` — this is arbitrary code execution against the trunk, and the deploy pipeline publishes from there.

Note the `approved` label gates *which* issues get processed, but the injection is in the commit step that runs after approval. A maintainer approving a normal-looking song submission is enough to fire it; the payload hides in the title.

### Verified
A title of `Blue Moon" ; touch /tmp/PWNED ; echo "` executes the injected command under the old form and does **not** under the new one, with the title still recorded verbatim in the commit message. `actionlint` reports no remaining findings beyond two pre-existing style nits.

### Fix
Pass number and title through `env:` and reference them as quoted shell variables, using two `-m` flags rather than one embedded multi-line string. Env values are never re-parsed as code — the same pattern these workflows already used correctly for their Python steps.

Also hardened the tune-request extract step, which wrote an attacker-derived value into `$GITHUB_OUTPUT` as unquoted `key=value`; now uses a delimiter block so a newline cannot forge extra step outputs. (GitHub strips newlines from issue titles today, so that one is belt-and-braces.)

### Also in this diff
Drops the `Generated with Claude Code` trailer from the three commit messages — those lines sat inside the strings being rewritten. Shout if you want them kept.

### Deliberately not fixed
Two pre-existing style-only lint findings: `SC2001` in process-tune-request (sed vs parameter expansion — left alone to avoid changing tune-name extraction semantics inside a security patch) and `SC2034` in sync-deleted-songs (unused loop variable).

### Not verified by CI
The GitHub Actions outage is still throttling webhooks, so no run may appear on this PR.