### PR TITLE
Bug bash: content workflow concurrency, list print font size

### DIFF
--- a/.github/workflows/process-song-correction.yml
+++ b/.github/workflows/process-song-correction.yml
@@ -4,9 +4,12 @@ on:
   issues:
     types: [labeled]
 
-# Serialize all content-processing workflows to prevent push conflicts
+# Serialize per issue, NOT across all content workflows. GitHub keeps only one
+# pending run per concurrency group, so a shared group silently evicts queued
+# runs when several issues are labelled at once (this dropped #208 and #209).
+# Cross-issue push races are already handled by the rebase-retry push below.
 concurrency:
-  group: content-processing
+  group: content-processing-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -62,12 +65,19 @@ jobs:
           git diff --staged --quiet || \
             git commit -m "Apply song correction from #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
-          # Retry push with rebase in case of concurrent pushes
+          # Retry push with rebase in case of concurrent pushes.
+          # Must fail loudly: falling out of the loop used to exit 0, so a
+          # commit that never reached the remote looked like a success.
+          pushed=0
           for i in 1 2 3; do
-            git push && break
+            if git push; then pushed=1; break; fi
             echo "Push failed, attempt $i - pulling and retrying..."
             git pull --rebase
           done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Push failed after 3 attempts - correction was NOT committed"
+            exit 1
+          fi
 
       - name: Close issue with comment
         uses: actions/github-script@v7

--- a/.github/workflows/process-song-correction.yml
+++ b/.github/workflows/process-song-correction.yml
@@ -4,12 +4,17 @@ on:
   issues:
     types: [labeled]
 
-# Serialize per issue, NOT across all content workflows. GitHub keeps only one
-# pending run per concurrency group, so a shared group silently evicts queued
-# runs when several issues are labelled at once (this dropped #208 and #209).
-# Cross-issue push races are already handled by the rebase-retry push below.
+# Group per (workflow, issue). All three content workflows trigger on every
+# `labeled` event and the job-level `if` filters them AFTERWARDS -- concurrency
+# is evaluated at the workflow-run level, before any job's `if`, so a run that
+# will skip still claims the group. With one shared group a SINGLE label event
+# started three runs, one won, one queued, and the third evicted the queued one
+# (GitHub keeps only one pending run per group). That is what silently dropped
+# submissions #208 and #209; batching several issues was never required.
+# Same issue + same workflow still serialises, which is the part that matters.
+# Cross-run push races are handled by the rebase-retry push below.
 concurrency:
-  group: content-processing-${{ github.event.issue.number }}
+  group: content-processing-correction-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/process-song-submission.yml
+++ b/.github/workflows/process-song-submission.yml
@@ -4,12 +4,17 @@ on:
   issues:
     types: [labeled]
 
-# Serialize per issue, NOT across all content workflows. GitHub keeps only one
-# pending run per concurrency group, so a shared group silently evicts queued
-# runs when several issues are labelled at once (this dropped #208 and #209).
-# Cross-issue push races are already handled by the rebase-retry push below.
+# Group per (workflow, issue). All three content workflows trigger on every
+# `labeled` event and the job-level `if` filters them AFTERWARDS -- concurrency
+# is evaluated at the workflow-run level, before any job's `if`, so a run that
+# will skip still claims the group. With one shared group a SINGLE label event
+# started three runs, one won, one queued, and the third evicted the queued one
+# (GitHub keeps only one pending run per group). That is what silently dropped
+# submissions #208 and #209; batching several issues was never required.
+# Same issue + same workflow still serialises, which is the part that matters.
+# Cross-run push races are handled by the rebase-retry push below.
 concurrency:
-  group: content-processing-${{ github.event.issue.number }}
+  group: content-processing-submission-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/process-song-submission.yml
+++ b/.github/workflows/process-song-submission.yml
@@ -4,9 +4,12 @@ on:
   issues:
     types: [labeled]
 
-# Serialize all content-processing workflows to prevent push conflicts
+# Serialize per issue, NOT across all content workflows. GitHub keeps only one
+# pending run per concurrency group, so a shared group silently evicts queued
+# runs when several issues are labelled at once (this dropped #208 and #209).
+# Cross-issue push races are already handled by the rebase-retry push below.
 concurrency:
-  group: content-processing
+  group: content-processing-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -61,12 +64,19 @@ jobs:
           git diff --staged --quiet || \
             git commit -m "Add song from submission #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
