### PR TITLE
Fix silent tab playback on iOS (unlock AudioContext inside the tap)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -10356,6 +10356,52 @@ body.has-list-context.has-bottomband .container {
     .app-topbar.has-back #auth-section {
         display: none;
     }
+
+    /* Playback band on a phone: ~13 control groups used to WRAP into 4-6
+       rows, a wall of buttons covering the tab with Play buried somewhere
+       inside it. One row that scrolls sideways instead, Play/Stop first so
+       they're never the thing you have to hunt for. */
+    .app-bottomband:has(.tab-controls) {
+        padding: var(--space-sm) 0.5rem;
+    }
+
+    .app-bottomband .tab-controls {
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        overflow-x: auto;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+    }
+
+    .app-bottomband .tab-controls::-webkit-scrollbar {
+        display: none;
+    }
+
+    .app-bottomband .tab-controls > * {
+        flex: 0 0 auto;
+        order: 2;
+    }
+
+    .app-bottomband .tab-controls .tab-play-btn { order: 0; }
+    .app-bottomband .tab-controls .tab-stop-btn { order: 1; }
+
+    /* The strip's overflow-x would clip the key pill's drop-up, so it
+       becomes a sheet pinned above the band instead. */
+    .app-bottomband .tab-controls .pill-popover {
+        position: fixed;
+        top: auto;
+        bottom: 60px;
+        left: 0.5rem;
+        right: 0.5rem;
+        width: auto;
+        max-width: none;
+    }
+
+    /* …and the band itself sits 60px up when the list nav bar is showing */
+    body.has-list-context .app-bottomband .tab-controls .pill-popover {
+        bottom: 120px;
+    }
 }
 
 /* Wanted list on the bounty board */

--- a/docs/js/CLAUDE.md
+++ b/docs/js/CLAUDE.md
@@ -32,6 +32,7 @@ docs/
 │   ├── collections.js  # Landing page collection definitions
 │   ├── analytics.js    # Behavioral analytics tracking
 │   ├── utils.js        # Shared utilities (escapeHtml, etc.)
+│   ├── audio-unlock.js # iOS audio: SYNC resume inside the tap + ringer-switch escape (never await before calling it)
 │   ├── supabase-auth.js # Auth, cloud sync, voting
 │   ├── renderers/      # Part renderers
 │   │   ├── index.js    # Renderer registry

--- a/docs/js/__tests__/audio-unlock.test.js
+++ b/docs/js/__tests__/audio-unlock.test.js
@@ -1,0 +1,42 @@
+// The iOS audio-session shim: ringer-switch escape (audioSession type +
+// silent HTML5 element) and a resume that never awaits first.
+import { describe, it, expect, vi } from 'vitest';
+import { unlockAudioContext, primeAudioSession } from '../audio-unlock.js';
+
+describe('audio unlock', () => {
+    it('promotes the audio session once and resumes the context', () => {
+        const session = { type: 'ambient' };
+        Object.defineProperty(navigator, 'audioSession',
+            { value: session, configurable: true });
+        const plays = vi.fn(() => Promise.resolve());
+        vi.stubGlobal('Audio', class {
+            constructor(src) { this.src = src; plays.mock.src = src; }
+            setAttribute() {}
+            play() { return plays(); }
+        });
+
+        const ctx = { state: 'suspended', resume: vi.fn(() => Promise.resolve()) };
+        expect(unlockAudioContext(ctx)).toBe(ctx);
+
+        // Ring/silent switch mutes the 'ambient' category — get out of it
+        expect(session.type).toBe('playback');
+        expect(plays).toHaveBeenCalledTimes(1);
+        expect(ctx.resume).toHaveBeenCalledTimes(1);
+
+        // Idempotent: the session priming is a one-time promotion, but every
+        // gesture still gets its own resume attempt
+        primeAudioSession();
+        unlockAudioContext(ctx);
+        expect(plays).toHaveBeenCalledTimes(1);
+        expect(ctx.resume).toHaveBeenCalledTimes(2);
+
+        vi.unstubAllGlobals();
+    });
+
+    it('leaves a running context alone and tolerates no context', () => {
+        const ctx = { state: 'running', resume: vi.fn() };
+        unlockAudioContext(ctx);
+        expect(ctx.resume).not.toHaveBeenCalled();
+        expect(unlockAudioContext(null)).toBe(null);
+    });
+});

