### PR TITLE
Tab renderer: stop silently dropping long slurs

### DIFF
--- a/.claude/skills/tab-debug/SKILL.md
+++ b/.claude/skills/tab-debug/SKILL.md
@@ -317,10 +317,32 @@ not decode 0x04 → bend.
 **Frontend**: `expandNotationWithReadingList()` in work-view.js expands measures
 **Files**: `sources/banjo-hangout/src/tef_parser/reader.py`, `docs/js/work-view.js`
 
-### Cross-measure ties not rendering
+### Slur/tie arc missing (FIXED for barlines — check the ROW boundary)
 
-**Cause**: Each measure is a separate SVG row, can't draw arc across
-**Workaround**: Tied notes show bracket notation `[7]` instead of arc
+**Not the cause**: "each measure is its own SVG". It isn't — a row holds
+several measures (`measuresPerRow`) in one SVG, and `renderSlurs()` runs
+per-row after the whole row is laid out, so ties AND techniques (`h`, `p`,
+`/`) arc across barlines fine. Brackets on a tied fret `[7]` supplement that
+arc, they don't replace it.
+
+**Was a cause until 2026-08**: `renderSlurs()` gated technique arcs on a fixed
+60px note-to-note distance, so any hammer/pull/slide spanning a quarter note
+or more vanished entirely — no arc, no `sl`/`H`/`P` label (the tech-symbol
+fallback skips h/p// on the grounds renderSlurs draws them), while playback
+still sounded it. 7 of 27 slides in `foggy-mountain-breakdown/banjo.otf.json`
+were invisible. Fixed by deleting the pixel gate: the source note is the
+immediately preceding note on the same string, which is what the articulation
+*means* and exactly what `tab-player.js` pairs. If you are ever tempted to
+re-add a pixel threshold here, don't — it silently drops real notation and
+re-breaks at every layout width.
+
+**Still a real cause**: the ROW boundary. `renderSlurs` only sees one row's
+notes, so a slur whose source is on the previous row can't be completed. Ties
+draw an incoming half-arc from the margin (`.tie-arc-in`); techniques draw
+nothing. Widen the window (or narrow `measuresPerRow`) to confirm that's what
+you're looking at.
+**Guard**: `docs/js/__tests__/tablature-slurs.test.js` renders the real FMB
+banjo tab and asserts arc count == technique count.
 
 ### Notes clustered in first half of measure (2/4 time rendered as 4/4)
 

--- a/docs/js/__tests__/tablature-rests.test.js
+++ b/docs/js/__tests__/tablature-rests.test.js
@@ -93,16 +93,19 @@ describe('TabRenderer tie arcs across barlines', () => {
         expect(rows[0].querySelector('.tie-arc-in')).toBeNull();
     });
 
-    it('keeps the tight cap for technique slurs', () => {
+    // Technique slurs used to be gated behind a 60px proximity cap, which
+    // silently ate any hammer/pull/slide spanning a quarter note or more.
+    // The pairing is musical, not spatial — see tablature-slurs.test.js.
+    it('arcs a technique across a barline too', () => {
         const container = document.createElement('div');
         document.body.appendChild(container);
         const r = new TabRenderer(container);
-        // hammer-on a full measure away — no slur
+        // hammer-on from the previous note on the string, a measure back
         r.render(TRACK, [
             { measure: 1, events: [{ tick: 0, notes: [{ s: 3, f: 0 }] }] },
             { measure: 2, events: [{ tick: 0, notes: [{ s: 3, f: 2, tech: 'h' }] }] },
         ], 480, '4/4');
-        expect(container.querySelector('.tech-slur')).toBeNull();
+        expect(container.querySelector('.tech-slur')).not.toBeNull();
     });
 });
 

--- a/docs/js/__tests__/tablature-slurs.test.js
+++ b/docs/js/__tests__/tablature-slurs.test.js
@@ -1,0 +1,195 @@
+// Technique slurs (slide / hammer-on / pull-off) must be VISIBLE.
+//
+// Regression guard for the invisible-slide bug: renderSlurs used to gate
+// technique arcs behind a fixed 60px proximity cap, so any slide spanning a
+// quarter note or more was silently dropped — no arc, no "sl" label, and the
+// tech-symbol fallback in the note loop deliberately skips h/p// because
+// renderSlurs "handles" them. On Foggy Mountain Breakdown that swallowed 7 of
+// 27 slides while playback still sounded every one of them.
+//
+// jsdom: container.clientWidth is 0, so the renderer falls back to an 800px
+// container -> availableWidth 720 -> 4 measures per row at 180px.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { TabRenderer } from '../renderers/tablature.js';
+
+// jsdom's import.meta.url isn't a file: URL, so walk up from cwd to the
+// repo root instead of resolving relative to this module.
+const REPO_ROOT = (() => {
+    let dir = process.cwd();
+    while (!fs.existsSync(path.join(dir, 'works')) && path.dirname(dir) !== dir) {
+        dir = path.dirname(dir);
+    }
+    return dir;
+})();
+
+const FMB = JSON.parse(fs.readFileSync(path.join(
+    REPO_ROOT, 'works/foggy-mountain-breakdown/banjo.otf.json'), 'utf8'));
+
+const TECH = new Set(['h', 'p', '/']);
+
+function renderTrack(track, notation, ticksPerBeat, options = {}) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    new TabRenderer(container, options)
+        .render(track, notation, ticksPerBeat, '4/4');
+    return container;
+}
+
+// Techniques pair with the immediately preceding note on the same string.
+// renderSlurs is row-scoped, so a technique whose source sits on the previous
+// ROW legitimately gets no arc (a known, out-of-scope limitation) — count the
+// pairs that are actually drawable so the expectation is exact, not a floor.
+function expectedSlurs(notation, measuresPerRow) {
+    let drawable = 0;
+    let total = 0;
+    for (let start = 0; start < notation.length; start += measuresPerRow) {
+        const lastOnString = {};
+        for (const measure of notation.slice(start, start + measuresPerRow)) {
+            for (const event of measure.events || []) {
+                for (const note of event.notes) {
+                    if (TECH.has(note.tech)) {
+                        total++;
+                        if (lastOnString[note.s]) drawable++;
+                    }
+                    lastOnString[note.s] = true;
+                }
+            }
+        }
+    }
+    return { drawable, total };
+}
+
+const countTech = (notation, tech) => notation.reduce((n, m) =>
+    n + (m.events || []).reduce((k, e) =>
+        k + e.notes.filter(note => tech ? note.tech === tech
+            : TECH.has(note.tech)).length, 0), 0);
+
+describe('technique slurs on the real Foggy Mountain Breakdown banjo tab', () => {
+    const banjo = FMB.notation.banjo;
+    const track = FMB.tracks.find(t => t.id === 'banjo');
+    const tpb = FMB.timing.ticks_per_beat;
+
+    it('the fixture still holds the articulations this test is about', () => {
+        expect(countTech(banjo, '/')).toBe(27);
+        expect(countTech(banjo, 'h')).toBe(33);
+        expect(countTech(banjo, 'p')).toBe(14);
+    });
+
+    it('draws an arc for EVERY slide, including the long ones', () => {
+        const c = renderTrack(track, banjo, tpb);
+        // 'sl' labels are emitted once per drawn slide arc.
+        const slLabels = [...c.querySelectorAll('text')]
+            .filter(t => t.textContent === 'sl');
+        expect(slLabels).toHaveLength(27);
+    });
+
+    it('draws exactly one arc per technique — no spurious pairings', () => {
+        const c = renderTrack(track, banjo, tpb);
+        const { drawable, total } = expectedSlurs(banjo, 4);
+        expect(total).toBe(74);            // 27 slides + 33 hammers + 14 pulls
+        expect(drawable).toBe(74);         // none stranded on a row boundary here
+        // Total arcs must EQUAL the technique count: a missing arc is the bug
+        // we fixed, a surplus arc would mean we started pairing unrelated notes.
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(drawable);
+        const labels = [...c.querySelectorAll('text')]
+            .filter(t => ['sl', 'H', 'P'].includes(t.textContent));
+        expect(labels).toHaveLength(drawable);
+    });
+
+    it('gives the long slides sane geometry, not degenerate stubs', () => {
+        const c = renderTrack(track, banjo, tpb);
+        const arcs = [...c.querySelectorAll('.tech-slur')];
+        // d = "M x1 y Q mx my x2 y"
+        const spans = arcs.map(a => {
+            const n = a.getAttribute('d').split(/[MQ\s]+/).filter(Boolean).map(Number);
+            return { x1: n[0], x2: n[4] };
+        });
+        for (const { x1, x2 } of spans) {
+            expect(x2).toBeGreaterThan(x1);           // left-to-right
+            expect(x2 - x1).toBeLessThan(720);        // never wider than a row
+        }
+        // The bug class was *long* techniques vanishing. Arcs inset 6px from
+        // each note centre, so the old 60px centre-to-centre cap is a 48px
+        // drawn span — at least one arc must now be wider than that.
+        expect(Math.max(...spans.map(s => s.x2 - s.x1))).toBeGreaterThan(48);
+    });
+
+    it('survives a wide layout (1 measure per row) without dropping arcs', () => {
+        // measureWidthFloor auto-expansion in the editor can blow past any
+        // fixed pixel cap; a layout-independent predicate must not care.
+        const c = renderTrack(track, banjo, tpb, { measuresPerRow: 1 });
+        const { drawable } = expectedSlurs(banjo, 1);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(drawable);
+    });
+});
+
+describe('renderSlurs pairing predicate', () => {
+    const TRACK = {
+        id: 'banjo',
+        instrument: '5-string-banjo',
+        tuning: ['D4', 'B3', 'G3', 'D3', 'G4'],
+    };
+    const render = (notation, options) => {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        new TabRenderer(container, options)
+            .render(TRACK, notation, 480, '4/4');
+        return container;
+    };
+
+    it('arcs a technique across a barline between two quarter notes', () => {
+        // Quarter on beat 4 of m1 slid into the downbeat of m2 — the exact
+        // shape (quarter-note source, tick-0 target) that the pixel cap ate.
+        const c = render([
+            { measure: 1, events: [{ tick: 1440, notes: [{ s: 3, f: 0, dur: 480 }] }] },
+            { measure: 2, events: [{ tick: 0, notes: [{ s: 3, f: 2, dur: 480, tech: '/' }] }] },
+        ]);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(1);
+        expect([...c.querySelectorAll('text')]
+            .filter(t => t.textContent === 'sl')).toHaveLength(1);
+    });
+
+    it('arcs a hammer-on a full measure away (playback sounds it either way)', () => {
+        const c = render([
+            { measure: 1, events: [{ tick: 0, notes: [{ s: 3, f: 0 }] }] },
+            { measure: 2, events: [{ tick: 0, notes: [{ s: 3, f: 2, tech: 'h' }] }] },
+        ]);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(1);
+    });
+
+    it('pairs only within a string, and only with the immediate predecessor', () => {
+        const c = render([{
+            measure: 1,
+            events: [
+                { tick: 0, notes: [{ s: 3, f: 0 }] },
+                { tick: 480, notes: [{ s: 1, f: 5 }] },   // other string, ignored
+                { tick: 960, notes: [{ s: 3, f: 2, tech: 'h' }] },
+            ],
+        }]);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(1);
+    });
+
+    it('draws no arc when the technique has no predecessor on its string', () => {
+        const c = render([{
+            measure: 1,
+            events: [{ tick: 0, notes: [{ s: 3, f: 2, tech: '/' }] }],
+        }]);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(0);
+    });
+
+    it('leaves tie arcs behaving as before', () => {
+        const c = render([
+            { measure: 1, events: [{ tick: 960, notes: [{ s: 3, f: 0, dur: 960 }] }] },
+            { measure: 2, events: [{ tick: 0, notes: [{ s: 3, f: 0, dur: 960, tie: true }] }] },
+        ]);
+        expect(c.querySelectorAll('.tie-arc')).toHaveLength(1);
+        expect(c.querySelectorAll('.tech-slur')).toHaveLength(0);
+        // ties carry no letter label
+        expect([...c.querySelectorAll('text')]
+            .filter(t => ['sl', 'H', 'P'].includes(t.textContent))).toHaveLength(0);
+    });
+});

