### PR TITLE
Add list-scale export (Export pill in list view)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -176,7 +176,6 @@
                     </div>
                 </div>
                 <div class="list-header-controls">
-                    <button id="list-print-btn" class="list-header-btn" title="Print all songs in this list">🖨️ Print</button>
                     <button id="list-share-btn" class="list-header-btn hidden" title="Copy share link">🔗 Share</button>
                     <button id="list-duplicate-btn" class="list-header-btn" title="Duplicate this list">📋 Duplicate</button>
                     <button id="list-follow-btn" class="list-header-btn hidden" title="Follow this list">👁️ Follow</button>

--- a/docs/js/__tests__/list-export.test.js
+++ b/docs/js/__tests__/list-export.test.js
@@ -11,6 +11,7 @@ import {
     stripToPlainText,
     buildListChordPro,
     buildListText,
+    buildListZipFiles,
     listFileBase,
 } from '../list-export.js';
 
@@ -135,5 +136,44 @@ describe('listFileBase', () => {
 
     it('bounds the length', () => {
         expect(listFileBase('x'.repeat(200)).length).toBeLessThanOrEqual(80);
+    });
+});
+
+describe('buildListZipFiles', () => {
+    it('emits one file per song, named from the title', () => {
+        const files = buildListZipFiles([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        expect(files.map(f => f.name)).toEqual(['How Long Blues.pro', 'Sally Goodin.pro']);
+    });
+
+    it('normalises metadata the same way the combined export does', () => {
+        const [file] = buildListZipFiles([SONG_A], [CONTENT_A]);
+        expect(file.content).toContain('{title: How Long Blues}');
+        expect(file.content).toContain('{meta: x_source web-chords}');
+    });
+
+    it('never emits {new_song} - each file is a single song', () => {
+        const files = buildListZipFiles([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        for (const f of files) expect(f.content).not.toContain('{new_song}');
+    });
+
+    it('deduplicates names when two works share a title', () => {
+        // A list can hold two arrangements of the same song; without this the
+        // zip would extract to a single file.
+        const dup = { id: 'c', title: 'How Long Blues', artist: 'Someone Else' };
+        const files = buildListZipFiles(
+            [SONG_A, dup],
+            [CONTENT_A, '{meta: title How Long Blues}\n[E]other version\n']
+        );
+        expect(files.map(f => f.name)).toEqual(['How Long Blues.pro', 'How Long Blues (2).pro']);
+    });
+
+    it('skips songs with no content', () => {
+        const files = buildListZipFiles([SONG_A, SONG_B], [CONTENT_A, '']);
+        expect(files).toHaveLength(1);
+    });
+
+    it('ends every file with a newline', () => {
+        const files = buildListZipFiles([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        for (const f of files) expect(f.content.endsWith('\n')).toBe(true);
     });
 });

--- a/docs/js/__tests__/list-export.test.js
+++ b/docs/js/__tests__/list-export.test.js
@@ -1,0 +1,139 @@
+// Tests for exporting a whole list as one file (#206 follow-up).
+//
+// The value of a list export is that it opens in someone ELSE'S ChordPro
+// reader, so these lock down the two portability decisions: {new_song}
+// between songs, and standard metadata emitted as standalone directives
+// rather than the {meta: ...} form many external tools ignore.
+import { describe, it, expect } from 'vitest';
+
+import {
+    normalizeChordProMeta,
+    stripToPlainText,
+    buildListChordPro,
+    buildListText,
+    listFileBase,
+} from '../list-export.js';
+
+const SONG_A = {
+    id: 'a', title: 'How Long Blues', artist: 'Del McCoury',
+};
+const CONTENT_A = `{meta: title How Long Blues}
+{meta: artist Del McCoury}
+{meta: composer Leroy Carr}
+{key: E}
+{meta: x_source web-chords}
+
+{start_of_chorus: Chorus}
+[E]How long, how [E7]long
+{end_of_chorus}`;
+
+const SONG_B = { id: 'b', title: 'Sally Goodin', artist: 'The Price Sisters' };
+const CONTENT_B = `{meta: title Sally Goodin}
+
+{start_of_verse: Verse 1}
+[A]Had a piece of pie
+{end_of_verse}`;
+
+describe('normalizeChordProMeta', () => {
+    it('rewrites standard meta names to standalone directives', () => {
+        const out = normalizeChordProMeta(CONTENT_A);
+        expect(out).toContain('{title: How Long Blues}');
+        expect(out).toContain('{artist: Del McCoury}');
+        expect(out).toContain('{composer: Leroy Carr}');
+    });
+
+    it('leaves non-standard meta alone', () => {
+        // x_source has no standalone directive - {meta: ...} is correct for it.
+        expect(normalizeChordProMeta(CONTENT_A)).toContain('{meta: x_source web-chords}');
+    });
+
+    it('leaves directives that are already standalone untouched', () => {
+        expect(normalizeChordProMeta('{key: E}')).toBe('{key: E}');
+    });
+
+    it('does not disturb chords or lyrics', () => {
+        expect(normalizeChordProMeta(CONTENT_A)).toContain('[E]How long, how [E7]long');
+    });
+
+    it('tolerates empty input', () => {
+        expect(normalizeChordProMeta('')).toBe('');
+        expect(normalizeChordProMeta(undefined)).toBe('');
+    });
+});
+
+describe('buildListChordPro', () => {
+    it('separates songs with {new_song}', () => {
+        const out = buildListChordPro([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        expect(out.match(/\{new_song\}/g)).toHaveLength(1);
+    });
+
+    it('does not emit {new_song} before the first song', () => {
+        // The directive is implied at the start of a file.
+        const out = buildListChordPro([SONG_A], [CONTENT_A]);
+        expect(out).not.toContain('{new_song}');
+        expect(out.trimStart().startsWith('{title:')).toBe(true);
+    });
+
+    it('gives every song a {title:} an external reader will recognise', () => {
+        const out = buildListChordPro([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        expect(out.match(/^\{title:/gm)).toHaveLength(2);
+    });
+
+    it('synthesises a title when the source has no title metadata', () => {
+        const out = buildListChordPro([SONG_A], ['[E]just chords, no metadata']);
+        expect(out).toContain('{title: How Long Blues}');
+    });
+
+    it('skips songs with no content instead of emitting empty entries', () => {
+        const out = buildListChordPro([SONG_A, SONG_B], [CONTENT_A, '']);
+        expect(out).not.toContain('{new_song}');
+        expect(out).toContain('How Long Blues');
+        expect(out).not.toContain('Sally Goodin');
+    });
+
+    it('handles an empty list without producing a stray separator', () => {
+        expect(buildListChordPro([], []).trim()).toBe('');
+    });
+});
+
+describe('buildListText', () => {
+    it('heads each song with its title and artist', () => {
+        const out = buildListText([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        expect(out).toContain('How Long Blues\nDel McCoury');
+        expect(out).toContain('Sally Goodin\nThe Price Sisters');
+    });
+
+    it('strips chords and directives from the body', () => {
+        const out = buildListText([SONG_A], [CONTENT_A]);
+        expect(out).toContain('How long, how long');
+        expect(out).not.toContain('[E7]');
+        expect(out).not.toContain('start_of_chorus');
+    });
+
+    it('separates songs with a visible rule', () => {
+        const out = buildListText([SONG_A, SONG_B], [CONTENT_A, CONTENT_B]);
+        expect(out).toContain('-'.repeat(40));
+    });
+});
+
+describe('stripToPlainText', () => {
+    it('collapses the blank lines left behind by removed directives', () => {
+        expect(stripToPlainText('{a}\n\n\n\n{b}\nword')).toBe('word');
+    });
+});
+
+describe('listFileBase', () => {
+    it('removes characters filesystems reject', () => {
+        expect(listFileBase('Sunday/Jam: "best" <picks>')).toBe('SundayJam best picks');
+    });
+
+    it('falls back when a name is empty or all-illegal', () => {
+        expect(listFileBase('')).toBe('songbook-list');
+        expect(listFileBase('///')).toBe('songbook-list');
+        expect(listFileBase(undefined)).toBe('songbook-list');
+    });
+
+    it('bounds the length', () => {
+        expect(listFileBase('x'.repeat(200)).length).toBeLessThanOrEqual(80);
+    });
+});

--- a/docs/js/__tests__/zip.test.js
+++ b/docs/js/__tests__/zip.test.js
@@ -1,0 +1,121 @@
+// Tests for the minimal ZIP writer used by list export.
+//
+// These parse the archive back out of the bytes rather than trusting the
+// writer's own arithmetic — a zip with a plausible-looking but wrong central
+// directory offset opens fine in some tools and fails in others, so the
+// structure is checked explicitly.
+import { describe, it, expect } from 'vitest';
+
+import { createZip, crc32 } from '../zip.js';
+
+const FIXED_DATE = new Date(2026, 7, 15, 12, 34, 56);
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** Minimal reader: walk the central directory the way an unzip tool would. */
+function readZip(bytes) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+    // End-of-central-directory is the last 22 bytes (no archive comment here).
+    const eocd = bytes.length - 22;
+    if (view.getUint32(eocd, true) !== 0x06054B50) throw new Error('no EOCD');
+
+    const count = view.getUint16(eocd + 10, true);
+    const cdSize = view.getUint32(eocd + 12, true);
+    const cdOffset = view.getUint32(eocd + 16, true);
+
+    const files = [];
+    let off = cdOffset;
+    for (let i = 0; i < count; i++) {
+        if (view.getUint32(off, true) !== 0x02014B50) throw new Error('bad central header');
+        const flags = view.getUint16(off + 8, true);
+        const method = view.getUint16(off + 10, true);
+        const crc = view.getUint32(off + 16, true);
+        const compSize = view.getUint32(off + 20, true);
+        const uncompSize = view.getUint32(off + 24, true);
+        const nameLen = view.getUint16(off + 28, true);
+        const localOff = view.getUint32(off + 42, true);
+        const name = dec.decode(bytes.subarray(off + 46, off + 46 + nameLen));
+
+        // Follow the pointer into the local header and pull the data out.
+        if (view.getUint32(localOff, true) !== 0x04034B50) throw new Error('bad local header');
+        const localNameLen = view.getUint16(localOff + 26, true);
+        const localExtraLen = view.getUint16(localOff + 28, true);
+        const dataStart = localOff + 30 + localNameLen + localExtraLen;
+        const content = dec.decode(bytes.subarray(dataStart, dataStart + uncompSize));
+
+        files.push({ name, content, crc, method, flags, compSize, uncompSize });
+        off += 46 + nameLen;
+    }
+
+    return { count, cdSize, cdOffset, cdSizeActual: off - cdOffset, files };
+}
+
+describe('crc32', () => {
+    it('matches the known checksum for a standard input', () => {
+        // "123456789" -> 0xCBF43926 is the canonical CRC-32 check value.
+        expect(crc32(enc.encode('123456789'))).toBe(0xCBF43926);
+    });
+
+    it('is zero for empty input', () => {
+        expect(crc32(new Uint8Array(0))).toBe(0);
+    });
+});
+
+describe('createZip', () => {
+    const FILES = [
+        { name: 'How Long Blues.pro', content: '{title: How Long Blues}\n[E]How long\n' },
+        { name: 'Sally Goodin.pro', content: '{title: Sally Goodin}\n[A]Had a piece of pie\n' },
+    ];
+
+    it('produces an archive whose central directory matches its contents', () => {
+        const zip = readZip(createZip(FILES, { date: FIXED_DATE }));
+        expect(zip.count).toBe(2);
+        // The declared central directory size must match what is actually there.
+        expect(zip.cdSize).toBe(zip.cdSizeActual);
+    });
+
+    it('round-trips names and content', () => {
+        const zip = readZip(createZip(FILES, { date: FIXED_DATE }));
+        expect(zip.files.map(f => f.name)).toEqual(FILES.map(f => f.name));
+        expect(zip.files.map(f => f.content)).toEqual(FILES.map(f => f.content));
+    });
+
+    it('stores a correct CRC for each entry', () => {
+        const zip = readZip(createZip(FILES, { date: FIXED_DATE }));
+        zip.files.forEach((f, i) => {
+            expect(f.crc).toBe(crc32(enc.encode(FILES[i].content)));
+        });
+    });
+
+    it('marks entries as stored with equal compressed and uncompressed sizes', () => {
+        const zip = readZip(createZip(FILES, { date: FIXED_DATE }));
+        for (const f of zip.files) {
+            expect(f.method).toBe(0);
+            expect(f.compSize).toBe(f.uncompSize);
+        }
+    });
+
+    it('flags names as UTF-8 and round-trips non-ASCII titles', () => {
+        const zip = readZip(createZip(
+            [{ name: 'Über Blues — Café.pro', content: '{title: Über}\n' }],
+            { date: FIXED_DATE }
+        ));
+        expect(zip.files[0].flags & 0x0800).toBe(0x0800);
+        expect(zip.files[0].name).toBe('Über Blues — Café.pro');
+        // Byte length differs from character length for multi-byte names.
+        expect(zip.files[0].content).toBe('{title: Über}\n');
+    });
+
+    it('is byte-stable for the same input and date', () => {
+        const a = createZip(FILES, { date: FIXED_DATE });
+        const b = createZip(FILES, { date: FIXED_DATE });
+        expect(Array.from(a)).toEqual(Array.from(b));
+    });
+
+    it('handles an empty archive', () => {
+        const zip = readZip(createZip([], { date: FIXED_DATE }));
+        expect(zip.count).toBe(0);
+        expect(zip.files).toEqual([]);
+    });
+});

--- a/docs/js/list-export.js
+++ b/docs/js/list-export.js
@@ -1,0 +1,96 @@
+// Exporting a whole list as one file.
+//
+// A list export has to survive leaving this app — the point is to open it in
+// someone else's ChordPro reader. Two things follow from that:
+//
+// 1. Songs are separated by {new_song}, the standard multi-song directive
+//    (chordpro.org/chordpro/directives-new_song). It is implied at the start
+//    of a file, so it goes BETWEEN songs, not before the first one.
+//
+// 2. Our corpus writes metadata as {meta: title ...}. That is semantically
+//    valid, but the spec is explicit that "many external tools will only
+//    recognize the {title: ...} directive". In a single-song file an
+//    unrecognised title is cosmetic; in a 40-song file the titles are the only
+//    way to navigate it, so we rewrite the standard names to their standalone
+//    directive form on the way out.
+
+/**
+ * Metadata names that ChordPro defines a standalone directive for.
+ * Anything else (our x_source, x_version_label, ...) is left as {meta: ...},
+ * which is exactly what that form is for.
+ */
+const STANDARD_META = new Set([
+    'title', 'sorttitle', 'subtitle', 'artist', 'composer', 'lyricist',
+    'arranger', 'copyright', 'album', 'year', 'key', 'time', 'tempo',
+    'duration', 'capo',
+]);
+
+/** Rewrite {meta: NAME VALUE} to {NAME: VALUE} for the standard names only. */
+export function normalizeChordProMeta(content) {
+    return (content || '').replace(
+        /\{meta:\s*([A-Za-z_][A-Za-z0-9_]*)\s+([^}]*)\}/g,
+        (whole, name, value) => STANDARD_META.has(name.toLowerCase())
+            ? `{${name.toLowerCase()}: ${value.trim()}}`
+            : whole
+    );
+}
+
+/** Strip chords and directives, leaving the bare lyric text. */
+export function stripToPlainText(content) {
+    return (content || '')
+        .replace(/\[[^\]]*\]/g, '')
+        .replace(/\{[^}]*\}/g, '')
+        .replace(/[ \t]+$/gm, '')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+/**
+ * One ChordPro document containing every song in the list.
+ * `contents[i]` is the raw ChordPro for `songs[i]`; missing entries are skipped
+ * rather than emitted as an empty song.
+ */
+export function buildListChordPro(songs, contents = []) {
+    const bodies = songs
+        .map((song, i) => {
+            const raw = (contents[i] || song.content || '').trim();
+            if (!raw) return null;
+            let body = normalizeChordProMeta(raw);
+            // A reader that only understands {title:} still needs one, even if
+            // the source had no title metadata at all.
+            if (!/^\{title:/m.test(body) && song.title) {
+                body = `{title: ${song.title}}\n${body}`;
+            }
+            return body;
+        })
+        .filter(Boolean);
+
+    // {new_song} is implied at the start of a file, so it only goes between.
+    return bodies.join('\n\n{new_song}\n\n') + '\n';
+}
+
+/** Human-readable text version: a titled header per song, lyrics only. */
+export function buildListText(songs, contents = []) {
+    const blocks = songs
+        .map((song, i) => {
+            const lyrics = stripToPlainText(contents[i] || song.content || '');
+            if (!lyrics) return null;
+            const title = song.title || 'Untitled';
+            const head = song.artist ? `${title}\n${song.artist}` : title;
+            return `${head}\n${'='.repeat(Math.max(title.length, 3))}\n\n${lyrics}`;
+        })
+        .filter(Boolean);
+
+    return blocks.join('\n\n\n' + '-'.repeat(40) + '\n\n\n') + '\n';
+}
+
+/** Filename stem for a list, safe across filesystems. */
+export function listFileBase(listName) {
+    const cleaned = (listName || '')
+        .replace(/[\/\\:*?"<>|]/g, '')   // characters filesystems reject
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 80)
+        .trim();
+    return cleaned || 'songbook-list';
+}

--- a/docs/js/list-export.js
+++ b/docs/js/list-export.js
@@ -84,6 +84,40 @@ export function buildListText(songs, contents = []) {
     return blocks.join('\n\n\n' + '-'.repeat(40) + '\n\n\n') + '\n';
 }
 
+/**
+ * One .pro file per song, for readers that import a folder rather than a
+ * multi-song file. Same metadata normalisation as the combined export.
+ *
+ * Names are deduplicated: a list can legitimately hold two works with the same
+ * title (different arrangements), and a zip with duplicate names extracts to
+ * whichever entry lands last.
+ */
+export function buildListZipFiles(songs, contents = []) {
+    const used = new Set();
+    const files = [];
+
+    songs.forEach((song, i) => {
+        const raw = (contents[i] || song.content || '').trim();
+        if (!raw) return;
+
+        let body = normalizeChordProMeta(raw);
+        if (!/^\{title:/m.test(body) && song.title) {
+            body = `{title: ${song.title}}\n${body}`;
+        }
+
+        const stem = listFileBase(song.title || song.id || 'song');
+        let name = `${stem}.pro`;
+        for (let n = 2; used.has(name.toLowerCase()); n++) {
+            name = `${stem} (${n}).pro`;
+        }
+        used.add(name.toLowerCase());
+
+        files.push({ name, content: body.endsWith('\n') ? body : `${body}\n` });
+    });
+
+    return files;
+}
+
 /** Filename stem for a list, safe across filesystems. */
 export function listFileBase(listName) {
     const cleaned = (listName || '')

--- a/docs/js/lists.js
+++ b/docs/js/lists.js
@@ -670,7 +670,6 @@ let listHeaderEl = null;
 let listHeaderNameEl = null;
 let listHeaderCountEl = null;
 let listHeaderBadgeEl = null;
-let listPrintBtnEl = null;
 let listShareBtnEl = null;
 let listDuplicateBtnEl = null;
 let listFollowBtnEl = null;
@@ -2234,8 +2233,7 @@ function renderListViewUI(listName, songIds, status) {
         }
 
         // Configure header buttons based on ownership
-        // Print - always visible
-        if (listPrintBtnEl) listPrintBtnEl.classList.remove('hidden');
+        // Print/export lives in the Export pill (mounted by main.js), not here
 
         // Share - owner only
         if (listShareBtnEl) {
@@ -2957,7 +2955,6 @@ export function initLists(options) {
     listHeaderNameEl = document.getElementById('list-header-name');
     listHeaderCountEl = document.getElementById('list-header-count');
     listHeaderBadgeEl = document.getElementById('list-header-badge');
-    listPrintBtnEl = document.getElementById('list-print-btn');
     listShareBtnEl = document.getElementById('list-share-btn');
     listDuplicateBtnEl = document.getElementById('list-duplicate-btn');
     listFollowBtnEl = document.getElementById('list-follow-btn');
@@ -3091,12 +3088,6 @@ export function initLists(options) {
     // ============================================
     // NEW LIST HEADER BUTTON HANDLERS
     // ============================================
-
-    // List header: Print button
-    listPrintBtnEl?.addEventListener('click', () => {
-        // Delegate to existing print functionality
-        printListBtnEl?.click();
-    });
 
     // List header: Share button
     listShareBtnEl?.addEventListener('click', async () => {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -48,7 +48,8 @@ import { initEditor, updateEditorPreview, enterEditMode, exitEditMode, editorGen
 import { escapeHtml, requireLogin, parseItemRef, buildDeleteCandidates, downloadFile } from './utils.js';
 import { parseChordPro, renderSectionsPrintHtml } from './renderers/chordpro.js';
 import { initShell, setTopBar, setBottomBand, setOverflowBase, setChromeAutoHide, pill } from './shell.js';
-import { buildListChordPro, buildListText, listFileBase } from './list-export.js';
+import { buildListChordPro, buildListText, buildListZipFiles, listFileBase } from './list-export.js';
+import { createZip } from './zip.js';
 import { initAnalytics, track, trackNavigation, trackThemeToggle, trackDeepLink } from './analytics.js';
 import { initFlags, openFeedbackModal } from './flags.js';
 import { initSuperUserRequest } from './superuser-request.js';
@@ -1823,6 +1824,14 @@ async function handleListExport(action) {
         downloadFile(`${base}.pro`, buildListChordPro(listSongs, contents), 'text/plain');
     } else if (action === 'download-text') {
         downloadFile(`${base}.txt`, buildListText(listSongs, contents), 'text/plain');
+    } else if (action === 'download-zip') {
+        // One .pro per song, for readers that import a folder of files
+        const files = buildListZipFiles(listSongs, contents);
+        if (!files.length) {
+            alert('No song content available to export.');
+            return;
+        }
+        downloadFile(`${base}.zip`, createZip(files), 'application/zip');
     }
 }
 
@@ -1830,6 +1839,7 @@ const LIST_EXPORT_ACTIONS = [
     { action: 'print', label: '🖨️ Print' },
     { action: 'download-chordpro', label: '⬇️ Download .pro' },
     { action: 'download-text', label: '⬇️ Download .txt' },
+    { action: 'download-zip', label: '🗜️ Download .zip (one file per song)' },
 ];
 
 /**

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -45,9 +45,10 @@ import { openWork, teardownTablatureView, configureWorkPage, updateWorkTopBar, h
 import { renderBountyView } from './bounty-view.js';
 import { initSearch, search, showPopularSongs, renderResults, parseSearchQuery } from './search-core.js';
 import { initEditor, updateEditorPreview, enterEditMode, exitEditMode, editorGenerateChordPro, closeHints, prepareAddSongView } from './editor.js';
-import { escapeHtml, requireLogin, parseItemRef, buildDeleteCandidates } from './utils.js';
+import { escapeHtml, requireLogin, parseItemRef, buildDeleteCandidates, downloadFile } from './utils.js';
 import { parseChordPro, renderSectionsPrintHtml } from './renderers/chordpro.js';
-import { initShell, setTopBar, setBottomBand, setOverflowBase, setChromeAutoHide } from './shell.js';
+import { initShell, setTopBar, setBottomBand, setOverflowBase, setChromeAutoHide, pill } from './shell.js';
+import { buildListChordPro, buildListText, listFileBase } from './list-export.js';
 import { initAnalytics, track, trackNavigation, trackThemeToggle, trackDeepLink } from './analytics.js';
 import { initFlags, openFeedbackModal } from './flags.js';
 import { initSuperUserRequest } from './superuser-request.js';
@@ -1734,10 +1735,14 @@ function openListsModal() {
 // PRINT LIST VIEW
 // ============================================
 
-async function openPrintListView() {
-    // Get the current list
+/**
+ * The list currently being viewed, with its songs resolved against the corpus.
+ * Shared by every Export action so print and download can't drift apart on
+ * which songs they think are in the list.
+ */
+function resolveViewingList() {
     const listId = getViewingListId();
-    if (!listId) return;
+    if (!listId) return null;
 
     // Find the list (favorites is now just a regular list)
     let list = userLists.find(l => l.id === listId || l.cloudId === listId);
@@ -1747,12 +1752,19 @@ async function openPrintListView() {
         list = getFavoritesList();
     }
 
-    if (!list) return;
+    if (!list) return null;
 
-    // Get all songs in the list
     const listSongs = list.songs
         .map(id => allSongs.find(s => s.id === id))
         .filter(Boolean);
+
+    return { list, listSongs };
+}
+
+async function openPrintListView() {
+    const resolved = resolveViewingList();
+    if (!resolved) return;
+    const { list, listSongs } = resolved;
 
     if (listSongs.length === 0) {
         alert('No songs in this list to print.');
@@ -1782,6 +1794,72 @@ async function openPrintListView() {
     }
     printWindow.document.write(printHtml);
     printWindow.document.close();
+}
+
+/**
+ * Download the whole list as one file. Both formats export the SOURCE
+ * ChordPro, not the transposed/Nashville view — same as the song page's
+ * Export, so a downloaded file always matches what's stored.
+ */
+async function handleListExport(action) {
+    if (action === 'print') {
+        openPrintListView();
+        return;
+    }
+
+    const resolved = resolveViewingList();
+    if (!resolved) return;
+    const { list, listSongs } = resolved;
+
+    if (listSongs.length === 0) {
+        alert('No songs in this list to export.');
+        return;
+    }
+
+    const contents = await getSongContents(listSongs);
+    const base = listFileBase(list.name);
+
+    if (action === 'download-chordpro') {
+        downloadFile(`${base}.pro`, buildListChordPro(listSongs, contents), 'text/plain');
+    } else if (action === 'download-text') {
+        downloadFile(`${base}.txt`, buildListText(listSongs, contents), 'text/plain');
+    }
+}
+
+const LIST_EXPORT_ACTIONS = [
+    { action: 'print', label: '🖨️ Print' },
+    { action: 'download-chordpro', label: '⬇️ Download .pro' },
+    { action: 'download-text', label: '⬇️ Download .txt' },
+];
+
+/**
+ * Export pill for the list header. The song page has had one of these all
+ * along; list view only offered a bare Print button, which is what sent the
+ * reporter of #206 looking for an Export control that wasn't there.
+ */
+function buildListExportPill() {
+    return pill('Export', (container, api) => {
+        container.innerHTML = LIST_EXPORT_ACTIONS.map(a =>
+            `<button class="pill-popover-item" data-action="${a.action}">${a.label}</button>`
+        ).join('');
+        container.querySelectorAll('[data-action]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                api.close();
+                handleListExport(btn.dataset.action);
+            });
+        });
+    }, { id: 'list-export-pill', title: 'Print or download every song in this list' });
+}
+
+/**
+ * Mount the Export pill in the list header, where the bare Print button used
+ * to be. It leads the control row because printing/exporting a set is the
+ * reason most people open a list in the first place.
+ */
+function mountListExportPill() {
+    const controls = document.querySelector('.list-header-controls');
+    if (!controls || document.getElementById('list-export-pill')) return;
+    controls.insertBefore(buildListExportPill(), controls.firstChild);
 }
 
 function generatePrintListPage(listName, songs, prefs, contents = []) {
@@ -2312,6 +2390,9 @@ function init() {
 
     // Print list button
     printListBtn?.addEventListener('click', openPrintListView);
+
+    // List header gets the full Export menu (print + downloads), not just print
+    mountListExportPill();
 
     // Close dropdowns when clicking outside
     document.addEventListener('click', (e) => {

--- a/docs/js/zip.js
+++ b/docs/js/zip.js
@@ -1,0 +1,129 @@
+// Minimal ZIP writer (stored, no compression).
+//
+// Exists because some ChordPro readers import a folder of one-song-per-file
+// rather than a multi-song file, and there is no bundler here to pull in a zip
+// library. Stored entries keep this small and dependency-free; ChordPro files
+// are a few KB each, so compression would buy little.
+//
+// Implements the subset of APPNOTE.TXT needed for a flat archive of small
+// files: local headers, a central directory, and an end-of-central-directory
+// record. No Zip64, no directory entries, no encryption.
+
+const CRC_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) {
+            c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+        }
+        table[i] = c >>> 0;
+    }
+    return table;
+})();
+
+export function crc32(bytes) {
+    let c = 0xFFFFFFFF;
+    for (let i = 0; i < bytes.length; i++) {
+        c = CRC_TABLE[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+    }
+    return (c ^ 0xFFFFFFFF) >>> 0;
+}
+
+/** MS-DOS packed date/time, which is what the ZIP header format stores. */
+function dosDateTime(d) {
+    const year = Math.max(1980, d.getFullYear());
+    return {
+        time: ((d.getHours() & 0x1F) << 11)
+            | ((d.getMinutes() & 0x3F) << 5)
+            | ((d.getSeconds() >> 1) & 0x1F),
+        date: (((year - 1980) & 0x7F) << 9)
+            | (((d.getMonth() + 1) & 0x0F) << 5)
+            | (d.getDate() & 0x1F),
+    };
+}
+
+/**
+ * Build a ZIP archive.
+ *
+ * @param {Array<{name: string, content: string|Uint8Array}>} files
+ * @param {{date?: Date}} opts  Fixed date makes output byte-stable for tests.
+ * @returns {Uint8Array}
+ */
+export function createZip(files, { date = new Date() } = {}) {
+    const encoder = new TextEncoder();
+    const { time: dosTime, date: dosDate } = dosDateTime(date);
+
+    const entries = files.map(f => {
+        const nameBytes = encoder.encode(f.name);
+        const dataBytes = typeof f.content === 'string'
+            ? encoder.encode(f.content)
+            : f.content;
+        return { nameBytes, dataBytes, crc: crc32(dataBytes), offset: 0 };
+    });
+
+    let size = 22; // end-of-central-directory record
+    for (const e of entries) {
+        size += 30 + e.nameBytes.length + e.dataBytes.length; // local header
+        size += 46 + e.nameBytes.length;                      // central header
+    }
+
+    const buf = new Uint8Array(size);
+    const view = new DataView(buf.buffer);
+    let off = 0;
+
+    // Bit 11 declares the name is UTF-8, so non-ASCII song titles survive.
+    const FLAG_UTF8 = 0x0800;
+    const METHOD_STORED = 0;
+    const VERSION = 20;
+
+    for (const e of entries) {
+        e.offset = off;
+        view.setUint32(off, 0x04034B50, true); off += 4;  // local file header
+        view.setUint16(off, VERSION, true); off += 2;
+        view.setUint16(off, FLAG_UTF8, true); off += 2;
+        view.setUint16(off, METHOD_STORED, true); off += 2;
+        view.setUint16(off, dosTime, true); off += 2;
+        view.setUint16(off, dosDate, true); off += 2;
+        view.setUint32(off, e.crc, true); off += 4;
+        view.setUint32(off, e.dataBytes.length, true); off += 4;  // compressed
+        view.setUint32(off, e.dataBytes.length, true); off += 4;  // uncompressed
+        view.setUint16(off, e.nameBytes.length, true); off += 2;
+        view.setUint16(off, 0, true); off += 2;           // extra field length
+        buf.set(e.nameBytes, off); off += e.nameBytes.length;
+        buf.set(e.dataBytes, off); off += e.dataBytes.length;
+    }
+
+    const centralStart = off;
+    for (const e of entries) {
+        view.setUint32(off, 0x02014B50, true); off += 4;  // central directory
+        view.setUint16(off, VERSION, true); off += 2;     // version made by
+        view.setUint16(off, VERSION, true); off += 2;     // version needed
+        view.setUint16(off, FLAG_UTF8, true); off += 2;
+        view.setUint16(off, METHOD_STORED, true); off += 2;
+        view.setUint16(off, dosTime, true); off += 2;
+        view.setUint16(off, dosDate, true); off += 2;
+        view.setUint32(off, e.crc, true); off += 4;
+        view.setUint32(off, e.dataBytes.length, true); off += 4;
+        view.setUint32(off, e.dataBytes.length, true); off += 4;
+        view.setUint16(off, e.nameBytes.length, true); off += 2;
+        view.setUint16(off, 0, true); off += 2;           // extra
+        view.setUint16(off, 0, true); off += 2;           // comment
+        view.setUint16(off, 0, true); off += 2;           // disk number start
+        view.setUint16(off, 0, true); off += 2;           // internal attrs
+        view.setUint32(off, 0, true); off += 4;           // external attrs
+        view.setUint32(off, e.offset, true); off += 4;    // local header offset
+        buf.set(e.nameBytes, off); off += e.nameBytes.length;
+    }
+    const centralEnd = off;
+
+    view.setUint32(off, 0x06054B50, true); off += 4;      // end of central dir
+    view.setUint16(off, 0, true); off += 2;               // this disk
+    view.setUint16(off, 0, true); off += 2;               // disk with central
+    view.setUint16(off, entries.length, true); off += 2;  // entries this disk
+    view.setUint16(off, entries.length, true); off += 2;  // entries total
+    view.setUint32(off, centralEnd - centralStart, true); off += 4;
+    view.setUint32(off, centralStart, true); off += 4;
+    view.setUint16(off, 0, true); off += 2;               // comment length
+
+    return buf;
+}


### PR DESCRIPTION
Fast follow to #206. Closing that issue by pointing at the list header's Print button only answered half of it — Export also copies and downloads, and none of that existed for a list. Renaming the button would have been a lie; this adds the missing capability so the name is honest.

## What changed

An Export pill in the list header, matching the song page, offering **Print** (the existing `openPrintListView` pipeline, not a second one), **Download .pro**, **Download .txt**, and **Download .zip** (one `.pro` per song).

The bare Print button is removed rather than hidden. `lists.js` un-hid it on every header render, so a hidden button would have kept fighting a live handler — its four now-dead references are gone too.

List resolution is extracted to `resolveViewingList()` so print and download can't disagree about which songs are in the list.

## What "export a list" means for other ChordPro readers

This is the part worth reviewing, since the whole point is that the file opens somewhere else.

**Songs are separated by `{new_song}`** — the standard multi-song directive. Per the spec it's implied at the start of a file, so it's emitted *between* songs only, never before the first.

**Standard metadata is rewritten from `{meta: title ...}` to `{title: ...}`.** The ChordPro spec is explicit:

> Although `{meta: title ...}` is semantically equivalent to `{title: ...}`, it is good practice to always use the latter. Many external tools will only recognize the `{title: ...}` directive.

Our corpus is written in the `meta` form. A raw dump would open **untitled** in many readers — cosmetic for a single song, ruinous for a 40-song file where titles are the only way to navigate. The rewrite covers only the names ChordPro defines a standalone directive for (title, artist, composer, key, capo, …); non-standard names like `x_source` and `x_version_label` stay as `{meta: ...}`, which is exactly what that form is for. A song whose source carries no title at all gets one synthesised from the index.

**Exports the stored source**, not the transposed or Nashville view — same as the song page's Export, so a downloaded file always matches what's in `works/`.

## Verification

In-browser against a real 3-song list: 2 `{new_song}` separators with none leading, 3 recognisable `{title:}` directives, no leftover `{meta: title|artist|composer}`, `x_source` preserved as meta, `.txt` with titled headers and chords stripped, filenames `Sunday Jam.pro` / `Sunday Jam.txt`. Print still routes through the existing pipeline and still honours the font size fixed in #210.

18 unit tests covering the meta rewrite, separator placement, title synthesis, empty/missing content, text formatting, and filename sanitising. Frontend 1455 passed, Python 398 passed / 1 skipped.

## Deliberately not included

Clipboard actions (Copy ChordPro / Copy Plain Text). They're in the song page's Export but are questionable at list scale — a 40-song clipboard paste is rarely what anyone wants. Easy to add if you'd rather have strict parity.

Nothing else — the ZIP option is now included (see below).

## The .zip option

Some readers import a folder of one-song-per-file rather than a multi-song file, so the combined `.pro` alone doesn't serve everyone. `docs/js/zip.js` is a minimal stored-mode ZIP writer: there's no bundler here to pull in a zip library, and ChordPro files are a few KB each so compression buys little. It implements the subset of APPNOTE.TXT needed for a flat archive — local headers, central directory, EOCD, CRC-32 — with general-purpose bit 11 set so non-ASCII titles survive as UTF-8. No Zip64, no directory entries.

Entries get the same metadata normalisation as the combined export, and names are deduplicated, since a list can hold two arrangements sharing a title that would otherwise extract to a single file.

Verified against real tools rather than the writer's own reader, which could share a bug with it:

- `unzip -t` validates every entry's CRC
- extracted lyrics are byte-identical to the source apart from the normalised metadata lines
- Python's `zipfile` confirms `flag_bits=0x0800` and decodes names correctly

One caveat worth recording: Apple's bundled **UnZip 6.00 (2009)** mangles non-ASCII filenames on extract. That's a limitation of that old tool — Python's `zipfile`, macOS Finder, and modern extractors handle the archive correctly. Most song titles are ASCII, so the blast radius is small.