-          # Retry push with rebase in case of concurrent pushes
+          # Retry push with rebase in case of concurrent pushes.
+          # Must fail loudly: falling out of the loop used to exit 0, so a
+          # commit that never reached the remote looked like a success.
+          pushed=0
           for i in 1 2 3; do
-            git push && break
+            if git push; then pushed=1; break; fi
             echo "Push failed, attempt $i - pulling and retrying..."
             git pull --rebase
           done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Push failed after 3 attempts - song was NOT committed"
+            exit 1
+          fi
 
       - name: Close issue with comment
         uses: actions/github-script@v7

--- a/.github/workflows/process-tune-request.yml
+++ b/.github/workflows/process-tune-request.yml
@@ -4,9 +4,12 @@ on:
   issues:
     types: [labeled]
 
-# Serialize all content-processing workflows to prevent push conflicts
+# Serialize per issue, NOT across all content workflows. GitHub keeps only one
+# pending run per concurrency group, so a shared group silently evicts queued
+# runs when several issues are labelled at once (this dropped #208 and #209).
+# Cross-issue push races are already handled by the rebase-retry push below.
 concurrency:
-  group: content-processing
+  group: content-processing-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -81,12 +84,19 @@ jobs:
           git diff --staged --quiet || \
             git commit -m "Add tune from request #${ISSUE_NUMBER}" -m "$ISSUE_TITLE"
 
-          # Retry push with rebase in case of concurrent pushes
+          # Retry push with rebase in case of concurrent pushes.
+          # Must fail loudly: falling out of the loop used to exit 0, so a
+          # commit that never reached the remote looked like a success.
+          pushed=0
           for i in 1 2 3; do
-            git push && break
+            if git push; then pushed=1; break; fi
             echo "Push failed, attempt $i - pulling and retrying..."
             git pull --rebase
           done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Push failed after 3 attempts - tune was NOT committed"
+            exit 1
+          fi
 
       - name: Close issue with comment
         uses: actions/github-script@v7

--- a/.github/workflows/process-tune-request.yml
+++ b/.github/workflows/process-tune-request.yml
@@ -4,12 +4,17 @@ on:
   issues:
     types: [labeled]
 
-# Serialize per issue, NOT across all content workflows. GitHub keeps only one
-# pending run per concurrency group, so a shared group silently evicts queued
-# runs when several issues are labelled at once (this dropped #208 and #209).
-# Cross-issue push races are already handled by the rebase-retry push below.
+# Group per (workflow, issue). All three content workflows trigger on every
+# `labeled` event and the job-level `if` filters them AFTERWARDS -- concurrency
+# is evaluated at the workflow-run level, before any job's `if`, so a run that
+# will skip still claims the group. With one shared group a SINGLE label event
+# started three runs, one won, one queued, and the third evicted the queued one
+# (GitHub keeps only one pending run per group). That is what silently dropped
+# submissions #208 and #209; batching several issues was never required.
+# Same issue + same workflow still serialises, which is the part that matters.
+# Cross-run push races are handled by the rebase-retry push below.
 concurrency:
-  group: content-processing-${{ github.event.issue.number }}
+  group: content-processing-tune-request-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:

--- a/docs/js/__tests__/print-font-size.test.js
+++ b/docs/js/__tests__/print-font-size.test.js
@@ -1,0 +1,68 @@
+// Regression tests for issue #210 — "Increasing font size when printing a
+// whole list does nothing."
+//
+// The list print view is a separate document (window.open + document.write)
+// with its own stylesheet, so it sizes song text in px while the app sizes it
+// with the FONT_SIZES em multipliers. generatePrintListPage() used to collect
+// fontSizeLevel into its prefs and then never read it, and the print document
+// hardcoded 14px — two font-size scales with no connection between them.
+//
+// printFontPxForLevel() is the bridge. These lock down that it stays derived
+// from FONT_SIZES rather than drifting into a third independent scale.
+import { describe, it, expect } from 'vitest';
+
+import {
+    FONT_SIZES,
+    printFontPxForLevel,
+    PRINT_BASE_FONT_PX,
+    PRINT_FONT_PX_MIN,
+    PRINT_FONT_PX_MAX,
+} from '../state.js';
+
+describe('printFontPxForLevel', () => {
+    it('maps the default level to the print base size', () => {
+        // Level 0 is the 1.0 multiplier — print output must be unchanged for
+        // everyone who never touched the font size control.
+        expect(printFontPxForLevel(0)).toBe(PRINT_BASE_FONT_PX);
+    });
+
+    it('scales by the same multiplier the song page uses', () => {
+        expect(printFontPxForLevel(6)).toBe(28);   // 14 * 2.0
+        expect(printFontPxForLevel(3)).toBe(20);   // 14 * 1.4 = 19.6, rounded
+        expect(printFontPxForLevel(-2)).toBe(11);  // 14 * 0.8 = 11.2, rounded
+    });
+
+    it('increases monotonically across the whole scale', () => {
+        const levels = Object.keys(FONT_SIZES).map(Number).sort((a, b) => a - b);
+        const sizes = levels.map(printFontPxForLevel);
+        for (let i = 1; i < sizes.length; i++) {
+            expect(sizes[i]).toBeGreaterThanOrEqual(sizes[i - 1]);
+        }
+    });
+
+    it('clamps to the bounds of the print view size input', () => {
+        // 14 * 0.5 = 7, below the input's min of 8.
+        expect(printFontPxForLevel(-5)).toBe(PRINT_FONT_PX_MIN);
+
+        for (const level of Object.keys(FONT_SIZES)) {
+            const px = printFontPxForLevel(level);
+            expect(px).toBeGreaterThanOrEqual(PRINT_FONT_PX_MIN);
+            expect(px).toBeLessThanOrEqual(PRINT_FONT_PX_MAX);
+        }
+    });
+
+    it('accepts string keys, since prefs round-trip through JSON', () => {
+        // View prefs are persisted to localStorage, so the level can come back
+        // as either a number or a string depending on the write path.
+        expect(printFontPxForLevel('6')).toBe(printFontPxForLevel(6));
+        expect(printFontPxForLevel('0')).toBe(printFontPxForLevel(0));
+    });
+
+    it('falls back to the base size for an unknown level', () => {
+        // Never return NaN into a CSS custom property — that would silently
+        // drop the rule and take the print view back to unstyled text.
+        expect(printFontPxForLevel(undefined)).toBe(PRINT_BASE_FONT_PX);
+        expect(printFontPxForLevel(null)).toBe(PRINT_BASE_FONT_PX);
+        expect(printFontPxForLevel(999)).toBe(PRINT_BASE_FONT_PX);
+    });
+});

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -23,6 +23,8 @@ import {
     showSectionLabels,
     twoColumnMode,
     fontSizeLevel,
+    printFontPxForLevel,
+    PRINT_BASE_FONT_PX, PRINT_FONT_PX_MIN, PRINT_FONT_PX_MAX,
     setListContext,
     setWorkRedirects, resolveWorkId,
     setBountyIndex,
@@ -1808,6 +1810,12 @@ function generatePrintListPage(listName, songs, prefs, contents = []) {
     if (prefs.chordDisplayMode === 'first') bodyClasses.push('chords-first');
     if (prefs.chordDisplayMode === 'none') bodyClasses.push('chords-none');
 
+    // Carry the reader's font size across the document boundary. The print
+    // window can't inherit the app's em multiplier (it's a separate document
+    // with its own stylesheet), so derive its px scale from the SAME
+    // FONT_SIZES table the song page uses — one source of truth, not two.
+    const fontPx = printFontPxForLevel(prefs.fontSizeLevel);
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1987,7 +1995,8 @@ function generatePrintListPage(listName, songs, prefs, contents = []) {
         }
         body.compact .repeat-instruction { display: block; }
         body.compact .section.is-repeat { display: none; }
-        .song-content { font-size: var(--font-size, 14px); }
+        .song-content { font-size: var(--font-size, ${PRINT_BASE_FONT_PX}px); }
+        :root { --font-size: ${fontPx}px; }
     </style>
 </head>
 <body class="${bodyClasses.join(' ')}">
@@ -1995,7 +2004,7 @@ function generatePrintListPage(listName, songs, prefs, contents = []) {
         <div class="font-size-control">
             <span class="control-label">Size:</span>
             <button id="font-decrease" class="size-btn">−</button>
-            <input type="number" id="font-size-input" value="14" min="8" max="32">
+            <input type="number" id="font-size-input" value="${fontPx}" min="${PRINT_FONT_PX_MIN}" max="${PRINT_FONT_PX_MAX}">
             <button id="font-increase" class="size-btn">+</button>
         </div>
         <div class="checkbox-group">
@@ -2032,7 +2041,7 @@ function generatePrintListPage(listName, songs, prefs, contents = []) {
         bind('page-per-song-toggle', e => B.toggle('page-per-song', e.target.checked));
         const input = document.getElementById('font-size-input');
         const setSize = v => {
-            input.value = Math.max(8, Math.min(32, v || 14));
+            input.value = Math.max(${PRINT_FONT_PX_MIN}, Math.min(${PRINT_FONT_PX_MAX}, v || ${fontPx}));
             document.documentElement.style.setProperty('--font-size', input.value + 'px');
         };
         document.getElementById('font-decrease').addEventListener('click', () => setSize(+input.value - 2));

--- a/docs/js/state.js
+++ b/docs/js/state.js
@@ -197,6 +197,19 @@ export const FONT_SIZES = {
     '6': 2.0
 };
 
+// The list print view is a separate document with its own stylesheet, so it
+// can't inherit the em multiplier above — it sizes song text in px instead.
+// These translate one scale into the other so the two can't drift apart.
+export const PRINT_BASE_FONT_PX = 14;   // what a 1.0 multiplier means in print
+export const PRINT_FONT_PX_MIN = 8;     // bounds match the print view's +/- input
+export const PRINT_FONT_PX_MAX = 32;
+
+/** Font size in px for the print view, for a given app font size level. */
+export function printFontPxForLevel(level) {
+    const px = PRINT_BASE_FONT_PX * (FONT_SIZES[level] ?? 1);
+    return Math.max(PRINT_FONT_PX_MIN, Math.min(PRINT_FONT_PX_MAX, Math.round(px)));
+}
+
 // ============================================
 // TABLATURE STATE
 // ============================================


### PR DESCRIPTION
Bug bash from Tim Clark's reports. Two CI fixes and one frontend fix.

## Content workflows silently dropped approved submissions

All three content workflows (`process-song-submission`, `process-song-correction`, `process-tune-request`) trigger on every `issues: labeled` event and shared a single `content-processing` concurrency group. The job-level `if` that filters them runs *after* concurrency is evaluated — group assignment happens at the workflow-run level — so a run that is going to skip still claims the group. GitHub keeps only one pending run per group, so of the three runs a single label event produced, one won, one queued, and the third evicted the queued one.

Observed directly while re-triggering #208: one label event produced two runs, `Process Tune Request` claimed the group and completed as skipped, and `Process Song Submission` — the run with actual work — was cancelled.

This corrects the original diagnosis. Batch-labelling several issues was never required to lose a run; a single label event was always enough. Any submission approved on its own has been at risk for as long as the three workflows have shared a group, so #208 and #209 may not be the only casualties — closed-but-unprocessed submissions are worth an audit.

Each workflow now gets its own group, keyed by workflow and issue. Same issue plus same workflow still serialises, which is the case that actually needs it.

Also makes the rebase-retry push fail loudly. It fell out of the loop after three failed attempts and exited 0, so a commit that never reached the remote reported success — which would have kept hiding drops even after the concurrency fix.

## Increasing font size when printing a whole list does nothing (#210)

`openPrintListView()` collected `fontSizeLevel` into its prefs object and `generatePrintListPage()` never read it — a dead parameter. Its five sibling prefs were threaded into the generated page's body classes; this one was not, so the size a reader set on a song page was dropped at the document boundary.

The print view is a separate document (`window.open` + `document.write`) with its own stylesheet, so it cannot inherit the app's em multipliers and sizes song text in px instead — previously hardcoded to 14px on an independent 8–32 scale. Two font-size systems with nothing connecting them.

Adds `printFontPxForLevel()` next to `FONT_SIZES`, where the scale is defined, and derives the print document's `:root --font-size`, its size input, and that input's fallback from it. One source of truth, so the two scales cannot drift.

Verified in-browser against the real print path: level 0 still yields 14px (no change for default readers), 3 → 20px, 5 → 25px, 6 → 28px rendered on both `.song-content` and the inherited `.lyric-line`, −5 clamps to the input's 8px minimum, and the print view's own +/− control still works. Six regression tests cover the mapping, monotonicity, clamping, string keys from JSON round-trips, and the unknown-level fallback.

## Tests

`npx vitest run` — 1437 passed (58 files). `uv run pytest` — 398 passed, 1 skipped.

## Follow-ups, not in this PR

- #206 closed as already supported: list printing exists behind the 🖨️ Print button in the list header. Tim went looking for "Export" and found "Print" — the two surfaces disagree on naming, which is worth reconciling.
- #208 and #209 have corrected bodies but still carry `approved`. The label has to come off and go back on to fire, so merging this alone will not process them.
- #207 and the submission-gate rework are being scoped separately.