--- a/docs/js/__tests__/tab-player-lifecycle.test.js
+++ b/docs/js/__tests__/tab-player-lifecycle.test.js
@@ -1,8 +1,27 @@
 // stop()/play() lifecycle: generation invalidation and loop-timer
 // hygiene. No audio here — init is stubbed; these guard the state
 // machine that decides WHETHER audio starts, not the audio itself.
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { TabPlayer } from '../renderers/tab-player.js';
+
+/** A fake AudioContext. `runs: false` never leaves 'suspended' (iOS with a
+ *  spent gesture activation — the clock stays frozen and nothing sounds). */
+function stubAudio({ runs = true } = {}) {
+    const ctx = {
+        state: 'suspended',
+        resume: vi.fn(() => {
+            if (runs) ctx.state = 'running';
+            return Promise.resolve();
+        }),
+    };
+    const ctor = vi.fn(() => ctx);
+    vi.stubGlobal('AudioContext', ctor);
+    // primeAudioSession() plays a silent element; jsdom has no media stack
+    vi.stubGlobal('Audio', class { setAttribute() {} play() { return Promise.resolve(); } });
+    return { ctx, ctor };
+}
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe('TabPlayer lifecycle guards', () => {
     it('stop() invalidates an in-flight play() generation', async () => {
@@ -52,5 +71,48 @@ describe('TabPlayer lifecycle guards', () => {
         expect(restart).not.toHaveBeenCalled();
         expect(p._playGen).toBeGreaterThan(gen);
         vi.useRealTimers();
+    });
+});
+
+describe('TabPlayer iOS audio unlock', () => {
+    it('unlockAudio() creates and resumes the context SYNCHRONOUSLY', () => {
+        // No await anywhere in this test: that is the whole point. iOS grants
+        // Web Audio only transient user activation, so a context built after
+        // an await stays suspended and playback is silent.
+        const { ctx, ctor } = stubAudio();
+        const p = new TabPlayer();
+
+        const got = p.unlockAudio();
+
+        expect(got).toBe(ctx);
+        expect(p.audioContext).toBe(ctx);
+        expect(ctx.resume).toHaveBeenCalled();
+        expect(ctx.state).toBe('running');
+
+        // A second tap reuses the one context
+        p.unlockAudio();
+        expect(ctor).toHaveBeenCalledTimes(1);
+    });
+
+    it('play() fails cleanly when the context never reaches running', async () => {
+        const { ctx } = stubAudio({ runs: false });
+        const p = new TabPlayer();
+        p.resumeGraceMs = 10;
+        // Stand in for init(): unlock + a player stub, no CDN fetch
+        p.init = async () => { p.unlockAudio(); p.player = {}; };
+
+        await expect(p.play({ tracks: [{ id: 't1' }] }))
+            .rejects.toThrow(/blocked/i);
+        expect(ctx.state).toBe('suspended');
+        expect(p.isPlaying).toBe(false);   // no Pause button left hanging
+    });
+
+    it('init() throws instead of half-initializing without Web Audio', async () => {
+        vi.stubGlobal('AudioContext', undefined);
+        vi.stubGlobal('webkitAudioContext', undefined);
+        const p = new TabPlayer();
+
+        await expect(p.init()).rejects.toThrow(/Web Audio/);
+        expect(p.audioContext).toBe(null);
     });
 });

--- a/docs/js/audio-unlock.js
+++ b/docs/js/audio-unlock.js
@@ -1,0 +1,64 @@
+// iOS/Safari audio unlock. WebKit grants only TRANSIENT user activation for
+// Web Audio: the context has to be constructed AND resumed inside the tap's
+// own call stack. One `await` first (a CDN script, a soundfont fetch) and the
+// context stays 'suspended' forever — its clock frozen near 0, so every
+// scheduled note waits for a time that never arrives and playback is silent
+// while the UI happily says it's playing. Everything here is therefore
+// synchronous by design; nothing in this module may await.
+//
+// Second, separate iOS quirk: Web Audio lands in the "ambient" audio session,
+// which the hardware ring/silent switch mutes. HTML5 <audio> is exempt, so
+// playing a silent element (plus opting into the 'playback' session type where
+// supported) promotes the session and keeps the switch out of it.
+
+// 0.025s of 8-bit 8kHz silence — 244 bytes, enough to promote the session.
+const SILENT_WAV = 'data:audio/wav;base64,UklGRuwAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YcgAAACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgA==';
+
+let sessionPrimed = false;
+let silentEl = null;
+
+/**
+ * Promote the page's audio session so the ringer switch doesn't mute us.
+ * Idempotent and synchronous — safe to call from every gesture handler.
+ */
+export function primeAudioSession() {
+    if (sessionPrimed) return;
+    sessionPrimed = true;
+
+    // Safari 16.4+ / Chrome: declare intent directly.
+    try {
+        if (navigator.audioSession) navigator.audioSession.type = 'playback';
+    } catch (e) {
+        // read-only or unsupported value — the silent element below still helps
+    }
+
+    if (typeof Audio !== 'function') return;
+    try {
+        silentEl = new Audio(SILENT_WAV);
+        silentEl.setAttribute('playsinline', '');
+        silentEl.volume = 0.01;
+        silentEl.play()?.catch(() => { /* no activation to spend; harmless */ });
+    } catch (e) {
+        silentEl = null;
+    }
+}
+
+/**
+ * Resume an AudioContext from inside a user gesture. Fires resume() without
+ * awaiting anything first — awaiting is exactly what loses the activation.
+ *
+ * @param {AudioContext} ctx
+ * @returns {AudioContext} the same context, for chaining
+ */
+export function unlockAudioContext(ctx) {
+    if (!ctx) return ctx;
+    primeAudioSession();
+    if (ctx.state === 'suspended') {
+        try {
+            ctx.resume()?.catch(err => console.warn('AudioContext resume failed:', err));
+        } catch (e) {
+            console.warn('AudioContext resume threw:', e);
+        }
+    }
+    return ctx;
+}

--- a/docs/js/chord-explorer/synth.js
+++ b/docs/js/chord-explorer/synth.js
@@ -1,6 +1,8 @@
 // Warm synth module for chord progression explorer
 // Uses Web Audio API with subtractive synthesis
 
+import { unlockAudioContext } from '../audio-unlock.js';
+
 /**
  * ChordSynth - A warm-sounding polyphonic synthesizer
  * Signal chain: Sawtooth → LowPass Filter → ADSR Envelope → Master Gain
@@ -43,10 +45,10 @@ export class ChordSynth {
         const AudioContextClass = window.AudioContext || window.webkitAudioContext;
         this.audioContext = new AudioContextClass();
 
-        // Resume if suspended (required after user interaction)
-        if (this.audioContext.state === 'suspended') {
-            await this.audioContext.resume();
-        }
+        // Resume if suspended (required after user interaction) and promote
+        // the iOS audio session so the ringer switch doesn't mute us. Fires
+        // resume() synchronously — awaiting first spends the tap's activation.
+        unlockAudioContext(this.audioContext);
 
         // Create master gain node
         this.masterGain = this.audioContext.createGain();

--- a/docs/js/otf-editor/editor.js
+++ b/docs/js/otf-editor/editor.js
@@ -16,6 +16,7 @@ import { NoteEntryPopover } from './popover.js';
 import { downloadOTF, cleanupOTF, validateOTF } from './actions.js';
 import { ContextMenu } from './context-menu.js';
 import { EditEventRecorder } from './recorder.js';
+import { unlockAudioContext } from '../audio-unlock.js';
 
 /**
  * OTF Editor - Main entry point
@@ -1138,6 +1139,9 @@ export class OTFEditor {
      * Toggle playback
      */
     async togglePlayback() {
+        // Sync, before any await: iOS only opens/resumes the audio context
+        // inside the gesture's own call stack (audio-unlock.js).
+        this.player?.unlockAudio();
         if (this.isPlaying) {
             this.stop();
         } else {
@@ -1173,6 +1177,7 @@ export class OTFEditor {
      * The verify loop: type a phrase, hear it from right there.
      */
     async playFromCursor() {
+        this.player?.unlockAudio();  // sync, inside the gesture/keystroke
         if (this.isPlaying) {
             this.stop();
             return;
@@ -1187,6 +1192,7 @@ export class OTFEditor {
      * play-from-cursor when there is no selection. Toggles off.
      */
     async loopSelection() {
+        this.player?.unlockAudio();  // sync, inside the gesture/keystroke
         if (this.isPlaying) {
             this.stop();
             return;
@@ -1275,15 +1281,25 @@ export class OTFEditor {
     }
 
     /**
+     * Create/resume the note-feedback AudioContext synchronously.
+     * @returns {AudioContext|null} null when the browser has no Web Audio
+     */
+    _ensureAudioContext() {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return null;
+        if (!this.audioContext) this.audioContext = new Ctx();
+        return unlockAudioContext(this.audioContext);
+    }
+
+    /**
      * Play audio feedback for note entry
      * @param {number} fret - Fret number
      * @param {number} string - String number (1-indexed)
      */
     _playNoteFeedback(fret, string) {
-        // Initialize AudioContext on first use (browser autoplay policy)
-        if (!this.audioContext) {
-            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        }
+        // Note entry IS the gesture: create and resume here, synchronously,
+        // or iOS leaves the context suspended and the pluck is silent.
+        if (!this._ensureAudioContext()) return;
 
         // Get string tuning to calculate pitch
         const track = this.state.getCurrentTrack();

--- a/docs/js/renderers/tab-player.js
+++ b/docs/js/renderers/tab-player.js
@@ -10,6 +10,7 @@ import {
     measureTimingFromOtf,
 } from './measure-timing.js';
 import { pitchedTracks } from './otf-tracks.js';
+import { unlockAudioContext } from '../audio-unlock.js';
 
 // Pitch name to MIDI mapping
 const PITCH_TO_MIDI = {};
@@ -58,6 +59,10 @@ export function getInstrumentKey(instrumentType) {
     return 'guitar';
 }
 
+// How long to wait for a soundfont's buffers to decode before calling it a
+// failure. Slow phones on hotel wifi need room; forever is not an option.
+const DECODE_TIMEOUT_MS = 15000;
+
 /**
  * Load a script dynamically
  */
@@ -70,7 +75,7 @@ function loadScript(url) {
         const script = document.createElement('script');
         script.src = url;
         script.onload = resolve;
-        script.onerror = reject;
+        script.onerror = () => reject(new Error(`Could not load ${url}`));
         document.head.appendChild(script);
     });
 }
@@ -218,6 +223,10 @@ export class TabPlayer {
         this.metronomeVolume = 0.3;
         this.metronomeNodes = [];  // Track oscillators for cleanup on stop
         this.metronomeGain = null; // Master gain: lets the toggle work LIVE
+
+        // How long play() waits for a resumed context to actually reach
+        // 'running' before giving up (tests shorten this).
+        this.resumeGraceMs = 1000;
     }
 
     /**
@@ -237,15 +246,38 @@ export class TabPlayer {
     }
 
     /**
+     * SYNCHRONOUS audio unlock — call this as the FIRST statement of any
+     * user-gesture handler that can lead to playback. iOS WebKit grants Web
+     * Audio only transient user activation, so a context created (or resumed)
+     * after an await never leaves 'suspended': its clock stays frozen, every
+     * note is scheduled into a time that never arrives, and playback is
+     * silent. Nothing here may await (see audio-unlock.js).
+     *
+     * @returns {AudioContext|null} null when the browser has no Web Audio
+     */
+    unlockAudio() {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return null;
+        if (!this.audioContext) this.audioContext = new Ctx();
+        return unlockAudioContext(this.audioContext);
+    }
+
+    /**
      * Initialize audio context and load WebAudioFont
      */
     async init() {
-        if (this.audioContext) return;
+        if (this.player) return;
+
+        // Context FIRST, synchronously: unlockAudio() has normally already
+        // made it inside the tap, but a caller that skipped the gesture hook
+        // still must not construct it after the CDN await below.
+        if (!this.unlockAudio()) {
+            throw new Error('This browser has no Web Audio support.');
+        }
 
         // Load WebAudioFont player
         await loadScript(WEBAUDIOFONT_URLS.player);
 
-        this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
         this.player = new window.WebAudioFontPlayer();
 
         // Master metronome gain — clicks route through this so the
@@ -253,6 +285,26 @@ export class TabPlayer {
         this.metronomeGain = this.audioContext.createGain();
         this.metronomeGain.gain.value = this._metronomeEnabled ? 1 : 0;
         this.metronomeGain.connect(this.audioContext.destination);
+    }
+
+    /**
+     * Wait (briefly) for the context to actually be running, resuming it once
+     * more if needed. iOS ignores a resume() whose gesture activation was
+     * already spent, so this is where a blocked context is caught.
+     * @throws {Error} when the context stays suspended past the grace window
+     */
+    async _awaitRunningContext() {
+        const ctx = this.audioContext;
+        if (ctx.state === 'suspended') {
+            try { await ctx.resume(); } catch (e) { /* reported below */ }
+        }
+        const deadline = Date.now() + this.resumeGraceMs;
+        while (ctx.state !== 'running' && Date.now() < deadline) {
+            await new Promise(r => setTimeout(r, 100));
+        }
+        if (ctx.state !== 'running') {
+            throw new Error('Sound is blocked by this browser — tap Play again.');
+        }
     }
 
     /**
@@ -310,12 +362,18 @@ export class TabPlayer {
             const instrumentData = window[instConfig.var];
             if (!instrumentData) continue;
 
-            await new Promise((resolve) => {
+            // BOUNDED: an undecodable soundfont used to poll forever, which
+            // showed up as a Pause button that never advanced and no error.
+            await new Promise((resolve, reject) => {
                 this.player.adjustPreset(this.audioContext, instrumentData);
+                const deadline = Date.now() + DECODE_TIMEOUT_MS;
                 const checkDecoded = () => {
                     const allDecoded = instrumentData.zones.every(zone => zone.buffer);
                     if (allDecoded) {
                         resolve();
+                    } else if (Date.now() >= deadline) {
+                        reject(new Error(
+                            `Timed out decoding the ${instConfig.name} sound.`));
                     } else {
                         setTimeout(checkDecoded, 50);
                     }
@@ -386,10 +444,11 @@ export class TabPlayer {
         await this.init();
         if (gen !== this._playGen) return;
 
-        if (this.audioContext.state === 'suspended') {
-            await this.audioContext.resume();
-            if (gen !== this._playGen) return;
-        }
+        // A context that never reaches 'running' has a frozen clock: notes
+        // would be scheduled into a time that never arrives (silence with a
+        // Pause button). Throw instead of pretending.
+        await this._awaitRunningContext();
+        if (gen !== this._playGen) return;
 
         // ALL tracks are scheduled; options.trackIds only sets which are
         // AUDIBLE at start. Each track plays through its own gain bus so
@@ -804,7 +863,12 @@ export class TabPlayer {
                     // count-in only on the FIRST pass
                     this._loopTimer = setTimeout(
                         () => this.play(this._loopSource,
-                            { ...options, countInBeats: 0, trackIds: liveIds }), 100);
+                            { ...options, countInBeats: 0, trackIds: liveIds })
+                            .catch(err => {
+                                console.warn('Loop restart failed:', err);
+                                this.stop();
+                                if (this.onPlaybackEnd) this.onPlaybackEnd();
+                            }), 100);
                 } else {
                     this.stop();
                     if (this.onPlaybackEnd) this.onPlaybackEnd();

--- a/docs/js/work-view.js
+++ b/docs/js/work-view.js
@@ -58,6 +58,7 @@ import { buildKeyPill, buildDisplayPill, buildInfoPill, buildExportPill, handleE
 import {
     attachTabPlaybackInteractions, playbackTickForPoint, playbackRangeForMeasures,
 } from './tab-playback-interactions.js';
+import { showToast } from './toast.js';
 
 // ============================================
 // WORK STATE
@@ -2505,18 +2506,28 @@ function setupTablaturePlayer(otf, controls, renderer) {
         playBtn.textContent = '⏸ Pause';
         playBtn.classList.add('playing');
         stopBtn.disabled = false;
-        await player.play(otf, {
-            // Player tempo is quarter-note bpm; the displayed number is
-            // per-beat of the feel, so two feel plays twice as fast.
-            tempo: currentTempo * (twoFeelMode ? 2 : 1),
-            transpose: currentCapo,
-            trackIds: getEnabledTrackIds(),
-            feel: twoFeelMode ? 'two' : null,
-            // Whole-song loop checkbox. A phrase-loop (drag) passes its own
-            // loop:true + range via `extra`, which overrides this.
-            loop: !!loopCheckbox?.checked,
-            ...extra,
-        });
+        try {
+            await player.play(otf, {
+                // Player tempo is quarter-note bpm; the displayed number is
+                // per-beat of the feel, so two feel plays twice as fast.
+                tempo: currentTempo * (twoFeelMode ? 2 : 1),
+                transpose: currentCapo,
+                trackIds: getEnabledTrackIds(),
+                feel: twoFeelMode ? 'two' : null,
+                // Whole-song loop checkbox. A phrase-loop (drag) passes its own
+                // loop:true + range via `extra`, which overrides this.
+                loop: !!loopCheckbox?.checked,
+                ...extra,
+            });
+        } catch (err) {
+            // Blocked audio context, dead soundfont CDN, decode timeout —
+            // say so out loud instead of leaving a Pause button that never
+            // advances.
+            console.error('Tab playback failed:', err);
+            player.stop();
+            showToast(err?.message || 'Could not start playback.',
+                { variant: 'warning', duration: 5000 });
+        }
         // play() can bail (superseded by a newer call, audio context
         // blocked) — reconcile the optimistic button with reality
         if (!player.isPlaying) {
@@ -2629,6 +2640,9 @@ function setupTablaturePlayer(otf, controls, renderer) {
 
     // Play/stop
     playBtn.addEventListener('click', async () => {
+        // FIRST, before any await: iOS only lets us open/resume the audio
+        // context inside the tap's own call stack (tab-player.unlockAudio).
+        player.unlockAudio();
         if (player.isPlaying) {
             player.stop();
             updatePlayLabel();


### PR DESCRIPTION
## Problem
Tab playback works on desktop but is completely silent on mobile (iOS/WebKit): tapping Play flips the button to Pause and nothing ever sounds.

## Root cause (triage-confirmed)
`TabPlayer.init()` constructed its `AudioContext` **after** `await`-ing the WebAudioFont CDN script, and `play()` only reached `resume()` after further awaits. iOS WebKit grants Web Audio only *transient* user activation — the context must be created/resumed synchronously in the tap's call stack — so the context stayed `suspended` with a frozen clock, every note was scheduled into a time that never arrives, and the progress loop spun forever in its count-in branch. Desktop Chrome/Firefox use sticky activation, which is why the identical code worked there. The chord explorer's synth already did this correctly; the tab player and OTF editor inverted the order.

## Fix
- **`tab-player.js`**: synchronous `unlockAudio()` (create + resume, no awaits); `init()` makes the context before the CDN await; `play()` waits a bounded grace for the context to reach `running` and throws instead of scheduling against a dead clock; instrument decode polling gets a 15s timeout (was: infinite spin → stuck Pause button on any CDN hiccup).
- **`audio-unlock.js` (new)**: shared sync unlock + iOS audio-session promotion (`navigator.audioSession.type='playback'` + one silent `<audio>` play) so the iPhone ring/silent switch no longer mutes Web Audio — an independent second cause of 'no sound'.
- **`work-view.js`**: unlock is the first statement of the Play tap handler; playback failures reset the button and show a warning toast.
- **`otf-editor/editor.js`**: same latent bug fixed for editor playback + note-entry preview audio.
- **`chord-explorer/synth.js`**: adopts the shared unlock (ringer-switch coverage; context order was already correct).
- **`style.css`** (`≤640px` media query only): the tab control band was wrapping ~13 control groups into 4–6 rows on a phone, burying Play. It's now a single horizontally scrollable row with Play/Stop ordered first. Desktop rules untouched.

## Desktop impact
None expected: unlock is a no-op when the context is already running, desktop keeps sticky activation semantics, and all CSS changes are inside the existing phone breakpoint. The one behavior change: `play()` now rejects on blocked audio / dead CDN / decode timeout instead of hanging — all callers catch and reset UI.

## Testing
- vitest: 81 files / 1788 tests green (5 new: sync unlock, clean failure on permanently-suspended context, init without Web Audio, session priming idempotence).
- Static-harness browser check of the phone band: 55px single row (was 169px wrapped), Play/Stop visible at row start, key-pill popover unclipped; desktop (1200px) layout unchanged.
- Real-device verification on iPhone pending (that's the point of shipping): test with the ringer switch ON.