--- a/docs/js/renderers/CLAUDE.md
+++ b/docs/js/renderers/CLAUDE.md
@@ -37,9 +37,11 @@ OTF JSON
     ↓ expandNotationWithReadingList()
 Expanded notation (repeats applied)
     ↓ render()
-SVG rows (one per measure)
-    ↓ renderMeasure()
+SVG rows (several measures per row — `measuresPerRow`, 'auto' by default)
+    ↓ renderRow() → per-measure geometry
 Note positions, fret numbers, articulations
+    ↓ renderSlurs() (row-scoped, after all measures in the row are laid out)
+Slur/tie arcs, including across barlines
 ```
 
 ### Articulations
@@ -48,12 +50,24 @@ The renderer shows these articulation marks:
 
 | Articulation | Symbol | Rendered As |
 |--------------|--------|-------------|
-| Hammer-on | `h` | Slur arc above + "h" |
-| Pull-off | `p` | Slur arc above + "p" |
-| Slide | `/` or `\` | Slur arc + "/" or "\" |
-| Tie | `~` | Bracket notation `[7]` |
+| Hammer-on | `h` | Slur arc above + "H" |
+| Pull-off | `p` | Slur arc above + "P" |
+| Slide | `/` | Slur arc + "sl" |
+| Bend/choke | `b` | Tilted arrow + "½", target fret bracketed `[7]` |
+| Tie | `tie: true` | Slur arc, continuation fret bracketed `[7]` |
 
-**Note**: Cross-measure ties use bracket notation because each measure is a separate SVG row.
+**Cross-barline arcs work.** A row holds several measures in ONE SVG
+(`measuresPerRow`), and `renderSlurs()` runs once per row after every measure
+in it is laid out — so ties AND techniques arc across barlines freely. The
+pairing is musical, not spatial: the source is the immediately preceding note
+on the same string, with no pixel-distance gate (a fixed cap used to eat any
+technique spanning a quarter note or more, and re-broke at every new layout
+width). Brackets are a *supplement* to the tie arc, not a substitute for it.
+
+**The remaining limitation is ROW boundaries**, not measure boundaries:
+`renderSlurs` only sees one row's notes, so a technique or tie whose source
+sits on the previous row gets no full arc. Ties draw an incoming half-arc from
+the margin (`.tie-arc-in`); techniques currently draw nothing.
 
 ### Multi-Track Support
 

--- a/docs/js/renderers/tablature.js
+++ b/docs/js/renderers/tablature.js
@@ -1082,12 +1082,20 @@ export class TabRenderer {
 
                 const n1 = notes[i - 1];
                 const xDist = n2.x - n1.x;
-                // Techniques (h/p/slide) connect adjacent notes — keep the
-                // tight cap. TIES legitimately span barlines (a whole note
-                // entered mid-measure splits across it), so allow a full
-                // measure's reach.
-                const maxDist = hasTie ? 400 : 60;
-                if (xDist > maxDist) continue;
+                // No proximity gate. The pairing is MUSICAL, not spatial:
+                // a slide/hammer/pull is notated on its target and means
+                // "sounded from the previous note on this string without a
+                // new pluck", and a tie's antecedent is likewise the previous
+                // note on the string — which is exactly what notes[i - 1] is
+                // here, by construction. Playback (tab-player.js) pairs the
+                // same two notes with no distance test, so any pixel cap makes
+                // notation and sound disagree: the old 60px technique cap ate
+                // every technique spanning a quarter note or more (7 of the 27
+                // slides in Foggy Mountain Breakdown), silently — the
+                // tech-symbol fallback above skips h/p// on the grounds that
+                // this function draws them. Pixel caps also re-break at wider
+                // layouts (the editor's measureWidthFloor expansion), which is
+                // why this isn't a bigger number.
 
                 // For closely-spaced notes (like grace note slides), reduce the offsets
                 // so the slur is still visible


### PR DESCRIPTION
Triage-classified ROOT FIX for the invisible-slide report (Foggy Mountain Breakdown m5→m6): renderSlurs gated technique arcs behind a fixed 60px distance, silently dropping any slide/hammer/pull spanning a quarter note or more — 7 of 27 slides on FMB banjo, with playback and notation disagreeing. The pixel gate is deleted, not raised: the pairing is musical (same pair playback sounds), verified corpus-wide (393 tabs, 8,784 technique notes, max gap 1200 ticks). Adds the first slur-emission test suite (arc count must EQUAL technique count); fixes a test that had codified the bug; corrects two stale doc claims about cross-measure slurs. 1734 unit tests green.