### PR TITLE
Tab submission: early offramp, additive siblings, correct correction targeting

### DIFF
--- a/docs/create.html
+++ b/docs/create.html
@@ -115,7 +115,7 @@
             saveDraft, loadDraft, clearDraft,
         } from './js/otf-editor/create-tab.js';
         import {
-            parseCreateTarget, presetForInstrument, submitNewTab,
+            parseCreateTarget, presetForInstrument, submitNewTab, targetBannerText,
         } from './js/otf-editor/create-tab-entry.js';
         import { parseTef, TefVersionError } from './js/tef-import/index.js';
 
@@ -143,7 +143,8 @@
                 strong.textContent = ` — ${target.instrument}`;
                 banner.append(strong);
             }
-            banner.append('. It joins that song as a new part when it’s published.');
+            banner.append('. ');
+            banner.append(targetBannerText(target));
             banner.classList.remove('hidden');
             if (target.title && !$('f-title').value) $('f-title').value = target.title;
         }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3513,6 +3513,87 @@ mark {
     color: var(--danger);
 }
 
+/* ── "This song already has tabs" — the early offramp panel ──
+   Shared by the add-song picker's tab step and the work page's bounty
+   section (docs/js/otf-editor/existing-tabs.js). */
+.tab-existing-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.75rem;
+    padding: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary, transparent);
+}
+
+.tab-existing-head {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.tab-existing-sub {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.tab-existing-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 15rem;
+    overflow-y: auto;
+}
+
+.tab-existing-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tab-existing-view,
+.tab-existing-improve,
+.tab-existing-add,
+.tab-existing-back {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.tab-existing-view {
+    flex: 1;
+    text-align: left;
+}
+
+.tab-existing-view:hover,
+.tab-existing-improve:hover,
+.tab-existing-add:hover,
+.tab-existing-back:hover {
+    border-color: var(--accent);
+}
+
+.tab-existing-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.tab-existing-add {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+    font-weight: 600;
+}
+
 /* Bounty CTA button reset (was <a>, now <button>) */
 .bounty-cta-btn {
     border: none;

--- a/docs/js/CLAUDE.md
+++ b/docs/js/CLAUDE.md
@@ -566,7 +566,8 @@ showing "not found" (openWork, `#song/` redirects, `#edit/` deep links).
   "tablature_parts": [{
     "instrument": "banjo",
     "label": "banjo",
-    "file": "data/tabs/red-haired-boy-banjo.otf.json",
+    "file": "data/tabs/red-haired-boy-banjo-1687.otf.json",
+    "src_file": "banjo.otf.json",   // the file inside works/{id}/
     "source": "banjo-hangout",
     "source_id": "1687",
     "author": "schlange",
@@ -762,6 +763,32 @@ Frictionless song requests without a GitHub account.
   branches on identity: **signed in** → a `pending_songs` placeholder the
   requester owns (and lands on); **anonymous** → a `tune-request` GitHub
   issue and a confirmation, with no placeholder work minted
+
+### Contributing a tab (`otf-editor/create-tab-entry.js`, `existing-tabs.js`)
+
+Two entry points open the tab editor pre-targeted at a work — the work
+page's "+ Add a tab" / tablature-bounty Contribute, and the add-song
+picker's Tablature card — both routing through `create.html` with
+`?work=&instrument=&title=&have=`.
+
+**A work that already has tabs for that instrument says so BEFORE the
+editor opens** (contract principle 4 — the offramp is offered early, never
+discovered at Submit). `tabEntryPlan(song, instrument)` reads
+`tablature_parts` straight off the index row (no fetch) and matches
+instrument families the way `tags.js getInstrumentTags` does, so a
+`5-string-banjo` part answers to `banjo`. When it finds any,
+`renderExistingTabsPanel` offers three ways forward:
+
+- **view** an existing take → `#work/{id}/{partId}`
+- **add mine as another version** → the editor exactly as before, with the
+  sibling count carried into the create-page banner
+- **improve this one** → the tab-correction path (`enterTabEditMode`), via
+  `requestTabEdit(workId, file)` when the work page isn't already open
+
+Same-instrument siblings are normal (foggy-mountain-breakdown carries
+eight banjo takes), so `create-tab-pr` **adds** a uniquely-named part
+rather than 409ing. A correction names the take it fixes with
+`src_file` — the published `file` name can't be mapped back to `works/`.
 
 ### Multi-Owner Lists & Thunderdome
 

--- a/docs/js/__tests__/add-song-picker-tab.test.js
+++ b/docs/js/__tests__/add-song-picker-tab.test.js
@@ -28,6 +28,7 @@ function mountPicker() {
                 <select id="picker-tab-instrument">
                     <option value=""></option>
                     <option value="banjo">Banjo</option>
+                    <option value="guitar">Guitar</option>
                 </select>
                 <div id="picker-tab-results"></div>
                 <button id="picker-tab-new"></button>
@@ -50,6 +51,17 @@ const SONGS = [
     { id: 'salt-creek', title: 'Salt Creek', artist: 'Bill Monroe' },
     { id: 'salty-dog-blues', title: 'Salty Dog Blues', artist: 'Flatt & Scruggs' },
     { id: 'gold-rush', title: 'Gold Rush', artist: 'Bill Monroe' },
+    {
+        id: 'foggy-mountain-breakdown', title: 'Foggy Mountain Breakdown',
+        artist: 'Earl Scruggs',
+        tablature_parts: [
+            { instrument: 'banjo', src_file: 'banjo.otf.json',
+              author: 'schlange', default: true },
+            { instrument: 'banjo', src_file: 'banjo-18967.otf.json',
+              author: 'Devon Wells' },
+            { instrument: 'mandolin', src_file: 'mandolin.otf.json' },
+        ],
+    },
 ];
 
 const clickTabCard = () =>
@@ -88,6 +100,7 @@ describe('picker → tablature', () => {
         rows[0].click();
         expect(launchTabCreator).toHaveBeenCalledWith({
             workId: 'salt-creek', instrument: 'banjo', title: 'Salt Creek',
+            existingCount: 0,
         });
         // Launch navigates away — the modal must not be left open behind it
         expect(document.getElementById('add-song-picker').classList.contains('hidden'))
@@ -113,6 +126,7 @@ describe('picker → tablature', () => {
         document.getElementById('picker-tab-new').click();
         expect(launchTabCreator).toHaveBeenCalledWith({
             workId: null, instrument: '', title: 'Brand New Tune',
+            existingCount: 0,
         });
     });
 
@@ -121,9 +135,82 @@ describe('picker → tablature', () => {
         clickTabCard();
         expect(launchTabCreator).toHaveBeenCalledWith({
             workId: 'gold-rush', instrument: '', title: 'Gold Rush',
+            existingCount: 0,
         });
         expect(document.querySelector('.picker-tab-target').classList.contains('hidden'))
             .toBe(true);
+    });
+});
+
+// The production bug (2026-08-16): a contributor targeted
+// foggy-mountain-breakdown with a banjo tab from this very picker, spent
+// an hour in the editor, and was blocked at Submit by the server's 409 —
+// no fork path, no warning, work at risk. Contract principle 4: the
+// offramp is a choice offered EARLY. The picker already holds the answer
+// (`tablature_parts` is on the index row), so it costs nothing to say so
+// before the editor opens.
+describe('picker → tablature: the early offramp', () => {
+    beforeEach(() => {
+        launchTabCreator.mockClear();
+        setAllSongs(SONGS);
+        mountPicker();
+        initAddSongPicker({ onUpload: () => {}, onChordPro: () => {} });
+    });
+
+    const chooseFoggy = (instrument = 'banjo') => {
+        openAddSongPicker();
+        clickTabCard();
+        const search = document.getElementById('picker-tab-search');
+        search.value = 'foggy';
+        search.dispatchEvent(new Event('input'));
+        document.getElementById('picker-tab-instrument').value = instrument;
+        document.querySelector('.picker-tab-result').click();
+    };
+
+    it('says what already exists instead of opening the editor', () => {
+        chooseFoggy();
+        expect(launchTabCreator).not.toHaveBeenCalled();
+        expect(document.querySelector('.tab-existing-head').textContent)
+            .toBe('Foggy Mountain Breakdown already has 2 banjo tabs');
+    });
+
+    it('adding yours alongside proceeds exactly as before, count in hand', () => {
+        chooseFoggy();
+        document.querySelector('.tab-existing-add').click();
+        expect(launchTabCreator).toHaveBeenCalledWith({
+            workId: 'foggy-mountain-breakdown', instrument: 'banjo',
+            title: 'Foggy Mountain Breakdown', existingCount: 2,
+        });
+    });
+
+    it('does not interrupt an instrument the work has no tab for', () => {
+        chooseFoggy('guitar');
+        expect(document.querySelector('.tab-existing-panel')).toBe(null);
+        expect(launchTabCreator).toHaveBeenCalledWith({
+            workId: 'foggy-mountain-breakdown', instrument: 'guitar',
+            title: 'Foggy Mountain Breakdown', existingCount: 0,
+        });
+    });
+
+    it('with no instrument chosen, reports every tab the song has', () => {
+        chooseFoggy('');
+        expect(document.querySelector('.tab-existing-head').textContent)
+            .toBe('Foggy Mountain Breakdown already has 3 tabs');
+    });
+
+    it('Back returns to the search results it came from', () => {
+        chooseFoggy();
+        document.querySelector('.tab-existing-back').click();
+        expect(document.querySelector('.tab-existing-panel')).toBe(null);
+        expect(document.getElementById('picker-tab-results').classList.contains('hidden'))
+            .toBe(false);
+        expect(document.querySelectorAll('.picker-tab-result').length).toBe(1);
+    });
+
+    it('leaves nothing behind when the picker closes', () => {
+        chooseFoggy();
+        document.getElementById('add-song-picker-close').click();
+        expect(document.querySelector('.tab-existing-panel')).toBe(null);
     });
 });
 

--- a/docs/js/__tests__/otf-editor/create-tab-entry.test.js
+++ b/docs/js/__tests__/otf-editor/create-tab-entry.test.js
@@ -8,7 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import {
     PART_INSTRUMENTS, partInstrumentFor, presetForInstrument,
-    sanitizeInstrument, createTabHref, parseCreateTarget,
+    sanitizeInstrument, createTabHref, parseCreateTarget, targetBannerText,
     launchTabCreator, submitNewTab,
 } from '../../otf-editor/create-tab-entry.js';
 import { buildNewTab, INSTRUMENT_CHOICES } from '../../otf-editor/create-tab.js';
@@ -62,19 +62,57 @@ describe('target round trip', () => {
         const target = parseCreateTarget(href.split('?')[1]);
         expect(target).toEqual({
             workId: 'salt-creek', instrument: 'banjo', title: 'Salt Creek',
+            existingCount: 0,
         });
     });
 
     it('is the plain create page with no target', () => {
         expect(createTabHref()).toBe('create.html');
         expect(parseCreateTarget('')).toEqual(
-            { workId: null, instrument: null, title: null });
+            { workId: null, instrument: null, title: null, existingCount: 0 });
     });
 
     it('drops a work id that is not a clean slug', () => {
         expect(createTabHref({ workId: '../../evil' })).toBe('create.html');
         expect(parseCreateTarget('work=..%2F..%2Fevil&title=x').workId).toBeNull();
         expect(parseCreateTarget('work=Salt_Creek').workId).toBeNull();
+    });
+});
+
+// The create page is standalone — it never loads the search index — so
+// the sibling count travels in the URL from the entry point that already
+// counted them. It is display copy: nothing branches on it.
+describe('the target banner is honest from the first pixel', () => {
+    it('carries the existing-tab count through the round trip', () => {
+        const href = createTabHref({
+            workId: 'foggy-mountain-breakdown', instrument: 'banjo',
+            title: 'Foggy Mountain Breakdown', existingCount: 3,
+        });
+        expect(parseCreateTarget(href.split('?')[1]).existingCount).toBe(3);
+    });
+
+    it('says you are adding ALONGSIDE, with the number, before a note is entered', () => {
+        const text = targetBannerText({ instrument: 'banjo', existingCount: 3 });
+        expect(text).toContain('alongside 3 existing banjo tabs');
+        expect(text).toContain('nothing is replaced');
+    });
+
+    it('keeps the old copy when the work has no tab for this instrument', () => {
+        expect(targetBannerText({ instrument: 'banjo', existingCount: 0 }))
+            .toBe('It joins that song as a new part when it’s published.');
+        expect(targetBannerText({})).toContain('joins that song as a new part');
+    });
+
+    it('reads right for exactly one sibling', () => {
+        expect(targetBannerText({ instrument: 'guitar', existingCount: 1 }))
+            .toContain('alongside 1 existing guitar tab —');
+    });
+
+    it('refuses a count with no work behind it, or a junk one', () => {
+        expect(createTabHref({ existingCount: 5 })).toBe('create.html');
+        expect(parseCreateTarget('work=salt-creek&have=lots').existingCount).toBe(0);
+        expect(parseCreateTarget('work=salt-creek&have=-3').existingCount).toBe(0);
+        expect(parseCreateTarget('have=9').existingCount).toBe(0);
     });
 });
 

--- a/docs/js/__tests__/otf-editor/existing-tabs.test.js
+++ b/docs/js/__tests__/otf-editor/existing-tabs.test.js
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+// The early offramp: "this song already has tabs for that instrument",
+// said at the moment a work+instrument is chosen rather than at Submit.
+//
+// The bug this exists to prevent: a contributor targeted
+// foggy-mountain-breakdown with a banjo tab, arranged it, hit Submit and
+// only then met a 409 — with no fork path and no warning that the work
+// already carried banjo takes. Contract principle 4 says the offramp is a
+// choice offered EARLY, so these are the two things that must hold: the
+// existing takes are found from data already in hand, and the panel
+// offers three ways forward (view / add alongside / improve) — never a
+// refusal.
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+    partMatchesInstrument, existingTabsFor, tabPartIdFor, tabDisplayName,
+    existingTabsHeadline, tabEntryPlan, renderExistingTabsPanel,
+} from '../../otf-editor/existing-tabs.js';
+
+const FOGGY = {
+    id: 'foggy-mountain-breakdown',
+    title: 'Foggy Mountain Breakdown',
+    tablature_parts: [
+        { instrument: 'mandolin', label: 'Mandolin Break', file: 'data/tabs/f-mandolin-1.otf.json',
+          src_file: 'mandolin.otf.json', default: true },
+        { instrument: 'banjo', file: 'data/tabs/f-banjo-20690.otf.json',
+          src_file: 'banjo.otf.json', author: 'schlange', default: true },
+        { instrument: 'banjo', file: 'data/tabs/f-banjo-18967.otf.json',
+          src_file: 'banjo-18967.otf.json', author: 'Devon Wells', difficulty: 'Expert' },
+        { instrument: 'banjo', file: 'data/tabs/f-banjo-22352.otf.json',
+          src_file: 'banjo-22352.otf.json', author: 'HOWDYDOODY' },
+    ],
+};
+
+describe('instrument matching', () => {
+    it('follows the app-wide instrument families, not string equality', () => {
+        // getInstrumentTags is THE source of instrument identity: a part
+        // stored as `5-string-banjo` answers to `banjo` in search, so it
+        // must answer to `banjo` here too.
+        expect(partMatchesInstrument({ instrument: '5-string-banjo' }, 'banjo')).toBe(true);
+        expect(partMatchesInstrument({ instrument: 'upright-bass' }, 'bass')).toBe(true);
+        expect(partMatchesInstrument({ instrument: 'banjo' }, 'banjo')).toBe(true);
+        expect(partMatchesInstrument({ instrument: 'mandolin' }, 'banjo')).toBe(false);
+    });
+
+    it('with no instrument asked for, every tab counts', () => {
+        // The work page's "+ Add a tab" button doesn't ask which
+        // instrument, so the panel reports what the song has overall.
+        expect(existingTabsFor(FOGGY, '').length).toBe(4);
+        expect(existingTabsFor(FOGGY, null).length).toBe(4);
+    });
+});
+
+describe('existingTabsFor', () => {
+    it('finds the same-instrument siblings the corpus already carries', () => {
+        const tabs = existingTabsFor(FOGGY, 'banjo');
+        expect(tabs.map(t => t.src_file)).toEqual([
+            'banjo.otf.json', 'banjo-18967.otf.json', 'banjo-22352.otf.json']);
+    });
+
+    it('is empty for an instrument the work has no tab for', () => {
+        expect(existingTabsFor(FOGGY, 'dobro')).toEqual([]);
+    });
+
+    it('tolerates a row with no tabs at all', () => {
+        expect(existingTabsFor({ id: 'x' }, 'banjo')).toEqual([]);
+        expect(existingTabsFor(null, 'banjo')).toEqual([]);
+    });
+});
+
+describe('tabEntryPlan', () => {
+    it('proceeds untouched when nothing collides', () => {
+        const plan = tabEntryPlan(FOGGY, 'dobro');
+        expect(plan.kind).toBe('proceed');
+        expect(plan.count).toBe(0);
+    });
+
+    it('proceeds when there is no target work at all (a brand-new song)', () => {
+        expect(tabEntryPlan(null, 'banjo').kind).toBe('proceed');
+    });
+
+    it('reports what exists — as a choice, never a refusal', () => {
+        const plan = tabEntryPlan(FOGGY, 'banjo');
+        expect(plan.kind).toBe('existing');
+        expect(plan.count).toBe(3);
+        expect(plan.workId).toBe('foggy-mountain-breakdown');
+        expect(plan.headline).toBe('Foggy Mountain Breakdown already has 3 banjo tabs');
+        expect(plan.tabs).toHaveLength(3);
+    });
+
+    it('names the work page part the existing takes live under', () => {
+        // buildPartsFromIndex gives an instrument ONE pill, slugged from
+        // the default-first arrangement's label — #work/{id}/banjo-tab.
+        expect(tabPartIdFor(FOGGY, 'banjo')).toBe('banjo-tab');
+        expect(tabPartIdFor(FOGGY, 'mandolin')).toBe('mandolin-break');
+        expect(tabPartIdFor(FOGGY, 'dobro')).toBe(null);
+    });
+
+    it('says "tab" not "tabs" for a single existing take', () => {
+        expect(existingTabsHeadline('Salt Creek', 1, 'banjo'))
+            .toBe('Salt Creek already has 1 banjo tab');
+        expect(existingTabsHeadline('Salt Creek', 2, ''))
+            .toBe('Salt Creek already has 2 tabs');
+    });
+
+    it('labels each take by who made it', () => {
+        expect(tabDisplayName(FOGGY.tablature_parts[2]))
+            .toBe('Banjo — Devon Wells (Expert)');
+        expect(tabDisplayName({ instrument: 'banjo' })).toBe('Banjo');
+    });
+});
+
+describe('the three-choice panel', () => {
+    const build = () => {
+        const onAdd = vi.fn(), onImprove = vi.fn(), onView = vi.fn(), onBack = vi.fn();
+        const plan = tabEntryPlan(FOGGY, 'banjo');
+        const el = renderExistingTabsPanel(plan, { onAdd, onImprove, onView, onBack });
+        document.body.innerHTML = '';
+        document.body.appendChild(el);
+        return { el, plan, onAdd, onImprove, onView, onBack };
+    };
+
+    it('states the count before anything else happens', () => {
+        const { el } = build();
+        expect(el.querySelector('.tab-existing-head').textContent)
+            .toBe('Foggy Mountain Breakdown already has 3 banjo tabs');
+    });
+
+    it('lists every existing take with a way to read it', () => {
+        const { el, onView } = build();
+        const rows = el.querySelectorAll('.tab-existing-view');
+        expect(rows).toHaveLength(3);
+        rows[1].click();
+        expect(onView).toHaveBeenCalledTimes(1);
+        expect(onView.mock.calls[0][0].src_file).toBe('banjo-18967.otf.json');
+    });
+
+    it('offers "add mine as another version" — the path that used to 409', () => {
+        const { el, onAdd, plan } = build();
+        el.querySelector('.tab-existing-add').click();
+        expect(onAdd).toHaveBeenCalledWith(plan);
+    });
+
+    it('routes "improve this one" at the take that was picked', () => {
+        const { el, onImprove } = build();
+        el.querySelectorAll('.tab-existing-improve')[2].click();
+        expect(onImprove).toHaveBeenCalledTimes(1);
+        expect(onImprove.mock.calls[0][0].src_file).toBe('banjo-22352.otf.json');
+    });
+
+    it('has no Back button when the caller offers nowhere to go back to', () => {
+        const el = renderExistingTabsPanel(tabEntryPlan(FOGGY, 'banjo'), { onAdd: () => {} });
+        expect(el.querySelector('.tab-existing-back')).toBe(null);
+    });
+
+    it('escapes titles rather than interpolating them', () => {
+        const el = renderExistingTabsPanel(
+            tabEntryPlan({ id: 'x', title: '<img src=x onerror=1>',
+                tablature_parts: [{ instrument: 'banjo' }] }, 'banjo'), {});
+        expect(el.querySelector('img')).toBe(null);
+        expect(el.querySelector('.tab-existing-head').textContent)
+            .toContain('<img src=x onerror=1>');
+    });
+});

--- a/docs/js/__tests__/work-view-arrangements.test.js
+++ b/docs/js/__tests__/work-view-arrangements.test.js
@@ -186,6 +186,25 @@ describe('applyArrangement', () => {
         expect(activeArrangement(p).author).toBe('Other');
     });
 
+    it('carries src_file, the file a correction to this take must name', () => {
+        // The index publishes `file` as the flattened data/tabs/ name,
+        // which can't be mapped back to works/. Without src_file on the
+        // ACTIVE arrangement, a correction to any take but the first was
+        // submitted against `{instrument}.otf.json` — a different part.
+        const p = buildPartsFromIndex({
+            id: 'x',
+            tablature_parts: [
+                banjo({ file: 'data/tabs/x-banjo-1.otf.json',
+                        src_file: 'banjo.otf.json', default: true }),
+                banjo({ source_id: '2', file: 'data/tabs/x-banjo-2.otf.json',
+                        src_file: 'banjo-2.otf.json' }),
+            ],
+        })[0];
+        expect(p.src_file).toBe('banjo.otf.json');
+        applyArrangement(p, 1);
+        expect(p.src_file).toBe('banjo-2.otf.json');
+    });
+
     it('leaves the pill label and partId alone', () => {
         const p = part();
         applyArrangement(p, 1);

--- a/docs/js/add-song-picker.js
+++ b/docs/js/add-song-picker.js
@@ -6,6 +6,7 @@ import { songHasContent, songHasAbc } from './song-content.js';
 import { generateSlug, escapeHtml, isPlaceholder } from './utils.js';
 import { track } from './analytics.js';
 import { launchTabCreator } from './otf-editor/create-tab-entry.js';
+import { tabEntryPlan, renderExistingTabsPanel } from './otf-editor/existing-tabs.js';
 
 const SUPABASE_URL = 'https://ofmqlrnyldlmvggihogt.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9mbXFscm55bGRsbXZnZ2lob2d0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY3MTY3OTksImV4cCI6MjA4MjI5Mjc5OX0.Fm7j7Sk-gThA7inYeZecFBY52776lkJeXbpR7UKYoPE';
@@ -128,6 +129,7 @@ export function initAddSongPicker({ onUpload: uploadCb, onChordPro: chordProCb }
 }
 
 function showCards() {
+    hideExistingTabsStep();
     pickerCards?.classList.remove('hidden');
     requestForm?.classList.add('hidden');
     tabTargetPanel?.classList.add('hidden');
@@ -141,9 +143,11 @@ function showCards() {
  */
 function startTabFlow() {
     if (currentContext.targetSlug) {
-        openTabCreator(currentContext.targetSlug, currentContext.title || '');
+        openTabCreator(currentContext.targetSlug, currentContext.title || '',
+            { fromSearch: false });
         return;
     }
+    hideExistingTabsStep();
     pickerCards?.classList.add('hidden');
     requestForm?.classList.add('hidden');
     tabTargetPanel?.classList.remove('hidden');
@@ -230,11 +234,81 @@ function renderTabResults() {
     `).join('');
 }
 
-/** Hand off to the tab editor. Login is gated inside launchTabCreator. */
-function openTabCreator(workId, title) {
+/**
+ * Hand off to the tab editor. Login is gated inside launchTabCreator.
+ *
+ * Except: if the chosen work ALREADY has tabs for the chosen instrument,
+ * that gets said here — before the editor opens and before an hour of
+ * arranging — as a choice, not a refusal (contract principle 4). The data
+ * is already in hand (`tablature_parts` on the index row), so this costs
+ * no fetch. `force` is the "add mine as another version" answer coming
+ * back through the same door.
+ */
+function openTabCreator(workId, title, { force = false, fromSearch = true } = {}) {
     const instrument = tabInstrument?.value || currentContext.instrument || '';
-    const launched = launchTabCreator({ workId: workId || null, instrument, title });
+    const song = workId ? allSongs.find(s => s.id === workId) : null;
+    const plan = tabEntryPlan(song, instrument, { title });
+
+    if (!force && plan.kind === 'existing') {
+        showExistingTabsStep(plan, { fromSearch });
+        return;
+    }
+    const launched = launchTabCreator({
+        workId: workId || null, instrument, title,
+        existingCount: plan.count,
+    });
     if (launched) closeAddSongPicker();
+}
+
+/** The tab-target step's sub-panel showing what's already published. */
+let existingTabsStep = null;
+
+function hideExistingTabsStep() {
+    existingTabsStep?.remove();
+    existingTabsStep = null;
+    tabTargetPanel?.querySelectorAll('.picker-tab-choose')
+        .forEach(el => el.classList.remove('hidden'));
+}
+
+function showExistingTabsStep(plan, { fromSearch = true } = {}) {
+    hideExistingTabsStep();
+    if (!tabTargetPanel) return;
+
+    pickerCards?.classList.add('hidden');
+    requestForm?.classList.add('hidden');
+    tabTargetPanel.classList.remove('hidden');
+
+    // Park the search step rather than destroy it — Back must return to
+    // the results the contributor just came from. (In contribute mode the
+    // work was already known and no search happened, so Back goes home.)
+    for (const el of tabTargetPanel.children) el.classList.add('picker-tab-choose');
+    tabTargetPanel.querySelectorAll('.picker-tab-choose')
+        .forEach(el => el.classList.add('hidden'));
+
+    existingTabsStep = renderExistingTabsPanel(plan, {
+        onAdd: () => openTabCreator(plan.workId, plan.title, { force: true }),
+        onView: (tab) => openWorkPart(plan, tab, { edit: false }),
+        onImprove: (tab) => openWorkPart(plan, tab, { edit: true }),
+        onBack: fromSearch ? hideExistingTabsStep : showCards,
+    });
+    tabTargetPanel.appendChild(existingTabsStep);
+    if (headerTitle) headerTitle.textContent = 'This song already has tabs';
+}
+
+/**
+ * Leave the picker for the work page's tab part — to read it, or to edit
+ * it (the existing tab-correction path: work-view mounts the OTF editor
+ * over the rendered tab and submits a `tab-correction`).
+ *
+ * work-view imports this module, so the import is dynamic to keep the
+ * cycle out of module-evaluation order; by the time anyone clicks, the
+ * SPA has long since loaded it.
+ */
+async function openWorkPart(plan, tab, { edit }) {
+    closeAddSongPicker();
+    const view = await import('./work-view.js');
+    if (edit) view.requestTabEdit(plan.workId, tab.file);
+    view.openWork(plan.workId, { partId: plan.partId || undefined });
 }
 
 function showRequestForm() {
@@ -507,6 +581,7 @@ export function openAddSongPicker(options = {}) {
 export function closeAddSongPicker() {
     pickerModal?.classList.add('hidden');
     // Reset to cards view for next open
+    hideExistingTabsStep();
     pickerCards?.classList.remove('hidden');
     requestForm?.classList.add('hidden');
     tabTargetPanel?.classList.add('hidden');

--- a/docs/js/add-song-picker.js
+++ b/docs/js/add-song-picker.js
@@ -267,7 +267,7 @@ function hideExistingTabsStep() {
     existingTabsStep?.remove();
     existingTabsStep = null;
     tabTargetPanel?.querySelectorAll('.picker-tab-choose')
-        .forEach(el => el.classList.remove('hidden'));
+        .forEach(el => el.classList.remove('hidden', 'picker-tab-choose'));
 }
 
 function showExistingTabsStep(plan, { fromSearch = true } = {}) {

--- a/docs/js/otf-editor/create-tab-entry.js
+++ b/docs/js/otf-editor/create-tab-entry.js
@@ -84,9 +84,22 @@ export function presetForInstrument(instrument) {
     return TARGET_PRESETS[sanitizeInstrument(instrument)] || '5-string-banjo';
 }
 
+/** Clamp a "tabs already published for this instrument" count, or 0. */
+function sanitizeCount(value) {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? Math.min(Math.floor(n), 999) : 0;
+}
+
 /**
  * Build the create-page URL for a (possibly targeted) new tab.
  * No target → the plain "start a tab from scratch" page.
+ *
+ * `existingCount` rides along so the create page can be honest from the
+ * first pixel ("adding your version alongside 8 existing banjo tabs")
+ * without loading the search index: create.html is a standalone page, and
+ * the entry points that send you here have already counted the siblings
+ * client-side. It is display copy only — nothing branches on it, so a
+ * stale or hand-edited number costs a wrong noun, never a wrong write.
  */
 export function createTabHref(target = {}, base = 'create.html') {
     const params = new URLSearchParams();
@@ -96,6 +109,8 @@ export function createTabHref(target = {}, base = 'create.html') {
     const instrument = sanitizeInstrument(target.instrument);
     if (instrument) params.set('instrument', instrument);
     if (target.title) params.set('title', String(target.title).slice(0, 200));
+    const existing = workId ? sanitizeCount(target.existingCount) : 0;
+    if (existing) params.set('have', String(existing));
     const query = params.toString();
     return query ? `${base}?${query}` : base;
 }
@@ -112,11 +127,31 @@ export function parseCreateTarget(search) {
         typeof search === 'string' ? search : (search || ''));
     const rawWork = params.get('work') || '';
     const title = (params.get('title') || '').trim().slice(0, 200);
+    const workId = SLUG_RE.test(rawWork) ? rawWork : null;
     return {
-        workId: SLUG_RE.test(rawWork) ? rawWork : null,
+        workId,
         instrument: sanitizeInstrument(params.get('instrument')) || null,
         title: title || null,
+        existingCount: workId ? sanitizeCount(params.get('have')) : 0,
     };
+}
+
+/**
+ * The target banner's sentence.
+ *
+ * When siblings already exist the banner says so BEFORE a note is
+ * entered — "adding your version alongside 8 existing banjo tabs". The
+ * old copy promised "It joins that song as a new part", which was true
+ * only until the server's 409; both halves of that lie are gone (the
+ * server now lands siblings additively, and the count is stated up front).
+ */
+export function targetBannerText(target = {}) {
+    const count = sanitizeCount(target.existingCount);
+    if (!count) return 'It joins that song as a new part when it’s published.';
+    const kind = target.instrument ? `${target.instrument} ` : '';
+    return `You’re adding your version alongside ${count} existing ${kind}`
+        + `tab${count === 1 ? '' : 's'} — takes live side by side, nothing is `
+        + 'replaced.';
 }
 
 /** Default login gate — the same three lines as utils.requireLogin. */

--- a/docs/js/otf-editor/existing-tabs.js
+++ b/docs/js/otf-editor/existing-tabs.js
@@ -1,0 +1,145 @@
+// "This song already has tabs for that instrument" — said BEFORE the
+// editor opens, not after the work is done.
+//
+// Contract principle 4: the offramp is a CHOICE OFFERED EARLY, never a
+// rejection discovered later. Until now a contributor could target
+// foggy-mountain-breakdown with a banjo tab, spend an hour arranging it,
+// hit Submit, and only then meet a 409 from create-tab-pr. The corpus has
+// carried same-instrument siblings for months (foggy alone has eight banjo
+// takes), so "already exists" was never a reason to refuse — only a reason
+// to ask which of three things the contributor meant:
+//
+//   (a) look at what's there,
+//   (b) add theirs alongside as another version, or
+//   (c) improve one of the existing tabs (the tab-correction path).
+//
+// This module is the shared, mostly-pure middle: given an index row and an
+// instrument it answers "what's already here?", and it builds the one panel
+// that both the add-song picker and the work page show. No state, no
+// fetches — `tablature_parts` is already on every index row.
+
+import { getInstrumentTags } from '../tags.js';
+import { escapeHtml, slugify, tabLabel } from '../utils.js';
+
+/**
+ * Does an existing tablature part count as "a tab for this instrument"?
+ *
+ * Instrument families come from getInstrumentTags — THE source of
+ * instrument identity everywhere else in the app (`tag:banjo` search, the
+ * Instrument facet, the result-card badges). A part stored as
+ * `5-string-banjo` answers to `banjo` there, so it answers to `banjo`
+ * here; anything else would tell a contributor that a banjo tab doesn't
+ * exist while search says it does.
+ */
+export function partMatchesInstrument(part, instrument) {
+    if (!instrument) return true;             // no instrument asked → all tabs count
+    const want = String(instrument).toLowerCase();
+    return getInstrumentTags({ tablature_parts: [part] }).includes(want);
+}
+
+/**
+ * The tabs a work already has for an instrument (all of them when the
+ * instrument is unknown — the "+ Add a tab" button doesn't ask first).
+ */
+export function existingTabsFor(song, instrument) {
+    return (song?.tablature_parts || [])
+        .filter(part => partMatchesInstrument(part, instrument));
+}
+
+/**
+ * The `#work/{id}/{partId}` segment the work page will give this
+ * instrument's tab pill. Mirrors buildPartsFromIndex: one pill per
+ * instrument, labelled by the default-first arrangement's own label.
+ */
+export function tabPartIdFor(song, instrument) {
+    const tabs = existingTabsFor(song, instrument);
+    if (!tabs.length) return null;
+    const primary = tabs.find(t => t.default === true) || tabs[0];
+    return slugify(primary.label || tabLabel(primary.instrument)) || null;
+}
+
+/** How one existing take reads in the list: "Banjo — schlange (Expert)". */
+export function tabDisplayName(part) {
+    const bits = [tabLabel(part?.instrument).replace(/ Tab$/, '')];
+    if (part?.author) bits.push(part.author);
+    const name = bits.filter(Boolean).join(' — ');
+    return part?.difficulty ? `${name} (${part.difficulty})` : name;
+}
+
+/**
+ * Headline for the panel: what's there, in the contributor's words —
+ * "Foggy Mountain Breakdown already has 8 banjo tabs".
+ */
+export function existingTabsHeadline(title, count, instrument) {
+    const kind = instrument ? `${instrument} ` : '';
+    return `${title || 'This song'} already has ${count} ${kind}tab${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * The whole entry-time decision, as data.
+ *
+ * `proceed` means nothing is in the way — the caller opens the editor
+ * exactly as before. `existing` means show the panel and let the
+ * contributor choose; it is never a refusal, and choice (b) leads to the
+ * same editor with the same target.
+ */
+export function tabEntryPlan(song, instrument, { title = null } = {}) {
+    const tabs = song ? existingTabsFor(song, instrument) : [];
+    if (!tabs.length) return { kind: 'proceed', tabs: [], count: 0 };
+    return {
+        kind: 'existing',
+        workId: song.id,
+        title: title || song.title || song.id,
+        instrument: instrument || '',
+        tabs,
+        count: tabs.length,
+        partId: tabPartIdFor(song, instrument),
+        headline: existingTabsHeadline(title || song.title || song.id,
+            tabs.length, instrument),
+    };
+}
+
+/**
+ * Build the three-choice panel.
+ *
+ * Callers supply the routing, because "view" and "improve" mean different
+ * navigation on the work page (already there) than in the picker (has to
+ * get there first). Returns a detached element — the caller decides where
+ * it lands.
+ */
+export function renderExistingTabsPanel(plan, {
+    onAdd, onImprove, onView, onBack = null,
+    addLabel = 'Add mine as another version',
+} = {}) {
+    const panel = document.createElement('div');
+    panel.className = 'tab-existing-panel';
+    panel.innerHTML = `
+        <div class="tab-existing-head">${escapeHtml(plan.headline)}</div>
+        <p class="tab-existing-sub">Nothing is in your way — takes live side by side,
+            and readers pick between them. Have a look first, add yours alongside,
+            or improve one that's already here.</p>
+        <ul class="tab-existing-list">
+            ${plan.tabs.map((tab, i) => `
+                <li class="tab-existing-item">
+                    <button type="button" class="tab-existing-view" data-idx="${i}"
+                        >${escapeHtml(tabDisplayName(tab))}</button>
+                    <button type="button" class="tab-existing-improve" data-idx="${i}"
+                        >Improve this one</button>
+                </li>`).join('')}
+        </ul>
+        <div class="tab-existing-actions">
+            <button type="button" class="tab-existing-add">${escapeHtml(addLabel)}</button>
+            ${onBack ? '<button type="button" class="tab-existing-back">Back</button>' : ''}
+        </div>`;
+
+    const tabAt = (btn) => plan.tabs[Number(btn.dataset.idx)];
+    panel.querySelectorAll('.tab-existing-view').forEach(btn =>
+        btn.addEventListener('click', () => onView?.(tabAt(btn), plan)));
+    panel.querySelectorAll('.tab-existing-improve').forEach(btn =>
+        btn.addEventListener('click', () => onImprove?.(tabAt(btn), plan)));
+    panel.querySelector('.tab-existing-add')
+        ?.addEventListener('click', () => onAdd?.(plan));
+    panel.querySelector('.tab-existing-back')
+        ?.addEventListener('click', () => onBack?.(plan));
+    return panel;
+}

--- a/docs/js/otf-editor/submit-tab.js
+++ b/docs/js/otf-editor/submit-tab.js
@@ -50,14 +50,18 @@ export async function accessToken() {
  * @param {'tab-correction'|'tab-submission'} p.type
  * @param {Object} p.otf - the document (serialized internally)
  * @param {string} p.title
- * @param {string} p.instrument - part instrument (correction target file)
+ * @param {string} p.instrument - part instrument
+ * @param {string} [p.file] - the works/ filename this correction targets
+ *   (a work can carry several arrangements per instrument; the instrument
+ *   alone names the wrong one for all but the first). Ignored for
+ *   submissions, which get their own name server-side.
  * @param {string} [p.workId] - required for corrections
  * @param {string} [p.comment] - required for corrections
  * @param {Function} [fetchImpl] - injectable for tests
  * @returns {Promise<{prNumber: number, prUrl: string}>}
  */
 export async function submitTab(
-    { type, otf, title, instrument, workId, comment },
+    { type, otf, title, instrument, file, workId, comment },
     fetchImpl = globalThis.fetch,
 ) {
     const token = await accessToken();
@@ -69,6 +73,7 @@ export async function submitTab(
         type,
         title,
         instrument,
+        ...(file ? { file } : {}),
         workId,
         comment,
         otf: serializeForSubmission(otf),

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -110,6 +110,21 @@ export function isTabOnlyWork(song) {
 }
 
 /**
+ * "banjo" -> "Banjo Tab", "tenor-banjo" -> "Tenor Banjo Tab".
+ *
+ * Lives here (not in work-view.js, which owns the page) because the part
+ * label is also the part's URL slug — `slugify(tabLabel(instrument))` is
+ * the `#work/{id}/{partId}` segment — and the contribution entry points
+ * need to name and link a tab without importing the whole song page.
+ */
+export function tabLabel(instrument) {
+    if (!instrument) return 'Tab';
+    const pretty = String(instrument).split('-')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    return `${pretty} Tab`;
+}
+
+/**
  * Whether the page-level song actions (the header ✏️ Edit button) apply
  * to the given part. They edit chordpro lead sheets; on a tablature part
  * they would open an empty song editor, so views hide them — tab parts

--- a/docs/js/work-view.js
+++ b/docs/js/work-view.js
@@ -37,9 +37,10 @@ import {
     getArrangementContent, peekArrangementContent,
 } from './song-content.js';
 import { CHROMATIC_MAJOR_KEYS } from './chords.js';
-import { escapeHtml, partUsesSongActions, isPlaceholder, requireLogin, slugify } from './utils.js';
+import { escapeHtml, partUsesSongActions, isPlaceholder, requireLogin, slugify, tabLabel } from './utils.js';
 import { openAddSongPicker } from './add-song-picker.js';
 import { launchTabCreator } from './otf-editor/create-tab-entry.js';
+import { tabEntryPlan, renderExistingTabsPanel } from './otf-editor/existing-tabs.js';
 import {
     TabRenderer, TabPlayer,
     TimelineTiming, identityTimeline, readingListTimeline,
@@ -74,6 +75,7 @@ let tempoOverride = null;        // { workId, quarterBpm } — user-set tempo;
 let activeTrackView = null;      // track id, 'all', or null (= lead track)
 let workViewEscHandler = null;   // Esc-to-disarm listener (single live copy)
 let activeEditSession = null;    // live tab edit session (torn down on nav)
+let pendingTabEdit = null;       // parked "open this tab in the editor" ask
 
 /**
  * Tear down everything the tablature view holds live handles to: the
@@ -203,19 +205,6 @@ function buildOtfTimings(otf, compact) {
 // WORK LOADING
 // ============================================
 
-/**
- * Build the parts list from index data.
- * Each part gets a unique `partId` slug derived from its label,
- * used in URLs (#work/{id}/{partId}) and list references.
- */
-/** "banjo" -> "Banjo Tab", "tenor-banjo" -> "Tenor Banjo Tab" */
-function tabLabel(instrument) {
-    if (!instrument) return 'Tab';
-    const pretty = instrument.split('-')
-        .map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
-    return `${pretty} Tab`;
-}
-
 /** "banjo-hangout" -> "Banjo Hangout" (source ids are slugs) */
 function prettySource(source) {
     if (!source) return '';
@@ -231,8 +220,8 @@ function prettySource(source) {
 // partId, which is a URL) belongs to the instrument and must not move when
 // the reader switches takes.
 const ARRANGEMENT_FIELDS = [
-    'file', 'source', 'source_id', 'author', 'source_page_url', 'author_url',
-    'difficulty', 'tuning',
+    'file', 'src_file', 'source', 'source_id', 'author', 'source_page_url',
+    'author_url', 'difficulty', 'tuning',
 ];
 
 /**
@@ -271,6 +260,10 @@ function applyArrangement(part, index) {
 }
 
 /**
+ * Build the parts list from index data. Each part gets a unique `partId`
+ * slug derived from its label, used in URLs (#work/{id}/{partId}) and
+ * list references.
+ *
  * @param {object} song  index row
  * @param {string|null} content  ChordPro if we already have it; null means
  *   "fetch on render" (the part is still built — has_content says it exists)
@@ -387,6 +380,10 @@ function showWorkLoading() {
  */
 export async function openWork(workId, options = {}) {
     workId = resolveWorkId(workId);
+
+    // An edit intent belongs to the work it was filed for; navigating
+    // anywhere else drops it rather than leaving it armed.
+    if (pendingTabEdit && pendingTabEdit.workId !== workId) pendingTabEdit = null;
 
     let song = allSongs.find(s => s.id === workId);
 
@@ -1543,11 +1540,7 @@ function renderBountySection() {
         btn.addEventListener('click', () => {
             const card = btn.closest('.work-bounty-card');
             if (card?.dataset.bountyType === 'tablature') {
-                launchTabCreator({           // gates on login itself
-                    workId: currentWork.id,
-                    instrument: card.dataset.bountyInstrument || '',
-                    title: currentWork.title,
-                });
+                startTabContribution(section, card.dataset.bountyInstrument || '');
                 return;
             }
             if (!requireLogin('contribute')) return;
@@ -1563,7 +1556,7 @@ function renderBountySection() {
 
     // Add a tab, unprompted — no bounty needed
     section.querySelector('#work-bounty-add-tab-btn')?.addEventListener('click', () => {
-        launchTabCreator({ workId: currentWork.id, title: currentWork.title });
+        startTabContribution(section, '');
     });
 
     // Wire request button
@@ -1573,6 +1566,81 @@ function renderBountySection() {
     });
 
     return section;
+}
+
+/**
+ * "Add a tab" / a tablature bounty's Contribute — with the offramp FIRST.
+ *
+ * If this work already has tabs for the instrument, the choice is offered
+ * here, on the page the contributor is already looking at: read one, add
+ * theirs alongside, or improve one. Only when there's nothing to collide
+ * with does the click go straight to the editor as before. This is
+ * contract principle 4 — the offramp is a choice offered early, never a
+ * 409 discovered after the work is done.
+ */
+function startTabContribution(section, instrument) {
+    if (!currentWork) return;
+    const plan = tabEntryPlan(currentWork, instrument, { title: currentWork.title });
+
+    if (plan.kind !== 'existing') {
+        launchTabCreator({           // gates on login itself
+            workId: currentWork.id, instrument, title: currentWork.title,
+        });
+        return;
+    }
+
+    const body = section.querySelector('#work-bounty-body');
+    if (!body) return;
+    body.querySelector('.tab-existing-panel')?.remove();
+    body.appendChild(renderExistingTabsPanel(plan, {
+        onAdd: () => launchTabCreator({
+            workId: currentWork.id, instrument, title: currentWork.title,
+            existingCount: plan.count,
+        }),
+        onView: (tab) => openTabPart(tab.file, { edit: false }),
+        onImprove: (tab) => openTabPart(tab.file, { edit: true }),
+        onBack: () => body.querySelector('.tab-existing-panel')?.remove(),
+    }));
+}
+
+/**
+ * A tab the reader asked for by file: select its instrument's part, point
+ * that part at this arrangement, and (for "improve") drop straight into
+ * the existing tab-correction editor once it renders.
+ *
+ * The edit intent is parked rather than executed because the OTF has to
+ * be fetched first — renderTablaturePart honors it at the end of a
+ * successful render, which is also the only place the document exists.
+ */
+function openTabPart(file, { edit = false } = {}) {
+    const part = availableParts.find(p => p.type === 'tablature' &&
+        (p.arrangements || []).some(a => a.file === file));
+    if (!part) return false;
+
+    if (edit) pendingTabEdit = { workId: currentWork?.id, file };
+
+    if (part !== activePart) {
+        selectPart(part);   // renders the part (and applies the intent)
+        return true;
+    }
+    // Already the active part: re-render it on the requested arrangement.
+    const idx = part.arrangements.findIndex(a => a.file === file);
+    applyArrangement(part, idx);
+    const content = document.getElementById('work-part-content');
+    if (content) {
+        content.innerHTML = '';
+        renderTablaturePart(part, content);
+    }
+    return true;
+}
+
+/**
+ * Ask the work page to open a specific tab file in edit mode. Used by the
+ * add-song picker's "Improve an existing tab" choice, which has to
+ * navigate to the work page before the editor can mount over the tab.
+ */
+export function requestTabEdit(workId, file) {
+    pendingTabEdit = workId && file ? { workId, file } : null;
 }
 
 /**
@@ -1830,6 +1898,15 @@ function renderDocumentPart(part, container) {
 async function renderTablaturePart(part, container) {
     container.innerHTML = '<div class="loading">Loading tablature...</div>';
 
+    // A parked "improve this tab" intent (from the picker's early offramp,
+    // or from this page's own panel) names an arrangement by file — point
+    // the part at it before anything is fetched.
+    if (pendingTabEdit && pendingTabEdit.workId === currentWork?.id) {
+        const idx = (part.arrangements || [])
+            .findIndex(a => a.file === pendingTabEdit.file);
+        if (idx >= 0) applyArrangement(part, idx);
+    }
+
     try {
         // Load OTF data. cache: 'no-cache' = revalidate with the server
         // (304 if unchanged) — Chrome's heuristic freshness otherwise
@@ -2062,6 +2139,14 @@ async function renderTablaturePart(part, container) {
             container.appendChild(attribution);
         }
 
+        // The parked "improve this one" intent: the document only exists
+        // here, so this is the one place the editor can be handed it.
+        if (pendingTabEdit && pendingTabEdit.workId === currentWork?.id &&
+            pendingTabEdit.file === part.file) {
+            pendingTabEdit = null;
+            enterTabEditMode(otf, part, container);
+        }
+
     } catch (e) {
         console.error('Error loading tablature:', e);
         container.innerHTML = `<div class="error">Failed to load tablature: ${escapeHtml(e.message)}</div>`;
@@ -2125,6 +2210,10 @@ async function enterTabEditMode(otf, part, container) {
                 otf: doc,
                 title: currentWork?.title || doc.metadata?.title || 'Untitled',
                 instrument: part.instrument || 'banjo',
+                // WHICH take is being corrected. A work can carry several
+                // arrangements per instrument, so the instrument alone
+                // names the wrong file for every one but the first.
+                file: part.src_file || undefined,
                 workId: currentWork?.id,
                 comment,
             });

--- a/docs/plans/contribution-pipeline.md
+++ b/docs/plans/contribution-pipeline.md
@@ -365,7 +365,24 @@ rather than overwrite a published tab of that instrument); the client sent
 the editor's PRESET name (`5-string-banjo`, and `tenor_banjo` — which the
 server's own `[a-z0-9-]` check rejects) where the corpus wants `banjo`;
 and `process_tab.py` stamped `x_corrected_*` on a part that had never been
-published. It does NOT move tabs onto the `pending_songs` pipeline — see
+published.
+
+*Corrected, 2026-08-16 — that 409 was a principle-4 violation and is
+gone.* The offramp now happens at ENTRY: the picker's result selection,
+"+ Add a tab" and a tablature bounty's Contribute all check the target
+work's `tablature_parts` client-side and, when the instrument is already
+covered, offer view / add-alongside / improve-an-existing-tab before the
+editor opens — with the sibling count repeated in `create.html`'s target
+banner. Server-side, a same-instrument submission is no longer refused
+but uniquified (`{instrument}-{base36 stamp+rand}.otf.json`, unique across
+concurrent branches in a way `works_writer._unique_filename`'s `-2`
+counter is not) and added as a NEW part, which is what the corpus has
+always modelled — `process_tab.py` now keys correction-vs-new-part on the
+FILE rather than the instrument, and stamps `source_id: pr-{n}` so
+siblings satisfy the schema. Two related holes closed on the way: index
+rows publish `src_file` and corrections name it, so fixing take #3 no
+longer writes over take #1. It does NOT move tabs onto the
+`pending_songs` pipeline — see
 the resolved deviation under 2b for why, and for the review-gate exception
 that leaves standing. Supersedes the new-tab half of #180; `create.html`
 is now reachable from the site, which was #180's last checklist item.

--- a/scripts/lib/build_works_index.py
+++ b/scripts/lib/build_works_index.py
@@ -704,9 +704,13 @@ def build_song_from_work(work_dir: Path) -> dict:
                 'source': prov.get('source'),
                 'source_id': prov.get('source_id'),
                 'author': prov.get('author'),
-                # Where the OTF lives inside works/ — used by the copy step,
-                # stripped before the index is written.
-                '_src': part.get('file'),
+                # Where the OTF lives inside works/. Used by the copy step,
+                # and PUBLISHED: a tab correction has to name the file it
+                # corrects, and the published name (which folds in the
+                # source_id) can't be mapped back to it. Without this a
+                # correction to any arrangement but the first landed on
+                # `{instrument}.otf.json` — a different part.
+                'src_file': part.get('file'),
             }
             # Arrangement-picker detail, when the listing had it
             if prov.get('difficulty'):
@@ -1069,10 +1073,10 @@ def build_works_index(works_dir: Path, output_file: Path, enrich_tags: bool = Tr
     published_tabs = set()
     for song in songs:
         for tab_part in song.get('tablature_parts', []):
-            # `_src` is the part's file inside works/ ({instrument}.otf.json for
-            # the first arrangement, {instrument}-{source_id}.otf.json for the
-            # alternates); it never reaches the index.
-            src_name = tab_part.pop('_src', None)
+            # `src_file` is the part's file inside works/
+            # ({instrument}.otf.json for the first arrangement,
+            # {instrument}-{source_id}.otf.json for the alternates).
+            src_name = tab_part.get('src_file')
             # dest is data/tabs/{work}-{instrument}-{source_id}.otf.json
             dest_path = Path('docs') / tab_part['file']
             work_id = song['id']

--- a/scripts/lib/process_tab.py
+++ b/scripts/lib/process_tab.py
@@ -70,6 +70,25 @@ def validate_otf(otf) -> list:
     return problems
 
 
+def part_instrument(otf_path: Path, declared) -> str:
+    """The corpus instrument this OTF file publishes as.
+
+    Historically read straight off the filename, which worked while every
+    tab was `works/<slug>/<instrument>.otf.json`. Same-instrument siblings
+    break that: `banjo-mfa3k2px9.otf.json` is a banjo tab, not a
+    "banjo-mfa3k2px9" one. The PR body's declared instrument is
+    authoritative when the filename is that instrument's — the edge
+    function validates it against the same [a-z0-9-] rule — and the
+    filename stem remains the fallback for hand-opened PRs.
+    """
+    stem = otf_path.name[:-len('.otf.json')] if otf_path.name.endswith('.otf.json') \
+        else otf_path.stem
+    if declared and re.fullmatch(r'[a-z0-9-]+', declared):
+        if stem == declared or stem.startswith(f'{declared}-'):
+            return declared
+    return stem
+
+
 def finalize_tab_file(otf_path: Path, meta: dict) -> Path:
     """Validate one changed OTF and make its work.yaml tell the story.
 
@@ -89,22 +108,37 @@ def finalize_tab_file(otf_path: Path, meta: dict) -> Path:
     work_dir = otf_path.parent
     work_id = work_dir.name
     repo_root = work_dir.parent.parent
-    instrument = otf_path.name.replace('.otf.json', '')
+    instrument = part_instrument(otf_path, meta.get('instrument'))
     work_yaml = work_dir / 'work.yaml'
     pr_number = meta.get('pr_number')
     issue_ref = int(pr_number) if str(pr_number).isdigit() else pr_number
 
     # Three shapes reach here, and only the middle one is a correction:
     #   - no work.yaml            → a submission that mints its own work
-    #   - work.yaml, no such part → a NEW tab for an existing song (the
-    #                               bounty case): append the part, and
-    #                               stamp it as a submission, not a fix
-    #   - work.yaml with the part → a correction to published content
+    #   - work.yaml, no such FILE → a NEW tab for an existing song: either
+    #                               an instrument it lacked (the bounty
+    #                               case) or another take on one it has
+    #                               (a sibling arrangement). Append the
+    #                               part; stamp it as a submission.
+    #   - work.yaml with the FILE → a correction to published content
+    #
+    # Keyed on the FILE, not the instrument. A work can carry several
+    # arrangements per instrument (foggy-mountain-breakdown has eight
+    # banjo takes), so "this work already has a banjo part" says nothing
+    # about whether THIS file is new — and treating an incoming sibling as
+    # a correction would repoint an existing part at it, orphaning the
+    # take it used to name.
     work = works_writer.load_work(repo_root, work_id) if work_yaml.exists() else None
     is_correction = bool(work and works_writer.find_parts(
-        work, {'type': 'tablature', 'instrument': instrument}))
+        work, {'type': 'tablature', 'file': otf_path.name}))
     submission_provenance = {
         'source': 'user-submission',
+        # What makes THIS take distinguishable from the work's other takes
+        # on the same instrument: work_schema requires every alternate
+        # tablature arrangement to carry a source_id, and build_works_index
+        # folds it into the published filename. The submission PR is the
+        # only stable id a user-submitted tab has.
+        'source_id': f'pr-{issue_ref}' if pr_number else None,
         'author': meta.get('attribution'),
         'submission_pr': issue_ref,
         'imported_at': str(date.today()),
@@ -116,11 +150,12 @@ def finalize_tab_file(otf_path: Path, meta: dict) -> Path:
         if work_yaml.exists() and not is_correction:
             # New part on an existing work: no x_corrected_* stamps — this
             # content was never published, so there is nothing it corrects.
-            works_writer.update_part(
+            # add_part APPENDS and refuses a genuine identity collision;
+            # it never reads-modifies-writes what's already there, so the
+            # existing takes keep their files, defaults and provenance.
+            works_writer.add_part(
                 repo_root, work_id,
-                match={'type': 'tablature', 'instrument': instrument},
-                file=otf_path.name,
-                add_if_missing=works_writer.PartSpec(
+                works_writer.PartSpec(
                     file=otf_path.name,
                     type='tablature',
                     format='otf',
@@ -133,8 +168,7 @@ def finalize_tab_file(otf_path: Path, meta: dict) -> Path:
             # Correction: record provenance on the matching part
             works_writer.update_part(
                 repo_root, work_id,
-                match={'type': 'tablature', 'instrument': instrument},
-                file=otf_path.name,
+                match={'type': 'tablature', 'file': otf_path.name},
                 provenance_updates={
                     'x_corrected_by': (f"github:{meta.get('pr_author')}"
                                        if meta.get('pr_author')
@@ -156,12 +190,7 @@ def finalize_tab_file(otf_path: Path, meta: dict) -> Path:
                     format='otf',
                     instrument=instrument,
                     default=True,
-                    provenance={
-                        'source': 'user-submission',
-                        'author': meta.get('attribution'),
-                        'submission_pr': issue_ref,
-                        'imported_at': str(date.today()),
-                    },
+                    provenance=dict(submission_provenance),
                 ),
                 tags=['Instrumental'],
                 on_collision='fail',
@@ -178,6 +207,10 @@ def process_changed(changed: list, body: str, pr_number: str, pr_author: str,
     """Process every changed works/*.otf.json. Returns the work dirs."""
     meta = {
         'title': extract_field(body, 'Title'),
+        # The corpus instrument name, declared by create-tab-pr. Needed
+        # because a sibling arrangement's filename carries a uniquifying
+        # suffix the instrument name doesn't.
+        'instrument': extract_field(body, 'Instrument'),
         # PR bodies always carry a verified submitter now (identity is
         # derived server-side in create-tab-pr); this fallback only covers
         # hand-opened PRs.

--- a/supabase/functions/create-tab-pr/index.ts
+++ b/supabase/functions/create-tab-pr/index.ts
@@ -39,10 +39,14 @@ interface TabPrRequest {
   type: 'tab-correction' | 'tab-submission'
   title: string
   workId?: string      // Required for corrections
-  instrument: string   // e.g. 'banjo' — becomes <instrument>.otf.json
+  instrument: string   // e.g. 'banjo' — names the part, and its file
+  file?: string        // Correction only: which arrangement's file to replace
   otf: string          // serialized OTF JSON
   comment?: string     // Required for corrections
 }
+
+// A part filename inside works/<slug>/ — never a path.
+const OTF_FILE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\.otf\.json$/
 
 function bad(status: number, error: string) {
   return new Response(JSON.stringify({ error }),
@@ -53,6 +57,24 @@ function slugify(text: string): string {
   return text.normalize('NFKD').replace(/[̀-ͯ]/g, '')
     .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
     .replace(/-+/g, '-') || 'untitled'
+}
+
+/**
+ * A collision-safe suffix for a sibling tab's filename.
+ *
+ * works_writer._unique_filename picks `banjo-2.otf.json` by counting what's
+ * already on disk, which is right for a local writer but not here: two
+ * submissions open two BRANCHES, and neither can see the other's file on
+ * main, so both would pick `-2` and the second merge would land on top of
+ * the first. A timestamp plus randomness is unique across branches by
+ * construction, and it echoes the corpus's own `{instrument}-{id}` sibling
+ * naming (banjo-18967.otf.json) rather than inventing a shape.
+ */
+function siblingSuffix(stamp: number): string {
+  const rand = new Uint8Array(2)
+  crypto.getRandomValues(rand)
+  return stamp.toString(36) +
+    Array.from(rand, b => (b % 36).toString(36)).join('')
 }
 
 serve(async (req) => {
@@ -90,7 +112,7 @@ serve(async (req) => {
       })
 
     const body: TabPrRequest = await req.json()
-    const { type, title, workId, instrument, otf, comment } = body
+    const { type, title, workId, instrument, file, otf, comment } = body
 
     if (type !== 'tab-correction' && type !== 'tab-submission') {
       return bad(400, 'Bad type')
@@ -109,6 +131,10 @@ serve(async (req) => {
     // and branch name, so nothing outside [a-z0-9-] may ever reach it.
     if (workId !== undefined && !/^[a-z0-9-]+$/.test(workId)) {
       return bad(400, 'Bad work id')
+    }
+    // Same rule for the correction target: it becomes a repo path.
+    if (file !== undefined && (typeof file !== 'string' || !OTF_FILE_RE.test(file))) {
+      return bad(400, 'Bad file name')
     }
     if (type === 'tab-correction' && (!workId || !comment)) {
       return bad(400, 'Tab corrections require workId and comment')
@@ -143,24 +169,46 @@ serve(async (req) => {
         targetWorkId = `${base}-${i + 1}`
       }
     }
-    const filePath = `works/${targetWorkId}/${instrument}.otf.json`
+    // Corrections name the arrangement they fix; a work can carry several
+    // per instrument, so `{instrument}.otf.json` is the right guess only
+    // for the first one (and only for legacy clients that send no file).
+    let fileName = (type === 'tab-correction' && file) ? file
+      : `${instrument}.otf.json`
 
-    // A submission must never quietly overwrite a tab that's already
-    // published for that instrument — replacing existing content is a
-    // CORRECTION, and that path requires a comment describing the change.
+    // A song that already has a tab for this instrument gets ANOTHER one,
+    // not a refusal.
+    //
+    // This used to 409 ("open it and use Edit to submit a correction"),
+    // which was a late block — the contributor had already arranged the
+    // whole tab — and it foreclosed something the corpus has always
+    // supported: same-instrument siblings as separate arrangements
+    // (foggy-mountain-breakdown carries eight banjo takes, and the
+    // frontend renders them as selectable arrangements). So the incoming
+    // file is given its own name and added as a NEW part; nothing that is
+    // already published is read, moved, or written. What we still refuse
+    // is a true overwrite — same file, same content path — which the
+    // uniquified name makes unreachable.
+    const stamp = Date.now()
     if (type === 'tab-submission' && workId) {
-      const clash = await gh(`/contents/${filePath}?ref=main`)
+      const clash = await gh(`/contents/works/${targetWorkId}/${fileName}?ref=main`)
       if (clash.ok) {
-        return bad(409, `This song already has a ${instrument} tab — `
-          + `open it and use Edit to submit a correction.`)
+        for (let i = 0; i < 5; i++) {
+          const candidate = `${instrument}-${siblingSuffix(stamp + i)}.otf.json`
+          const probe = await gh(`/contents/works/${targetWorkId}/${candidate}?ref=main`)
+          if (probe.status === 404) { fileName = candidate; break }
+        }
+        if (fileName === `${instrument}.otf.json`) {
+          return bad(409, 'Could not find a free filename for this tab — try again.')
+        }
       }
     }
+    const filePath = `works/${targetWorkId}/${fileName}`
 
     // Branch off main
     const mainRef = await gh('/git/ref/heads/main')
     if (!mainRef.ok) throw new Error(`ref lookup failed: ${mainRef.status}`)
     const baseSha = (await mainRef.json()).object.sha
-    const branch = `tab/${type === 'tab-correction' ? 'fix' : 'new'}-${targetWorkId}-${Date.now()}`
+    const branch = `tab/${type === 'tab-correction' ? 'fix' : 'new'}-${targetWorkId}-${stamp}`
     const mkBranch = await gh('/git/refs', {
       method: 'POST',
       body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: baseSha }),
@@ -193,6 +241,7 @@ serve(async (req) => {
 **Work ID:** ${targetWorkId}
 **Title:** ${title}
 **Instrument:** ${instrument}
+**File:** ${fileName}
 **Submitted by:** ${attribution}
 
 ${comment ? `### Changes Made\n${comment}\n` : ''}

--- a/tests/test_process_tab.py
+++ b/tests/test_process_tab.py
@@ -32,10 +32,12 @@ def otf_doc(track_id='banjo'):
     }
 
 
-def write_otf(repo, work_id, instrument, doc=None):
+def write_otf(repo, work_id, name, doc=None):
+    """``name`` is the works/ filename stem — 'banjo', or a sibling
+    arrangement's uniquified 'banjo-mfa3k2px9'."""
     work_dir = repo / 'works' / work_id
     work_dir.mkdir(parents=True, exist_ok=True)
-    path = work_dir / f'{instrument}.otf.json'
+    path = work_dir / f'{name}.otf.json'
     path.write_text(json.dumps(doc or otf_doc()))
     return path
 
@@ -127,6 +129,120 @@ def test_a_second_instrument_does_not_disturb_the_first(repo):
     assert by_instrument['banjo']['provenance']['source'] == 'banjo-hangout'
     assert 'x_corrected_by' not in by_instrument['banjo']['provenance']
     assert by_instrument['mandolin']['provenance']['source'] == 'user-submission'
+
+
+class TestSameInstrumentSibling:
+    """A second banjo tab for a song that already has one.
+
+    The corpus has always carried these (foggy-mountain-breakdown has
+    eight banjo takes, rendered as selectable arrangements), but
+    create-tab-pr used to 409 the submission — a late block, discovered
+    only after the contributor had arranged the whole tab. It now
+    uniquifies the filename and lands the tab as a NEW part, so this is
+    the shape process_tab has to get right: append, never adopt.
+    """
+
+    @pytest.fixture
+    def repo_with_banjo(self, repo):
+        works_writer.create_work(
+            repo, 'salt-creek', 'Salt Creek',
+            works_writer.PartSpec(file='banjo.otf.json', type='tablature',
+                                  format='otf', instrument='banjo', default=True,
+                                  provenance={'source': 'banjo-hangout',
+                                              'author': 'schlange'}),
+            verbose=False)
+        write_otf(repo, 'salt-creek', 'banjo')
+        return repo
+
+    def test_lands_as_a_new_part_with_its_own_provenance(self, repo_with_banjo):
+        write_otf(repo_with_banjo, 'salt-creek', 'banjo-mfa3k2px9')
+
+        run(repo_with_banjo, ['works/salt-creek/banjo-mfa3k2px9.otf.json'])
+
+        work = yaml.safe_load(
+            (repo_with_banjo / 'works/salt-creek/work.yaml').read_text())
+        assert [p['file'] for p in work['parts']] == [
+            'banjo.otf.json', 'banjo-mfa3k2px9.otf.json']
+
+        sibling = work['parts'][1]
+        # The uniquifying suffix is a FILENAME detail, not the instrument
+        assert sibling['instrument'] == 'banjo'
+        assert sibling['type'] == 'tablature'
+        assert sibling['provenance']['source'] == 'user-submission'
+        assert sibling['provenance']['author'] == 'Jane Picker'
+        assert sibling['provenance']['submission_pr'] == 412
+        # Nothing was corrected — this content had never been published
+        assert not [k for k in sibling['provenance'] if k.startswith('x_corrected')]
+        # A sibling never displaces the take that's already pinned
+        assert not sibling.get('default')
+
+    def test_the_existing_take_is_untouched(self, repo_with_banjo):
+        before = (repo_with_banjo / 'works/salt-creek/banjo.otf.json').read_text()
+        write_otf(repo_with_banjo, 'salt-creek', 'banjo-mfa3k2px9')
+
+        run(repo_with_banjo, ['works/salt-creek/banjo-mfa3k2px9.otf.json'])
+
+        work = yaml.safe_load(
+            (repo_with_banjo / 'works/salt-creek/work.yaml').read_text())
+        original = work['parts'][0]
+        assert original['file'] == 'banjo.otf.json'      # not repointed
+        assert original['default'] is True
+        assert original['provenance']['source'] == 'banjo-hangout'
+        assert original['provenance']['author'] == 'schlange'
+        assert 'x_corrected_by' not in original['provenance']
+        assert (repo_with_banjo / 'works/salt-creek/banjo.otf.json').read_text() \
+            == before
+
+    def test_correcting_a_sibling_stamps_that_sibling_only(self, repo_with_banjo):
+        """The other half of the same rule: corrections are keyed on the
+        file too, so fixing take #2 must not stamp take #1."""
+        works_writer.add_part(
+            repo_with_banjo, 'salt-creek',
+            works_writer.PartSpec(file='banjo-22352.otf.json', type='tablature',
+                                  format='otf', instrument='banjo',
+                                  provenance={'source': 'banjo-hangout',
+                                              'source_id': '22352'}),
+            verbose=False)
+        write_otf(repo_with_banjo, 'salt-creek', 'banjo-22352')
+
+        run(repo_with_banjo, ['works/salt-creek/banjo-22352.otf.json'])
+
+        work = yaml.safe_load(
+            (repo_with_banjo / 'works/salt-creek/work.yaml').read_text())
+        by_file = {p['file']: p for p in work['parts']}
+        assert len(work['parts']) == 2                    # no third part minted
+        assert by_file['banjo-22352.otf.json']['provenance']['x_correction_pr'] == 412
+        assert 'x_corrected_by' not in by_file['banjo.otf.json']['provenance']
+
+    def test_a_true_overwrite_is_still_refused(self, repo_with_banjo):
+        """Same instrument, same file, no correction intent — the one case
+        that stays an error rather than becoming a sibling."""
+        work = works_writer.load_work(repo_with_banjo, 'salt-creek')
+        # Two parts claiming one file can only come from a bad write; the
+        # writer refuses to add a third onto the same name.
+        with pytest.raises(works_writer.PartExistsError):
+            works_writer.add_part(
+                repo_with_banjo, 'salt-creek',
+                works_writer.PartSpec(file='banjo.otf.json', type='tablature',
+                                      format='otf', instrument='banjo',
+                                      provenance={'source': 'user-submission'}),
+                verbose=False)
+        assert len(work['parts']) == 1
+
+
+def test_instrument_comes_from_the_pr_body_when_the_filename_is_suffixed():
+    """The filename stem is no longer the instrument once siblings exist."""
+    from pathlib import Path
+    assert process_tab.part_instrument(
+        Path('works/x/banjo-mfa3k2px9.otf.json'), 'banjo') == 'banjo'
+    assert process_tab.part_instrument(
+        Path('works/x/banjo.otf.json'), 'banjo') == 'banjo'
+    # A declared instrument that doesn't match the file is not trusted
+    assert process_tab.part_instrument(
+        Path('works/x/mandolin.otf.json'), 'banjo') == 'mandolin'
+    # Hand-opened PR with no declaration: the stem still answers
+    assert process_tab.part_instrument(
+        Path('works/x/dobro.otf.json'), None) == 'dobro'
 
 
 def test_a_tab_with_no_work_yet_mints_its_own_work(repo):

--- a/tests/test_tab_arrangements.py
+++ b/tests/test_tab_arrangements.py
@@ -386,8 +386,10 @@ class TestIndexContract:
             assert sum(defaults) == 1
 
     def test_source_path_is_carried_for_the_copy_step(self, work_dir):
+        """And published: a correction has to name the file it corrects,
+        and the published name can't be mapped back to the works/ one."""
         song = build_song_from_work(work_dir)
-        assert [p['_src'] for p in song['tablature_parts']] == [
+        assert [p['src_file'] for p in song['tablature_parts']] == [
             'banjo.otf.json', 'banjo-222.otf.json', 'mandolin.otf.json']
 
     def test_published_name_falls_back_when_source_id_missing(self):


### PR DESCRIPTION
Fixes the late-block the owner hit kicking the tires: targeting a work that already has tabs of your instrument now shows the choice BEFORE the editor opens (view them / add yours as another version / improve one) from both entry points, the create.html banner says 'alongside N existing tabs' from the first pixel, and create-tab-pr adds a same-instrument tab as a uniquified sibling part instead of returning 409 (the corpus already holds sibling takes — foggy-mountain-breakdown has three banjo tabs).

Also fixes three real pre-existing bugs found en route: correction detection keyed on instrument (an incoming sibling repointed the existing part at the new file, orphaning the named take), instrument derived from the filename stem (breaks on uniquified names), and corrections targeting by instrument alone (correcting take #3 landed on take #1 — corrections now name the exact take via src_file).

Tests: 1753 vitest / 557 pytest green; new coverage for sibling adds, per-take corrections, panel routing, banner contract. PR review gate for tabs unchanged.