### PR TITLE
High scores: contribution leaderboard with server-side anonymization

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -15,6 +15,10 @@
     --danger-hover: #b91c1c;
     --success: #16a34a;
     --heart: #e11d48;
+    /* High Scores podium */
+    --medal-gold: #b8860b;
+    --medal-silver: #6b7280;
+    --medal-bronze: #a1662f;
 
     /* Spacing scale */
     --space-xs: 0.25rem;
@@ -53,6 +57,9 @@
     --danger-hover: #fca5a5;
     --success: #4ade80;
     --heart: #fb7185;
+    --medal-gold: #fbbf24;
+    --medal-silver: #cbd5e1;
+    --medal-bronze: #d68a52;
 }
 
 /* Base */
@@ -6005,6 +6012,115 @@ a.my-submission-row:hover {
 }
 .my-submissions-empty .bounty-cta-btn {
     margin-top: 0.75rem;
+}
+
+/* High Scores (#174) — the contribution leaderboard */
+.high-scores-view {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+.high-scores-header {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+.bounty-high-scores-link {
+    color: var(--accent);
+    text-decoration: none;
+}
+.bounty-high-scores-link:hover {
+    text-decoration: underline;
+}
+.high-scores-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.high-score-row {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: 0.7rem 1rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: var(--radius-md);
+}
+.high-score-rank {
+    flex-shrink: 0;
+    width: 2rem;
+    text-align: center;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+.high-score-main {
+    flex: 1;
+    min-width: 0;
+}
+.high-score-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    overflow-wrap: anywhere;
+}
+.high-score-breakdown {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    margin-top: 0.1rem;
+}
+.high-score-total {
+    flex-shrink: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.high-score-you-badge {
+    margin-left: 0.45rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 20%, transparent);
+    color: var(--accent);
+    vertical-align: middle;
+}
+/* Medals are the left rule + the rank numeral, so they read the same in both
+   themes without repainting the row background. */
+.high-score-row-gold {
+    border-left-color: var(--medal-gold);
+}
+.high-score-row-gold .high-score-rank,
+.high-score-row-gold .high-score-total {
+    color: var(--medal-gold);
+}
+.high-score-row-silver {
+    border-left-color: var(--medal-silver);
+}
+.high-score-row-silver .high-score-rank,
+.high-score-row-silver .high-score-total {
+    color: var(--medal-silver);
+}
+.high-score-row-bronze {
+    border-left-color: var(--medal-bronze);
+}
+.high-score-row-bronze .high-score-rank,
+.high-score-row-bronze .high-score-total {
+    color: var(--medal-bronze);
+}
+.high-score-row-you {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+}
+/* A medalled row that is also the caller's keeps its medal rule. */
+.high-score-row-you.high-score-row-gold { border-left-color: var(--medal-gold); }
+.high-score-row-you.high-score-row-silver { border-left-color: var(--medal-silver); }
+.high-score-row-you.high-score-row-bronze { border-left-color: var(--medal-bronze); }
+.high-scores-privacy-note {
+    margin-top: 1.25rem;
+    text-align: center;
 }
 
 /* Search empty results */

--- a/docs/js/CLAUDE.md
+++ b/docs/js/CLAUDE.md
@@ -28,6 +28,7 @@ docs/
 │   ├── flags.js        # Unified feedback modal (song issues, bugs, general feedback)
 │   ├── add-song-picker.js # Add/request-a-song picker (also serves #request-song)
 │   ├── superuser-request.js # Super-user request modal and submission
+│   ├── high-scores.js  # `#high-scores` leaderboard — renders `get_leaderboard()`; identities are resolved SERVER-side (no email/uuid ever reaches this file)
 │   ├── collections.js  # Landing page collection definitions
 │   ├── analytics.js    # Behavioral analytics tracking
 │   ├── utils.js        # Shared utilities (escapeHtml, etc.)

--- a/docs/js/__tests__/high-scores.test.js
+++ b/docs/js/__tests__/high-scores.test.js
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+// High Scores (#174) — the contribution leaderboard.
+//
+// There is deliberately NO alias/anonymization logic to test here: every
+// identity decision happens inside the `get_leaderboard()` definer function
+// (supabase/migrations/20260816120000_leaderboard.sql), and the RPC hands
+// back an already-resolved `display` string with no email or uuid attached.
+// These tests cover the presentation contract instead — medal assignment,
+// the songs/tabs breakdown, the is_you highlight, and the empty/error states
+// — plus the fact that the view renders for a signed-out visitor at all,
+// which is what makes the board public.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    medalFor, breakdownText, buildScoreRows, scoreRowHtml, renderHighScoresView,
+} from '../high-scores.js';
+
+describe('medalFor', () => {
+    it('assigns gold/silver/bronze to the top three', () => {
+        expect(medalFor(1)).toBe('gold');
+        expect(medalFor(2)).toBe('silver');
+        expect(medalFor(3)).toBe('bronze');
+    });
+
+    it('gives nothing to fourth place and below', () => {
+        expect(medalFor(4)).toBeNull();
+        expect(medalFor(97)).toBeNull();
+    });
+
+    it('gives nothing for a missing/zero rank', () => {
+        expect(medalFor(0)).toBeNull();
+        expect(medalFor(undefined)).toBeNull();
+    });
+});
+
+describe('breakdownText', () => {
+    it('joins both halves when both are non-zero', () => {
+        expect(breakdownText({ songs: 3, tabs: 2 })).toBe('3 songs · 2 tabs');
+    });
+
+    it('singularizes a count of one', () => {
+        expect(breakdownText({ songs: 1, tabs: 1 })).toBe('1 song · 1 tab');
+    });
+
+    it('drops a zero half rather than printing "0 tabs"', () => {
+        expect(breakdownText({ songs: 4, tabs: 0 })).toBe('4 songs');
+        expect(breakdownText({ songs: 0, tabs: 4 })).toBe('4 tabs');
+    });
+
+    it('is empty when there is nothing to break down', () => {
+        expect(breakdownText({ songs: 0, tabs: 0 })).toBe('');
+        expect(breakdownText()).toBe('');
+    });
+});
+
+describe('buildScoreRows', () => {
+    it('normalizes an RPC row into a display-ready entry', () => {
+        const [row] = buildScoreRows([
+            { rank: 1, display: 'Mike', total: 5, songs: 3, tabs: 2, is_you: false },
+        ]);
+        expect(row).toMatchObject({
+            rank: 1, display: 'Mike', total: 5, songs: 3, tabs: 2,
+            isYou: false, medal: 'gold', breakdown: '3 songs · 2 tabs',
+        });
+    });
+
+    it('maps is_you onto isYou, and only for a literal true', () => {
+        const rows = buildScoreRows([
+            { rank: 1, display: 'A', total: 1, songs: 1, tabs: 0, is_you: true },
+            { rank: 2, display: 'B', total: 1, songs: 1, tabs: 0, is_you: false },
+            { rank: 3, display: 'C', total: 1, songs: 1, tabs: 0, is_you: null },
+        ]);
+        expect(rows.map(r => r.isYou)).toEqual([true, false, false]);
+    });
+
+    it('preserves the RPC order and its tied ranks', () => {
+        const rows = buildScoreRows([
+            { rank: 1, display: 'Lonesome Fiddler', total: 4, songs: 4, tabs: 0 },
+            { rank: 2, display: 'Salty Drifter', total: 2, songs: 1, tabs: 1 },
+            { rank: 2, display: 'Gospel Picker', total: 2, songs: 2, tabs: 0 },
+            { rank: 4, display: 'Rusty Hobo', total: 1, songs: 0, tabs: 1 },
+        ]);
+        expect(rows.map(r => r.display)).toEqual([
+            'Lonesome Fiddler', 'Salty Drifter', 'Gospel Picker', 'Rusty Hobo',
+        ]);
+        // A tie shares a medal; the skipped rank gets none.
+        expect(rows.map(r => r.medal)).toEqual(['gold', 'silver', 'silver', null]);
+    });
+
+    it('handles missing/undefined input without throwing', () => {
+        expect(buildScoreRows(null)).toEqual([]);
+        expect(buildScoreRows(undefined)).toEqual([]);
+        expect(buildScoreRows([])).toEqual([]);
+    });
+});
+
+describe('scoreRowHtml', () => {
+    const entry = (over = {}) => buildScoreRows([{
+        rank: 1, display: 'Mike', total: 5, songs: 3, tabs: 2, is_you: false, ...over,
+    }])[0];
+
+    it('tags the row with its medal class', () => {
+        expect(scoreRowHtml(entry({ rank: 1 }))).toContain('high-score-row-gold');
+        expect(scoreRowHtml(entry({ rank: 2 }))).toContain('high-score-row-silver');
+        expect(scoreRowHtml(entry({ rank: 3 }))).toContain('high-score-row-bronze');
+        const plain = scoreRowHtml(entry({ rank: 9 }));
+        expect(plain).not.toMatch(/high-score-row-(gold|silver|bronze)/);
+    });
+
+    it("highlights and badges the caller's own row", () => {
+        const mine = scoreRowHtml(entry({ is_you: true }));
+        expect(mine).toContain('high-score-row-you');
+        expect(mine).toContain('high-score-you-badge');
+
+        const theirs = scoreRowHtml(entry({ is_you: false }));
+        expect(theirs).not.toContain('high-score-row-you');
+        expect(theirs).not.toContain('high-score-you-badge');
+    });
+
+    it('renders the breakdown, and omits it entirely when empty', () => {
+        expect(scoreRowHtml(entry())).toContain('3 songs · 2 tabs');
+        expect(scoreRowHtml(entry({ songs: 0, tabs: 0, total: 0 })))
+            .not.toContain('high-score-breakdown');
+    });
+
+    it('escapes the display string (it is server-supplied, not trusted markup)', () => {
+        const html = scoreRowHtml(entry({ display: '<img src=x onerror=1>' }));
+        expect(html).not.toContain('<img');
+        expect(html).toContain('&lt;img');
+    });
+});
+
+describe('renderHighScoresView', () => {
+    let container;
+
+    const stubRpc = (result) => {
+        const rpc = vi.fn(async () => result);
+        window.SupabaseAuth = { getUser: () => null, supabase: { rpc } };
+        return rpc;
+    };
+
+    // The module caches per caller id; flush it between tests by rendering
+    // once as a different user, which is exactly what invalidates it in the
+    // app. The stub's RPC never settles, so this flush can't land a stale
+    // result on top of the next test's fetch.
+    const flushCache = () => {
+        window.SupabaseAuth = {
+            getUser: () => ({ id: `flush-${Math.random()}` }),
+            supabase: { rpc: () => new Promise(() => {}) },
+        };
+        renderHighScoresView(document.createElement('div'));
+    };
+
+    const settle = async () => {
+        await new Promise(r => setTimeout(r, 0));
+        await new Promise(r => setTimeout(r, 0));
+    };
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        flushCache();
+        vi.unstubAllGlobals();
+        delete window.SupabaseAuth;
+        document.body.innerHTML = '';
+    });
+
+    it('shows the board to a signed-out visitor (the RPC is granted to anon)', async () => {
+        const rpc = stubRpc({
+            data: [
+                { rank: 1, display: 'Mike', total: 5, songs: 3, tabs: 2, is_you: false },
+                { rank: 2, display: 'Lonesome Fiddler', total: 2, songs: 2, tabs: 0, is_you: false },
+            ],
+            error: null,
+        });
+
+        renderHighScoresView(container);
+        expect(container.textContent).toMatch(/counting up/i);
+        await settle();
+
+        expect(rpc).toHaveBeenCalledWith('get_leaderboard');
+        expect(container.textContent).toContain('Mike');
+        expect(container.textContent).toContain('Lonesome Fiddler');
+        // Nobody is "you" when nobody is signed in.
+        expect(container.querySelector('.high-score-row-you')).toBeNull();
+    });
+
+    it('highlights exactly one row when the RPC marks it as the caller', async () => {
+        window.SupabaseAuth = {
+            getUser: () => ({ id: 'u1' }),
+            supabase: {
+                rpc: async () => ({
+                    data: [
+                        { rank: 1, display: 'Mike', total: 5, songs: 5, tabs: 0, is_you: false },
+                        { rank: 2, display: 'alice@example.com', total: 2, songs: 2, tabs: 0, is_you: true },
+                    ],
+                    error: null,
+                }),
+            },
+        };
+
+        renderHighScoresView(container);
+        await settle();
+
+        const mine = container.querySelectorAll('.high-score-row-you');
+        expect(mine).toHaveLength(1);
+        expect(mine[0].textContent).toContain('alice@example.com');
+    });
+
+    it('shows the empty state when nobody has contributed yet', async () => {
+        stubRpc({ data: [], error: null });
+        renderHighScoresView(container);
+        await settle();
+        expect(container.textContent).toMatch(/no contributions yet/i);
+    });
+
+    it('fails soft when the RPC errors', async () => {
+        stubRpc({ data: null, error: { message: 'boom' } });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        renderHighScoresView(container);
+        await settle();
+
+        expect(container.textContent).toMatch(/couldn't load the high scores/i);
+        expect(container.querySelector('.high-scores-list')).toBeNull();
+        warn.mockRestore();
+    });
+
+    it('fails soft when Supabase is not initialized at all', async () => {
+        window.SupabaseAuth = { getUser: () => null };
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        renderHighScoresView(container);
+        await settle();
+
+        expect(container.textContent).toMatch(/couldn't load the high scores/i);
+        warn.mockRestore();
+    });
+});

--- a/docs/js/bounty-view.js
+++ b/docs/js/bounty-view.js
@@ -357,6 +357,11 @@ export function renderBountyView(container) {
                 <h1 class="bounty-title">Bounty Board</h1>
                 <p class="bounty-subtitle">Songs and parts the community is looking for. Know one? Help us out!</p>
                 <p class="bounty-stats">${wanted.length} missing standards · ${filteredPlaceholders.length} started pages · ${filteredBounties.length} part requests</p>
+                <!-- The bounty board is the contributor hub, so the board of
+                     who has actually filled these in belongs next to it. A
+                     plain hash link is enough: main.js routes #high-scores on
+                     hashchange. -->
+                <p class="bounty-stats"><a class="bounty-high-scores-link" href="#high-scores">🏆 High scores</a></p>
             </div>
 
             ${wantedHtml}

--- a/docs/js/high-scores.js
+++ b/docs/js/high-scores.js
@@ -1,0 +1,196 @@
+// High Scores (#174, in part) — the public contribution leaderboard.
+//
+// PRIVACY: this module has no privacy logic, on purpose. Everything that
+// could identify a contributor is resolved inside `get_leaderboard()`
+// (supabase/migrations/20260816120000_leaderboard.sql, `security definer`):
+// the RPC returns { rank, display, total, songs, tabs, is_you } and NOTHING
+// else — no email, no uuid, no auth metadata for anyone but the caller. There
+// is nothing here to mask, because the identifiers never arrive. Do not add a
+// second data source to this view that would reintroduce them.
+//
+// `display` is already the final string: Mike's opted-in real name, the
+// caller's own email on their own row, or a salted bluegrass alias
+// ("Lonesome Fiddler") for everyone else. Render it verbatim.
+//
+// The RPC is granted to `anon` as well as `authenticated`, so a signed-out
+// visitor sees the whole board — aliased, with is_you false everywhere.
+//
+// `buildScoreRows` / `medalFor` / `breakdownText` are pure and exported for
+// unit testing; everything else is rendering + Supabase I/O.
+
+import { escapeHtml } from './utils.js';
+
+/** Medal class for a rank, or null. Ranks are 1-based and may tie. */
+export function medalFor(rank) {
+    if (rank === 1) return 'gold';
+    if (rank === 2) return 'silver';
+    if (rank === 3) return 'bronze';
+    return null;
+}
+
+/** "3 songs · 1 tab" — zero-count halves are dropped, never rendered as "0". */
+export function breakdownText({ songs = 0, tabs = 0 } = {}) {
+    const parts = [];
+    if (songs > 0) parts.push(`${songs} song${songs === 1 ? '' : 's'}`);
+    if (tabs > 0) parts.push(`${tabs} tab${tabs === 1 ? '' : 's'}`);
+    return parts.join(' · ');
+}
+
+/**
+ * Normalize `get_leaderboard()` rows into display-ready entries. Pure: no
+ * DOM, no network. Rows arrive already ranked and ordered by the RPC; this
+ * only fills in the presentation bits and defends against nulls.
+ *
+ * @param {Array<object>} rpcRows
+ * @returns {Array<{rank:number, display:string, total:number, songs:number,
+ *                  tabs:number, isYou:boolean, medal:string|null,
+ *                  breakdown:string}>}
+ */
+export function buildScoreRows(rpcRows) {
+    return (rpcRows || []).map(row => {
+        const songs = Number(row.songs) || 0;
+        const tabs = Number(row.tabs) || 0;
+        const rank = Number(row.rank) || 0;
+        return {
+            rank,
+            display: row.display || 'Anonymous Picker',
+            total: Number(row.total) || 0,
+            songs,
+            tabs,
+            isYou: row.is_you === true,
+            medal: medalFor(rank),
+            breakdown: breakdownText({ songs, tabs }),
+        };
+    });
+}
+
+// Module-level cache. Keyed by the caller's id (or null when signed out) so
+// signing in/out refetches — `is_you` and the caller's own display depend on
+// who is asking.
+let cache = null;
+let cacheUserId;
+let fetchStarted = false;
+let fetchFailed = false;
+
+function resetCache() {
+    cache = null;
+    fetchStarted = false;
+    fetchFailed = false;
+}
+
+async function fetchScores() {
+    const supabase = window.SupabaseAuth?.supabase;
+    if (!supabase) throw new Error('Supabase not initialized');
+    const { data, error } = await supabase.rpc('get_leaderboard');
+    if (error) throw error;
+    return buildScoreRows(data || []);
+}
+
+function shellHtml(inner) {
+    return `
+        <div class="high-scores-view">
+            <div class="high-scores-header">
+                <h1 class="bounty-title">High Scores</h1>
+                <p class="bounty-subtitle">The folks keeping this songbook filled in.</p>
+            </div>
+            ${inner}
+        </div>
+    `;
+}
+
+function loadingHtml() {
+    return shellHtml('<p class="bounty-filter-hint">Counting up the contributions…</p>');
+}
+
+function errorHtml() {
+    return shellHtml(`
+        <div class="bounty-empty">
+            <p>Couldn't load the high scores right now.</p>
+            <p class="bounty-empty-sub">Try refreshing the page in a moment.</p>
+        </div>
+    `);
+}
+
+function emptyStateHtml() {
+    return shellHtml(`
+        <div class="bounty-empty">
+            <p>No contributions yet — be the first.</p>
+            <p class="bounty-empty-sub">Add a song, fix a chord, or drop in a tab and your name lands right here.</p>
+        </div>
+    `);
+}
+
+export function scoreRowHtml(entry) {
+    const classes = ['high-score-row'];
+    if (entry.medal) classes.push(`high-score-row-${entry.medal}`);
+    if (entry.isYou) classes.push('high-score-row-you');
+    return `
+        <div class="${classes.join(' ')}">
+            <div class="high-score-rank">${entry.rank}</div>
+            <div class="high-score-main">
+                <div class="high-score-name">${escapeHtml(entry.display)}${entry.isYou ? '<span class="high-score-you-badge">you</span>' : ''}</div>
+                ${entry.breakdown ? `<div class="high-score-breakdown">${escapeHtml(entry.breakdown)}</div>` : ''}
+            </div>
+            <div class="high-score-total">${entry.total}</div>
+        </div>
+    `;
+}
+
+function listHtml(entries) {
+    return shellHtml(`
+        <div class="high-scores-list">
+            ${entries.map(scoreRowHtml).join('')}
+        </div>
+        <p class="bounty-filter-hint high-scores-privacy-note">
+            Contributors show up under a bluegrass handle unless they've asked
+            to be named. Nobody's email or account ever leaves the server.
+        </p>
+    `);
+}
+
+/**
+ * Render the High Scores view into `container`. Follows the bounty-view /
+ * my-submissions pattern: the fetch is lazy and cached, and re-renders the
+ * container once it lands — guarded on `container.isConnected` so a stale
+ * in-flight fetch never paints over a view the user has navigated away from.
+ */
+export function renderHighScoresView(container) {
+    const userId = window.SupabaseAuth?.getUser?.()?.id || null;
+
+    if (cacheUserId !== userId) {
+        cacheUserId = userId;
+        resetCache();
+    }
+
+    if (!fetchStarted) {
+        fetchStarted = true;
+        fetchScores()
+            .then(rows => {
+                cache = rows;
+                if (container.isConnected) renderHighScoresView(container);
+            })
+            .catch(err => {
+                console.warn('Could not load high scores:', err);
+                fetchFailed = true;
+                cache = [];
+                if (container.isConnected) renderHighScoresView(container);
+            });
+    }
+
+    if (cache === null) {
+        container.innerHTML = loadingHtml();
+        return;
+    }
+
+    if (fetchFailed) {
+        container.innerHTML = errorHtml();
+        return;
+    }
+
+    if (!cache.length) {
+        container.innerHTML = emptyStateHtml();
+        return;
+    }
+
+    container.innerHTML = listHtml(cache);
+}

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -48,6 +48,7 @@ import { initSongView, goBack, getCurrentSong, navigatePrev, navigateNext, setLi
 import { openWork, teardownTablatureView, configureWorkPage, updateWorkTopBar, handleEditAction } from './work-view.js';
 import { renderBountyView } from './bounty-view.js';
 import { renderMySubmissionsView } from './my-submissions.js';
+import { renderHighScoresView } from './high-scores.js';
 import { initSearch, search, showPopularSongs, renderResults, parseSearchQuery, searchableSongs } from './search-core.js';
 import { initEditor, updateEditorPreview, enterEditMode, exitEditMode, editorGenerateChordPro, closeHints, prepareAddSongView } from './editor.js';
 import { escapeHtml, requireLogin, parseItemRef, buildDeleteCandidates, downloadFile } from './utils.js';
@@ -222,6 +223,9 @@ function pushHistoryState(view, data = {}, replace = false) {
         case 'my-submissions':
             hash = '#my-submissions';
             break;
+        case 'high-scores':
+            hash = '#high-scores';
+            break;
         case 'favorites':
             // Favorites is just a list with ID 'favorites'
             // Use 'list' view type for consistency
@@ -324,6 +328,9 @@ function handleHistoryNavigation(state) {
             break;
         case 'my-submissions':
             showView('my-submissions');
+            break;
+        case 'high-scores':
+            showView('high-scores');
             break;
         case 'favorites':
             showView('favorites');
@@ -493,6 +500,14 @@ function initViewSubscription() {
                 editorPanel?.classList.add('hidden');
                 songListsView?.classList.add('hidden');
                 renderMySubmissionsView(resultsDiv);
+                break;
+            case 'high-scores':
+                searchContainer?.classList.add('hidden');
+                resultsDiv?.classList.remove('hidden');
+                songView?.classList.add('hidden');
+                editorPanel?.classList.add('hidden');
+                songListsView?.classList.add('hidden');
+                renderHighScoresView(resultsDiv);
                 break;
             case 'song-lists':
                 searchContainer?.classList.add('hidden');
@@ -777,6 +792,11 @@ function handleDeepLink() {
         trackDeepLink('my-submissions', hash);
         showView('my-submissions');
         pushHistoryState('my-submissions', {}, true);
+        return true;
+    } else if (hash === '#high-scores') {
+        trackDeepLink('high-scores', hash);
+        showView('high-scores');
+        pushHistoryState('high-scores', {}, true);
         return true;
     } else if (hash === '#request-song') {
         trackDeepLink('request-song', hash);
@@ -2450,6 +2470,7 @@ function init() {
         onReportBug: () => openFeedbackModal({ type: 'bug-report' }),
     });
     setOverflowBase([
+        { label: 'High Scores', onClick: () => { showView('high-scores'); pushHistoryState('high-scores'); } },
         { label: 'About', onClick: () => { location.href = 'about.html'; } },
         { label: 'Dev Blog', onClick: () => { location.href = 'blog.html'; } },
         { label: 'Standards Board', onClick: () => { location.href = 'bluegrass-standards-board.html'; } },

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -80,6 +80,24 @@ SQL migrations for the Supabase Postgres database. Version-controlled and applie
 - `trusted_users` - Users allowed to edit someone else's chart **in place** (everyone else's edit forks to a new arrangement)
 - `pending_songs` - Any logged-in user's submission, live in the overlay, awaiting the GitHub commit
 - `review_requests` - The destructive residue (phase 2d): trusted users request delete / suppress / merge-redirect, admins decide
+- `leaderboard_identities` - Opt-in real names for the High Scores board. **RLS on, zero policies** — only `get_leaderboard()` reads it
+- `leaderboard_salt` - One random uuid that salts the leaderboard aliases. **RLS on, zero policies.** Never expose it: contributor uuids are already public in `works/*/work.yaml` (`provenance.submitted_by`), so an unsalted alias hash would be a join key straight back to real contributors
+
+**Key functions:**
+- `get_leaderboard()` (`20260816120000_leaderboard.sql`, **not yet applied**) —
+  the High Scores board, `security definer`, granted to `anon` *and*
+  `authenticated`. Aggregates `submission_log` over CONTENT actions only
+  (`song_submit`, `song_correction`, `tab_submit`, `tab_correction`; reports
+  and requests don't score) and returns
+  `(rank, display, total, songs, tabs, is_you)`.
+  **The anonymization is the feature.** No email, uuid, or auth metadata for
+  any user but the caller is in the response at all — it isn't masked, it
+  isn't there. `display` resolves as: opt-in name from
+  `leaderboard_identities` → the caller's own email on their own row →
+  otherwise a deterministic bluegrass alias from `md5(salt || user_id)` over a
+  24 x 24 adjective/noun table, with a two-hex-char suffix added only to rows
+  that actually collide. Ships the deterministic-alias half of #174; that
+  issue stays open for real profiles. Frontend: `docs/js/high-scores.js`.
 
 **Retired:** `doc_staging` (+ the `doc-staging` storage bucket) — the
 document-upload intake, removed in phase 2d. The drop migration

--- a/supabase/migrations/20260816120000_leaderboard.sql
+++ b/supabase/migrations/20260816120000_leaderboard.sql
@@ -1,0 +1,225 @@
+-- NOT YET APPLIED. High Scores — the contribution leaderboard (#174, in part).
+--
+-- PRIVACY CONTRACT (this is the whole point of the design; read before editing)
+--
+--   The board is public. Contributor identities are NOT. The rule is
+--   ANONYMIZE ON THE SERVER, NOT IN THE CLIENT: no email, no uuid, and no
+--   auth.users metadata for any user other than the caller ever leaves the
+--   database. This is not masking — the response literally does not contain
+--   those columns, so there is nothing to un-mask in a devtools panel, a
+--   cached response, or a scraped API call.
+--
+--   Three ways a row's `display` can be resolved, in this order:
+--
+--     1. leaderboard_identities  — an explicit, opt-in real name. Seeded with
+--        exactly one row (Mike). Nobody is in here unless they asked to be.
+--     2. the caller's own row    — the caller already knows their own email,
+--        so showing it back to them ("that's me") leaks nothing.
+--     3. everyone else           — a deterministic bluegrass alias derived
+--        from a SALTED hash of the user's uuid.
+--
+--   WHY THE SALT MATTERS. Contributor uuids are already public: they are
+--   written into works/*/work.yaml as `provenance.submitted_by`. An UNSALTED
+--   hash would therefore be a join key — anyone could hash the uuids they
+--   can read out of the repo and map every alias back to a real contributor,
+--   which is exactly the de-anonymization this feature is meant to prevent.
+--   leaderboard_salt holds a random uuid that never leaves the database (RLS
+--   on, zero policies, read only by the definer function below), so the alias
+--   space is not computable by anyone outside Postgres.
+--
+--   Consequently BOTH tables here are policy-less by design. `enable row level
+--   security` with no policies means: no client, anon or authenticated, can
+--   select a single row. The only reader is get_leaderboard(), which is
+--   `security definer` and returns aggregates that carry no identifiers.
+--
+-- Relationship to #174: that issue asks for auto-generated user names wired
+-- to bounties and contributions, eventually backed by real profiles. This
+-- migration ships the deterministic-alias half of it and nothing more —
+-- there is no profile table, no user-visible name choice, and no way for a
+-- user to see their own alias. #174 stays open for the profile work.
+
+-- ---------------------------------------------------------------------------
+-- 1. Opt-in real names
+-- ---------------------------------------------------------------------------
+
+create table if not exists leaderboard_identities (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table leaderboard_identities enable row level security;
+
+-- Deliberately NO policies. Only get_leaderboard() (security definer) reads
+-- this; adding a "readable by anyone" policy would publish the user_id ->
+-- real name mapping, which is the one thing this table must not do.
+
+-- Seed the one opt-in identity. Guarded: if that account does not exist in
+-- this project (fresh/local database), the select returns no rows and the
+-- migration still applies cleanly.
+insert into leaderboard_identities (user_id, display_name)
+select id, 'Mike' from auth.users where email = 'michael.beaumier@gmail.com'
+on conflict (user_id) do update set display_name = excluded.display_name;
+
+-- ---------------------------------------------------------------------------
+-- 2. The private alias salt
+-- ---------------------------------------------------------------------------
+
+create table if not exists leaderboard_salt (
+  id int primary key default 1 check (id = 1),
+  salt uuid not null default gen_random_uuid()
+);
+
+alter table leaderboard_salt enable row level security;
+
+-- Deliberately NO policies (see the contract above). If this value ever
+-- leaks, every alias becomes linkable to a public provenance uuid; rotating
+-- it re-randomizes the whole board's aliases, which is the intended repair.
+insert into leaderboard_salt (id) values (1) on conflict (id) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. get_leaderboard()
+-- ---------------------------------------------------------------------------
+--
+-- Counts CONTENT contributions only. Verified against the edge functions that
+-- actually write submission_log:
+--
+--   counted   song_submit       auto-commit-song/index.ts
+--             song_correction   (labelled in docs/js/my-submissions.js; kept
+--                                so historical//future correction rows count)
+--             tab_submit        create-tab-pr/index.ts
+--             tab_correction    create-tab-pr/index.ts
+--   excluded  flag_report       create-flag-issue  — a report, not content
+--             song_request      create-song-request — an ask, not content
+--             placeholder_request create-song-request — likewise
+--             doc_upload        retired with the doc-staging intake (phase 2d)
+--
+-- Anonymous rows (user_id is null) are dropped: there is nobody to credit.
+
+create or replace function get_leaderboard()
+returns table (
+  rank int,
+  display text,
+  total int,
+  songs int,
+  tabs int,
+  is_you boolean
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+stable
+as $$
+-- RETURNS TABLE names (rank/display/total/songs/tabs/is_you) are also plpgsql
+-- variables; if one ever matches a column in the body, take the column. Every
+-- such reference below is already table-qualified, so this is a guard against
+-- a future edit, not a live fix. (Must precede DECLARE.)
+#variable_conflict use_column
+declare
+  v_salt text;
+  -- 24 x 24 = 576 aliases. Either list can grow independently: the modulo
+  -- below reads array_length(), so nothing needs to stay in sync. Growing a
+  -- list DOES reshuffle every existing alias, which is harmless (nobody is
+  -- promised a stable handle yet) but will look like a mass rename.
+  v_adjectives text[] := array[
+    'Foggy Mountain', 'Lonesome', 'Clinch Mountain', 'High Lonesome',
+    'Gospel', 'Flatpickin''', 'Blue Ridge', 'Rollin''',
+    'Crooked', 'Barn-Burnin''', 'Midnight', 'Whiskey',
+    'Old-Time', 'Hard-Drivin''', 'Shady Grove', 'Salty',
+    'Cripple Creek', 'Back Porch', 'Rusty', 'Thumbpickin''',
+    'Cumberland', 'Wayfarin''', 'Ramblin''', 'Sawmill'
+  ];
+  v_nouns text[] := array[
+    'Willie', 'Rambler', 'Picker', 'Drifter',
+    'Songbird', 'Fiddler', 'Banjoist', 'Hollerer',
+    'Stomper', 'Yodeler', 'Bootlegger', 'Preacher',
+    'Harmonizer', 'Wanderer', 'Crooner', 'Strummer',
+    'Chopper', 'Whistler', 'Traveler', 'Balladeer',
+    'Muleskinner', 'Hobo', 'Troubadour', 'Roustabout'
+  ];
+  v_adj_n int := array_length(v_adjectives, 1);
+  v_noun_n int := array_length(v_nouns, 1);
+begin
+  select s.salt::text into v_salt from leaderboard_salt s where s.id = 1;
+  -- Refuse to run unsalted: an unsalted alias is a join key onto the public
+  -- provenance uuids (see the contract above), so a missing salt row is a
+  -- privacy failure, not a cosmetic one.
+  if v_salt is null then
+    raise exception 'leaderboard_salt is not seeded';
+  end if;
+
+  return query
+  with totals as (
+    select
+      l.user_id,
+      count(*)::int as total,
+      count(*) filter (where l.action in ('song_submit', 'song_correction'))::int as songs,
+      count(*) filter (where l.action in ('tab_submit', 'tab_correction'))::int as tabs
+    from submission_log l
+    where l.user_id is not null
+      and l.action in ('song_submit', 'song_correction', 'tab_submit', 'tab_correction')
+    group by l.user_id
+    having count(*) > 0
+  ),
+  hashed as (
+    select
+      t.*,
+      md5(v_salt || t.user_id::text) as h
+    from totals t
+  ),
+  aliased as (
+    select
+      hh.*,
+      v_adjectives[(get_byte(decode(hh.h, 'hex'), 0) % v_adj_n) + 1]
+        || ' ' ||
+      v_nouns[(get_byte(decode(hh.h, 'hex'), 1) % v_noun_n) + 1] as alias
+    from hashed hh
+  ),
+  disambiguated as (
+    select
+      a.*,
+      -- 576 aliases over a small board still collide occasionally. Append a
+      -- short hash suffix ONLY to the rows that actually collide, so the
+      -- common case stays a clean two-word name. The suffix comes from the
+      -- salted hash, so it is no more linkable than the alias itself.
+      --
+      -- Hex chars 5-6 = digest byte 2, deliberately NOT bytes 0-1: those two
+      -- pick the adjective and the noun, so rows that collide on the alias
+      -- already agree on them mod 24, and a suffix drawn from there would
+      -- have only ~11 distinct values. Byte 2 is independent of the alias,
+      -- so the suffix uses its full 256-value space.
+      case
+        when count(*) over (partition by a.alias) > 1
+          then a.alias || ' #' || substr(a.h, 5, 2)
+        else a.alias
+      end as alias_display
+    from aliased a
+  )
+  select
+    (rank() over (order by d.total desc))::int as rank,
+    coalesce(
+      ident.display_name,
+      case when d.user_id = auth.uid() then u.email end,
+      d.alias_display
+    )::text as display,
+    d.total,
+    d.songs,
+    d.tabs,
+    coalesce(d.user_id = auth.uid(), false) as is_you
+  from disambiguated d
+  left join leaderboard_identities ident on ident.user_id = d.user_id
+  -- auth.users is joined ONLY to resolve the caller's own email. The join is
+  -- narrowed to auth.uid() so no other user's row is even read.
+  left join auth.users u on u.id = d.user_id and u.id = auth.uid()
+  -- Stable ordering without leaking anything: ties break on the salted hash,
+  -- not on a uuid, an email, or a created_at.
+  order by d.total desc, d.h;
+end;
+$$;
+
+-- Callable by signed-in users and by signed-out visitors alike (the board is
+-- public; only the identities behind it are not). Nothing else gets it —
+-- `public` would hand it to every future role by default.
+revoke all on function get_leaderboard() from public;
+grant execute on function get_leaderboard() to anon;
+grant execute on function get_leaderboard() to authenticated;


### PR DESCRIPTION
Contribution leaderboard at #high-scores. Content actions only (songs + tabs; requests/flags score nothing). All privacy enforced inside one security-definer RPC: opt-in named identities (Mike seeded by email lookup), everyone else a stable salted bluegrass alias (salt server-side only — raw uuids are public in works provenance, so unsalted hashes would be linkable), the caller's own row carries their email + is_you. Verified against a real Postgres: anon/authenticated see zero rows of the identity/salt tables while the RPC serves the board; 400-user seed produces zero residual alias collisions. Frontend follows the my-submissions conventions; entry via overflow menu + bounty page link. Migration NOT yet applied — applied via Management API after merge. Ships the alias half of #174. 1754 vitest green.