### PR TITLE
Migration fix: drop CHECK on nonexistent pending_songs.notes

### DIFF
--- a/supabase/migrations/20260815120000_pending_songs_open_writes.sql
+++ b/supabase/migrations/20260815120000_pending_songs_open_writes.sql
@@ -102,11 +102,8 @@ begin
       check (composer is null or char_length(composer) <= 300);
   end if;
 
-  if not exists (select 1 from pg_constraint where conname = 'pending_songs_notes_len') then
-    alter table pending_songs
-      add constraint pending_songs_notes_len
-      check (notes is null or char_length(notes) <= 5000);
-  end if;
+  -- No notes cap: pending_songs has no notes column (request "notes" are
+  -- folded into content/issue text by create-song-request, capped there).
 
   if not exists (select 1 from pg_constraint where conname = 'pending_songs_tags_size') then
     alter table pending_songs


### PR DESCRIPTION
One-block fix found while applying the phase migrations to prod: the open-writes migration added a CHECK on a `notes` column pending_songs never had. All five migrations are now applied to prod (verified: policies, size caps, review_requests, dedup_hold, arr_key, doc_staging dropped) and recorded in schema_migrations; this aligns the repo file with what actually ran.