### PR TITLE
Phone tab controls: performance band + settings sheet

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -42,6 +42,11 @@
 
     /* Legacy - keeping for existing usage */
     --btn-label-size: var(--font-sm);
+
+    /* Chrome heights. --bottomband-h is overwritten by shell.js with the
+       band's measured height; --listbar-h is the list nav bar the band
+       stacks on top of. */
+    --listbar-h: 60px;
 }
 
 [data-theme="dark"] {
@@ -10004,8 +10009,11 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     border-top: 1px solid var(--border);
 }
 
+/* --bottomband-h is the band's live height, published by shell.js. The band
+   is no longer a constant (the phone playback strip is taller), so anything
+   stacked on it reads the variable; the fallback covers first paint. */
 body.has-bottomband .container {
-    padding-bottom: 72px;
+    padding-bottom: calc(var(--bottomband-h, 52px) + 20px);
 }
 
 /* Pill: inline disclosure control (replaces bespoke collapsible bars) */
@@ -10265,11 +10273,11 @@ body.chrome-hidden .app-topbar:focus-within {
 
 /* When the list nav bar and the bottom band are both present, stack them */
 body.has-list-context .app-bottomband {
-    bottom: 60px;
+    bottom: var(--listbar-h);
 }
 
 body.has-list-context.has-bottomband .container {
-    padding-bottom: 132px;
+    padding-bottom: calc(var(--bottomband-h, 52px) + var(--listbar-h) + 20px);
 }
 
 /* ============================================
@@ -10357,6 +10365,13 @@ body.has-list-context.has-bottomband .container {
     overflow: visible;
 }
 
+/* The tab settings sheet is phone-only. tab-controls-sheet.js inserts it
+   (and the ⚙ button) only while the media query matches, so the desktop DOM
+   is untouched; this belt-and-braces rule covers the resize instant. */
+.tab-settings-sheet {
+    display: none;
+}
+
 /* Phone song-page band diet: back · logo · Lists · ⋯ (Export/bug/theme/
    auth live in the overflow or on other pages) */
 @media (max-width: 640px) {
@@ -10367,24 +10382,27 @@ body.has-list-context.has-bottomband .container {
     }
 
     /* Playback band on a phone: ~13 control groups used to WRAP into 4-6
-       rows, a wall of buttons covering the tab with Play buried somewhere
-       inside it. One row that scrolls sideways instead, Play/Stop first so
-       they're never the thing you have to hunt for. */
+       rows, then (worse) into a 1468px sideways strip with no scroll
+       affordance — Play/Stop were reachable, tempo and everything past it
+       were not. The band now carries the PERFORMANCE controls only
+       (Play · Stop · tempo · loop · ⚙) and tab-controls-sheet.js re-parents
+       the rest into the settings sheet below. */
+    /* Asymmetric padding: the top gap is where the position readout rides */
     .app-bottomband:has(.tab-controls) {
-        padding: var(--space-sm) 0.5rem;
+        padding: 0.7rem 0.5rem 0.4rem;
+        min-height: 60px;
     }
 
     .app-bottomband .tab-controls {
         flex-wrap: nowrap;
-        justify-content: flex-start;
+        justify-content: center;
+        gap: 0.4rem;
+        /* Safety net only — the five band controls fit 390px. A visible
+           scrollbar is the affordance if a narrower device overflows. */
         overflow-x: auto;
         overflow-y: hidden;
         -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-    }
-
-    .app-bottomband .tab-controls::-webkit-scrollbar {
-        display: none;
+        scrollbar-width: thin;
     }
 
     .app-bottomband .tab-controls > * {
@@ -10394,22 +10412,171 @@ body.has-list-context.has-bottomband .container {
 
     .app-bottomband .tab-controls .tab-play-btn { order: 0; }
     .app-bottomband .tab-controls .tab-stop-btn { order: 1; }
+    .app-bottomband .tab-controls .tab-tempo-group { order: 2; }
+    .app-bottomband .tab-controls .tab-loop-toggle { order: 3; }
+    .app-bottomband .tab-controls .tab-more-btn { order: 4; }
+
+    /* 44px touch targets (the desktop 32px row was 28-33px on a phone) */
+    .app-bottomband .tab-controls .qc-toggle-btn {
+        height: 44px;
+        padding: 0 0.6rem;
+        font-size: 0.9rem;
+        border-radius: var(--radius-md);
+    }
+
+    .app-bottomband .tab-controls .qc-btn {
+        width: 40px;
+        height: 44px;
+        font-size: 1.2rem;
+    }
+
+    .app-bottomband .tab-controls .qc-label {
+        height: 44px;
+        min-width: 26px;
+        padding: 0 0.2rem;
+    }
+
+    .app-bottomband .tab-controls .tab-loop-toggle {
+        height: 44px;
+        padding: 0 0.55rem;
+        border-radius: var(--radius-md);
+    }
+
+    .app-bottomband .tab-controls .tab-more-btn {
+        width: 44px;
+        padding: 0;
+        justify-content: center;
+        font-size: 1.15rem;
+    }
+
+    /* The clock has no room in a five-control row, so it rides the band's
+       top edge instead (empty whenever playback is stopped). */
+    .app-bottomband .tab-controls .tab-position {
+        position: absolute;
+        top: 1px;
+        left: 0;
+        right: 0;
+        min-width: 0;
+        text-align: center;
+        font-size: 0.62rem;
+        line-height: 1;
+        pointer-events: none;
+    }
 
     /* The strip's overflow-x would clip the key pill's drop-up, so it
        becomes a sheet pinned above the band instead. */
-    .app-bottomband .tab-controls .pill-popover {
+    .app-bottomband .tab-controls .pill-popover,
+    .tab-settings-sheet {
         position: fixed;
         top: auto;
-        bottom: 60px;
+        bottom: calc(var(--bottomband-h, 60px) + 8px);
         left: 0.5rem;
         right: 0.5rem;
         width: auto;
         max-width: none;
     }
 
-    /* …and the band itself sits 60px up when the list nav bar is showing */
-    body.has-list-context .app-bottomband .tab-controls .pill-popover {
-        bottom: 120px;
+    /* …and the band itself sits on top of the list nav bar when showing */
+    body.has-list-context .app-bottomband .tab-controls .pill-popover,
+    body.has-list-context .tab-settings-sheet {
+        bottom: calc(var(--bottomband-h, 60px) + var(--listbar-h) + 8px);
+    }
+
+    /* Settings sheet: everything the band gave up, in labeled rows. */
+    .tab-settings-sheet {
+        z-index: 950;
+        display: block;
+        max-height: 62vh;
+        overflow-y: auto;
+        padding: var(--space-sm);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    }
+
+    .tab-sheet-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.4rem 0.15rem;
+    }
+
+    .tab-sheet-row + .tab-sheet-row {
+        border-top: 1px solid var(--border);
+    }
+
+    .tab-sheet-label {
+        flex: 0 0 3.2rem;
+        font-size: var(--font-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-secondary);
+    }
+
+    .tab-sheet-items {
+        display: flex;
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    /* The mixer's band styling (left rule, inline width) makes no sense in
+       a labeled row */
+    .tab-settings-sheet .tab-track-mixer {
+        border-left: none;
+        padding: 0;
+        gap: 0.4rem;
+    }
+
+    .tab-settings-sheet .qc-btn { width: 40px; height: 40px; }
+    .tab-settings-sheet .qc-label { height: 40px; }
+    .tab-settings-sheet .qc-toggle-btn { height: 40px; padding: 0 0.75rem; }
+    .tab-settings-sheet .pill-btn { padding: 0.45rem 0.75rem; }
+    .tab-settings-sheet .pill-mode-btn { padding: 0.5rem 0.7rem; }
+    .tab-settings-sheet .track-toggle,
+    .tab-settings-sheet .tab-metronome-toggle {
+        padding: 0.45rem 0.6rem;
+    }
+
+    /* The count-in label is an unstyled native checkbox everywhere else;
+       in a row of bordered toggles it needs the same outline to read as
+       one of them. */
+    .tab-settings-sheet .tab-countin-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.45rem 0.6rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--bg);
+    }
+
+    /* Drop-ups opened from inside the sheet sit above the sheet itself */
+    .tab-settings-sheet .pill-popover {
+        z-index: 960;
+    }
+}
+
+/* Narrow phones (360px and down): the same five controls, tighter. Keeps
+   the 44px height — only the gaps and side padding give. */
+@media (max-width: 374px) {
+    .app-bottomband .tab-controls {
+        gap: 0.25rem;
+    }
+
+    .app-bottomband .tab-controls .qc-btn {
+        width: 36px;
+    }
+
+    .app-bottomband .tab-controls .qc-toggle-btn {
+        padding: 0 0.45rem;
+    }
+
+    .app-bottomband .tab-controls .tab-more-btn {
+        width: 40px;
     }
 }
 

--- a/docs/js/CLAUDE.md
+++ b/docs/js/CLAUDE.md
@@ -18,6 +18,7 @@ docs/
 │   ├── work-view.js    # THE unified song page (openWork) — all routes land here
 │   ├── song-view.js    # Lead-sheet rendering helpers, ABC notation, list nav
 │   ├── song-controls.js # Pill builders: Key / Display / Info / Export
+│   ├── tab-controls-sheet.js # Phone: re-parents the tab band's non-transport controls into a ⚙ settings sheet
 │   ├── chords.js       # Transposition, Nashville numbers, key detection
 │   ├── tags.js         # Tag dropdown, filtering, virtual instrument tags/facets
 │   ├── title-match.js  # Song-title normalization (bounty board dedupe)
@@ -76,7 +77,20 @@ quick-controls bar, or bottom sheet anymore:
   Pages declare their chrome with `setTopBar({ back, title, actions, overflow, navActive })`.
 - **Bottom band** (`.app-bottomband`): the one home for practice/playback
   controls (tab player transport, track mixer, ABC controls). Mount content
-  with `setBottomBand(el)`; pass `null` to hide it.
+  with `setBottomBand(el)`; pass `null` to hide it. Its height is NOT a
+  constant — the phone tab strip is 65px, a wrapped desktop band is 88px —
+  so shell.js publishes the measured height as `--bottomband-h` on
+  `<html>` (ResizeObserver + on every `setBottomBand`). Anything stacked on
+  the band (drop-up popovers, the tab settings sheet, `.container`'s
+  bottom padding) offsets off that variable, never a literal.
+- **Phone tab band** (`tab-controls-sheet.js`): at ≤640px the band keeps
+  Play / Stop / tempo / loop / ⚙ and the ⚙ sheet holds everything else
+  (size, key, layout, feel, count-in, metronome, mixer, Edit). The controls
+  are MOVED into the sheet, not rebuilt — the sheet lives inside
+  `.tab-controls`, so `controls.querySelector(...)` in
+  `setupTablaturePlayer` and the listeners it attached both survive.
+  Widening the viewport moves them back and deletes the sheet, so the
+  desktop DOM is byte-identical to `createTablatureControls`' output.
 - **Pill primitive**: `pill(label, buildContent, opts)` returns a small
   labeled button that opens a popover. All song-page controls are pills.
 - **Auto-hiding chrome** (`setChromeAutoHide(on)`, enabled on song pages):

--- a/docs/js/__tests__/tab-controls-sheet.test.js
+++ b/docs/js/__tests__/tab-controls-sheet.test.js
@@ -1,0 +1,231 @@
+// Phone settings sheet for the tablature band. The point of the module is
+// that controls are MOVED, not rebuilt — so every test here checks that the
+// listeners work-view.js attached once still fire from the sheet, and that
+// widening the viewport puts the band back exactly as it was.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachTabControlsSheet } from '../tab-controls-sheet.js';
+
+function fakeMedia(matches) {
+    const listeners = [];
+    return {
+        matches,
+        addEventListener: (_type, fn) => listeners.push(fn),
+        removeEventListener: (_type, fn) => {
+            const i = listeners.indexOf(fn);
+            if (i >= 0) listeners.splice(i, 1);
+        },
+        setMatches(v) {
+            this.matches = v;
+            listeners.slice().forEach(fn => fn({ matches: v }));
+        },
+    };
+}
+
+// Mirrors createTablatureControls' markup (a two-track work, so the mixer,
+// repeat group and feel group are all present).
+function buildControls() {
+    const el = document.createElement('div');
+    el.className = 'tab-controls';
+    el.innerHTML = `
+        <div class="qc-group tab-size-group">
+            <button class="tab-size-down qc-btn">−</button>
+            <span class="qc-label">Aa</span>
+            <button class="tab-size-up qc-btn">+</button>
+        </div>
+        <div class="qc-group qc-key-group">
+            <button class="tab-key-down qc-btn">−</button>
+            <div class="pill tab-key-pill"><button class="pill-btn">G</button></div>
+            <button class="tab-key-up qc-btn">+</button>
+        </div>
+        <div class="qc-group tab-tempo-group">
+            <button class="tab-tempo-down qc-btn">−</button>
+            <span class="qc-label tab-tempo-display">100</span>
+            <button class="tab-tempo-up qc-btn">+</button>
+        </div>
+        <button class="tab-play-btn qc-toggle-btn">▶ Play</button>
+        <button class="tab-stop-btn qc-toggle-btn" disabled>⏹ Stop</button>
+        <button class="tab-edit-btn qc-toggle-btn">✏️ Edit</button>
+        <label class="tab-metronome-toggle"><input type="checkbox" class="tab-metronome-checkbox"></label>
+        <label class="tab-countin-toggle"><input type="checkbox" class="tab-countin-checkbox" checked></label>
+        <label class="tab-loop-toggle"><input type="checkbox" class="tab-loop-checkbox"></label>
+        <div class="qc-group pill-mode-group tab-repeat-group"><button class="pill-mode-btn">Unrolled</button></div>
+        <div class="qc-group pill-mode-group tab-feel-group"><button class="pill-mode-btn">Four feel</button></div>
+        <span class="tab-position"></span>
+        <span class="tab-capo-indicator"></span>
+        <div class="tab-track-mixer"><label class="track-toggle"><input type="checkbox" class="track-checkbox" data-track-id="banjo"></label></div>
+    `;
+    document.body.appendChild(el);
+    return el;
+}
+
+const bandClasses = (controls) => [...controls.children]
+    .map(c => c.className)
+    .filter(c => !c.includes('tab-settings-sheet') && !c.includes('tab-more-btn'));
+
+let controls;
+let sheetApi;
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    controls = buildControls();
+});
+
+describe('tab settings sheet — phone', () => {
+    beforeEach(() => {
+        sheetApi = attachTabControlsSheet(controls, fakeMedia(true));
+    });
+
+    it('leaves only the performance controls on the band', () => {
+        const direct = bandClasses(controls);
+        expect(direct.some(c => c.includes('tab-play-btn'))).toBe(true);
+        expect(direct.some(c => c.includes('tab-stop-btn'))).toBe(true);
+        expect(direct.some(c => c.includes('tab-tempo-group'))).toBe(true);
+        expect(direct.some(c => c.includes('tab-loop-toggle'))).toBe(true);
+        expect(direct.some(c => c.includes('tab-position'))).toBe(true);
+        expect(direct.length).toBe(5);
+    });
+
+    it('moves everything else into the sheet', () => {
+        const sheet = controls.querySelector('.tab-settings-sheet');
+        for (const sel of ['.tab-size-group', '.qc-key-group', '.tab-repeat-group',
+            '.tab-feel-group', '.tab-metronome-toggle', '.tab-countin-toggle',
+            '.tab-track-mixer', '.tab-edit-btn', '.tab-capo-indicator']) {
+            expect(sheet.querySelector(sel), sel).toBeTruthy();
+        }
+    });
+
+    it('keeps the controls addressable from the band root', () => {
+        // setupTablaturePlayer queries `controls`, not the band's children
+        expect(controls.querySelector('.tab-size-down')).toBeTruthy();
+        expect(controls.querySelectorAll('.track-checkbox').length).toBe(1);
+    });
+
+    it('preserves listeners across the move', () => {
+        // Fresh controls so the listener predates the re-parent
+        document.body.innerHTML = '';
+        const fresh = buildControls();
+        let clicks = 0;
+        fresh.querySelector('.tab-size-down').addEventListener('click', () => clicks++);
+        attachTabControlsSheet(fresh, fakeMedia(true));
+        fresh.querySelector('.tab-settings-sheet .tab-size-down').click();
+        expect(clicks).toBe(1);
+    });
+
+    it('labels every row it filled and hides the ones it did not', () => {
+        const shown = [...controls.querySelectorAll('.tab-sheet-row:not(.hidden) .tab-sheet-label')]
+            .map(el => el.textContent);
+        expect(shown).toEqual(['Size', 'Key', 'Layout', 'Feel', 'Practice', 'Tracks', 'Tab']);
+
+        document.body.innerHTML = '';
+        const bare = buildControls();
+        bare.querySelector('.tab-track-mixer').remove();
+        bare.querySelector('.tab-feel-group').remove();
+        attachTabControlsSheet(bare, fakeMedia(true));
+        const bareRows = [...bare.querySelectorAll('.tab-sheet-row:not(.hidden) .tab-sheet-label')]
+            .map(el => el.textContent);
+        expect(bareRows).toEqual(['Size', 'Key', 'Layout', 'Practice', 'Tab']);
+    });
+});
+
+describe('tab settings sheet — open/close', () => {
+    let moreBtn;
+    let sheet;
+
+    beforeEach(() => {
+        sheetApi = attachTabControlsSheet(controls, fakeMedia(true));
+        moreBtn = controls.querySelector('.tab-more-btn');
+        sheet = controls.querySelector('.tab-settings-sheet');
+    });
+
+    it('wires aria-expanded and aria-controls', () => {
+        expect(moreBtn.getAttribute('aria-controls')).toBe(sheet.id);
+        expect(moreBtn.getAttribute('aria-expanded')).toBe('false');
+        moreBtn.click();
+        expect(moreBtn.getAttribute('aria-expanded')).toBe('true');
+        expect(sheet.classList.contains('hidden')).toBe(false);
+    });
+
+    it('toggles closed on a second tap', () => {
+        moreBtn.click();
+        moreBtn.click();
+        expect(sheetApi.isOpen()).toBe(false);
+    });
+
+    it('closes on Escape', () => {
+        moreBtn.click();
+        document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(sheetApi.isOpen()).toBe(false);
+    });
+
+    it('closes on an outside click but not an inside one', () => {
+        moreBtn.click();
+        sheet.querySelector('.tab-size-down').click();
+        expect(sheetApi.isOpen()).toBe(true);
+        document.body.click();
+        expect(sheetApi.isOpen()).toBe(false);
+    });
+
+    it('closes when Edit hands the band to the editor', () => {
+        moreBtn.click();
+        sheet.querySelector('.tab-edit-btn').click();
+        expect(sheetApi.isOpen()).toBe(false);
+    });
+});
+
+describe('tab settings sheet — desktop and breakpoint crossing', () => {
+    it('inserts nothing while the media query does not match', () => {
+        const before = [...controls.children];
+        attachTabControlsSheet(controls, fakeMedia(false));
+        expect(controls.querySelector('.tab-settings-sheet')).toBeNull();
+        expect(controls.querySelector('.tab-more-btn')).toBeNull();
+        expect([...controls.children]).toEqual(before);
+    });
+
+    it('restores the exact band DOM when the viewport widens', () => {
+        const before = bandClasses(controls);
+        const mq = fakeMedia(true);
+        attachTabControlsSheet(controls, mq);
+        expect(bandClasses(controls).length).toBe(5);
+
+        mq.setMatches(false);
+        expect(bandClasses(controls)).toEqual(before);
+        expect(controls.querySelector('.tab-settings-sheet')).toBeNull();
+        expect(controls.querySelector('.tab-more-btn')).toBeNull();
+    });
+
+    it('re-collapses when the viewport narrows again, sheet closed', () => {
+        const mq = fakeMedia(false);
+        const api = attachTabControlsSheet(controls, mq);
+        mq.setMatches(true);
+        controls.querySelector('.tab-more-btn').click();
+        expect(api.isOpen()).toBe(true);
+
+        mq.setMatches(false);
+        mq.setMatches(true);
+        expect(api.isOpen()).toBe(false);
+        expect(bandClasses(controls).length).toBe(5);
+    });
+
+    it('keeps checkbox state through a round trip', () => {
+        const mq = fakeMedia(false);
+        attachTabControlsSheet(controls, mq);
+        const box = controls.querySelector('.tab-metronome-checkbox');
+        box.checked = true;
+        mq.setMatches(true);
+        mq.setMatches(false);
+        expect(controls.querySelector('.tab-metronome-checkbox').checked).toBe(true);
+    });
+
+    it('drops the previous band listeners when a re-render replaces it', () => {
+        const first = attachTabControlsSheet(controls, fakeMedia(true));
+        controls.querySelector('.tab-more-btn').click();
+        expect(first.isOpen()).toBe(true);
+
+        const next = buildControls();
+        attachTabControlsSheet(next, fakeMedia(true));
+        // The old handlers are gone, so the orphaned sheet stops reacting
+        document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(first.isOpen()).toBe(true);
+        expect(next.querySelector('.tab-settings-sheet')).toBeTruthy();
+    });
+});

--- a/docs/js/shell.js
+++ b/docs/js/shell.js
@@ -61,6 +61,14 @@ export function initShell({ nav = [], onToggleTheme, onReportBug } = {}) {
     bottomBandEl.className = 'app-bottomband hidden';
     document.body.appendChild(bottomBandEl);
 
+    // The band is no longer a fixed 52px (the phone tab strip is taller, and
+    // it grows again when a settings sheet's controls come home), so anything
+    // stacked on top of it — drop-ups, sheets, body padding — reads its live
+    // height off --bottomband-h instead of a hardcoded offset.
+    if (typeof ResizeObserver !== 'undefined') {
+        new ResizeObserver(syncBandHeight).observe(bottomBandEl);
+    }
+
     actionsEl = topbarEl.querySelector('#topbar-actions');
     titleEl = topbarEl.querySelector('#topbar-title');
     backBtn = topbarEl.querySelector('#topbar-back');
@@ -199,6 +207,14 @@ export function setBottomBand(contentEl) {
         bottomBandEl.classList.add('hidden');
         document.body.classList.remove('has-bottomband');
     }
+    syncBandHeight();
+}
+
+/** Publish the bottom band's live height as --bottomband-h (0 when hidden). */
+function syncBandHeight() {
+    if (!bottomBandEl) return;
+    const h = bottomBandEl.classList.contains('hidden') ? 0 : bottomBandEl.offsetHeight;
+    document.documentElement.style.setProperty('--bottomband-h', `${h}px`);
 }
 
 /**

--- a/docs/js/tab-controls-sheet.js
+++ b/docs/js/tab-controls-sheet.js
@@ -1,0 +1,163 @@
+// Phone layout for the tablature bottom band.
+//
+// The band holds ~14 control groups (1468px of them). On a phone only the
+// performance controls stay on the band — Play, Stop, tempo, loop — and
+// everything else moves into a settings sheet behind a ⚙ button.
+//
+// The controls are MOVED, not rebuilt: every listener is attached once in
+// work-view.js against nodes it found under `.tab-controls`, and appendChild
+// preserves both the listeners and that ancestry (the sheet lives inside
+// `.tab-controls`), so `controls.querySelector('.tab-key-down')` keeps
+// working from either side of the breakpoint.
+
+const PHONE_MQ = '(max-width: 640px)';
+
+// Sheet rows in display order. A row that captures nothing is dropped, so
+// works without a reading list / mixer / feel toggle get a shorter sheet.
+const SHEET_ROWS = [
+    { label: 'Size', selectors: ['.tab-size-group'] },
+    { label: 'Key', selectors: ['.qc-key-group', '.tab-capo-indicator'] },
+    { label: 'Layout', selectors: ['.tab-repeat-group'] },
+    { label: 'Feel', selectors: ['.tab-feel-group'] },
+    { label: 'Practice', selectors: ['.tab-metronome-toggle', '.tab-countin-toggle'] },
+    { label: 'Tracks', selectors: ['.tab-track-mixer'] },
+    { label: 'Tab', selectors: ['.tab-edit-btn'] },
+];
+
+let sheetSeq = 0;
+let activeSheet = null; // one tab band exists at a time; re-render replaces it
+
+/**
+ * Wire the phone settings sheet onto a freshly built `.tab-controls`.
+ * No-op visually on desktop: the More button and sheet are only inserted
+ * while the media query matches, so the wide DOM is byte-identical to
+ * what createTablatureControls returned.
+ *
+ * @param {HTMLElement} controls  the `.tab-controls` element
+ * @param {MediaQueryList} [media]  injectable for tests
+ * @returns {{destroy: () => void, isOpen: () => boolean, setOpen: (b:boolean) => void, mediaChanged: () => void}}
+ */
+export function attachTabControlsSheet(controls, media) {
+    activeSheet?.destroy();
+
+    const mq = media || (typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia(PHONE_MQ)
+        : { matches: false, addEventListener() {}, removeEventListener() {} });
+
+    // Snapshot before anything moves — restoring is "re-append in this order".
+    const bandOrder = [...controls.children];
+
+    const sheetId = `tab-settings-sheet-${++sheetSeq}`;
+
+    const moreBtn = document.createElement('button');
+    moreBtn.type = 'button';
+    moreBtn.className = 'tab-more-btn qc-toggle-btn';
+    moreBtn.textContent = '⚙';
+    moreBtn.title = 'More tab settings';
+    moreBtn.setAttribute('aria-label', 'More tab settings');
+    moreBtn.setAttribute('aria-expanded', 'false');
+    moreBtn.setAttribute('aria-controls', sheetId);
+
+    const sheet = document.createElement('div');
+    sheet.id = sheetId;
+    sheet.className = 'tab-settings-sheet hidden';
+    sheet.setAttribute('role', 'group');
+    sheet.setAttribute('aria-label', 'Tab settings');
+
+    const rows = SHEET_ROWS.map(({ label, selectors }) => {
+        const row = document.createElement('div');
+        row.className = 'tab-sheet-row hidden';
+        const labelEl = document.createElement('span');
+        labelEl.className = 'tab-sheet-label';
+        labelEl.textContent = label;
+        const items = document.createElement('div');
+        items.className = 'tab-sheet-items';
+        row.append(labelEl, items);
+        sheet.appendChild(row);
+        return { row, items, selectors };
+    });
+
+    let inSheet = false;
+
+    const setOpen = (open) => {
+        sheet.classList.toggle('hidden', !open);
+        moreBtn.classList.toggle('active', open);
+        moreBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    };
+
+    const isOpen = () => !sheet.classList.contains('hidden');
+
+    const moveIntoSheet = () => {
+        if (inSheet) return;
+        controls.append(moreBtn, sheet);
+        for (const { row, items, selectors } of rows) {
+            for (const sel of selectors) {
+                // :scope > — only band-level children move; nested matches
+                // (a .qc-btn inside a group) travel with their parent.
+                for (const node of controls.querySelectorAll(`:scope > ${sel}`)) {
+                    items.appendChild(node);
+                }
+            }
+            row.classList.toggle('hidden', items.children.length === 0);
+        }
+        inSheet = true;
+    };
+
+    const moveIntoBand = () => {
+        if (!inSheet) return;
+        setOpen(false);
+        for (const node of bandOrder) controls.appendChild(node);
+        moreBtn.remove();
+        sheet.remove();
+        inSheet = false;
+    };
+
+    const apply = () => (mq.matches ? moveIntoSheet() : moveIntoBand());
+
+    // A re-render swaps in a new `.tab-controls`; the orphaned one's global
+    // listeners have to go with it. (createTablatureControls attaches before
+    // setBottomBand mounts, so "not connected yet" is not "detached".)
+    let everMounted = false;
+    const detachedTeardown = () => {
+        if (controls.isConnected) { everMounted = true; return false; }
+        if (!everMounted) return false;
+        destroy();
+        return true;
+    };
+
+    const onDocClick = (e) => {
+        if (detachedTeardown() || !isOpen()) return;
+        if (!sheet.contains(e.target) && !moreBtn.contains(e.target)) setOpen(false);
+    };
+
+    const onKeyDown = (e) => {
+        if (detachedTeardown()) return;
+        if (e.key === 'Escape' && isOpen()) setOpen(false);
+    };
+
+    moreBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setOpen(!isOpen());
+    });
+
+    // Edit tears the band down and mounts the editor bar — don't leave a
+    // sheet floating over it.
+    sheet.addEventListener('click', (e) => {
+        if (e.target.closest('.tab-edit-btn')) setOpen(false);
+    });
+
+    function destroy() {
+        mq.removeEventListener?.('change', apply);
+        document.removeEventListener('click', onDocClick);
+        document.removeEventListener('keydown', onKeyDown);
+        if (activeSheet?.controls === controls) activeSheet = null;
+    }
+
+    mq.addEventListener?.('change', apply);
+    document.addEventListener('click', onDocClick);
+    document.addEventListener('keydown', onKeyDown);
+    apply();
+
+    activeSheet = { controls, destroy, isOpen, setOpen, mediaChanged: apply };
+    return activeSheet;
+}

--- a/docs/js/work-view.js
+++ b/docs/js/work-view.js
@@ -54,6 +54,7 @@ import { showListPicker, updateTriggerButton } from './list-picker.js';
 import { openFlagModal } from './flags.js';
 import { trackSongView } from './analytics.js';
 import { setTopBar, setBottomBand, pill, setChromeAutoHide } from './shell.js';
+import { attachTabControlsSheet } from './tab-controls-sheet.js';
 import { buildKeyPill, buildDisplayPill, buildInfoPill, buildExportPill, handleExport } from './song-controls.js';
 import {
     attachTabPlaybackInteractions, playbackTickForPoint, playbackRangeForMeasures,
@@ -2285,7 +2286,7 @@ function createTablatureControls(otf, part) {
     const controls = document.createElement('div');
     controls.className = 'tab-controls';
     controls.innerHTML = `
-        <div class="qc-group">
+        <div class="qc-group tab-size-group">
             <button class="tab-size-down qc-btn" title="Decrease size">−</button>
             <span class="qc-label">Aa</span>
             <button class="tab-size-up qc-btn" title="Increase size">+</button>
@@ -2295,7 +2296,7 @@ function createTablatureControls(otf, part) {
             <span class="tab-key-slot"></span>
             <button class="tab-key-up qc-btn" title="Transpose up">+</button>
         </div>
-        <div class="qc-group">
+        <div class="qc-group tab-tempo-group">
             <button class="tab-tempo-down qc-btn" title="Decrease tempo">−</button>
             <span class="qc-label tab-tempo-display">${defaultTempo}</span>
             <button class="tab-tempo-up qc-btn" title="Increase tempo">+</button>
@@ -2356,6 +2357,11 @@ function createTablatureControls(otf, part) {
         step: (delta) => setKeyIdx(keyIdx + delta),
         onChange: (cb) => changeListeners.push(cb),
     };
+
+    // Phone: everything but Play/Stop/tempo/loop moves into a ⚙ sheet. The
+    // nodes stay descendants of `controls`, so the querySelector wiring in
+    // setupTablaturePlayer (which runs after this) is unaffected.
+    attachTabControlsSheet(controls);
 
     return controls;
 }


### PR DESCRIPTION
## Problem
After #246 restored mobile playback, the phone band was a 1468px-wide horizontally scrolling strip in a ~390px viewport with the scrollbar hidden: Play/Stop were visible, but tempo, Edit, metronome, count-in, loop, layout/feel toggles, position readout, and the track mixer were all offscreen with no affordance that scrolling existed. Touch targets were 28–33px.

## Design (measured on a Pixel 9-emulated 400×809 viewport)
- **Band (≤640px)**: performance controls only — Play · Stop · tempo (− bpm +) · loop · ⚙ More. One row, zero overflow at 390px, 44px touch targets. The position clock rides the band's top edge while playing.
- **Settings sheet**: ⚙ toggles a sheet pinned above the band (same idiom as the key pill's drop-up) holding everything else in labeled rows — Size, Key (+capo), Layout (Unrolled/Repeats), Feel (Four/Two), Practice (metronome, count-in), Tracks (mixer), Tab (Edit). Closes on re-tap, outside tap, Escape, or entering Edit. `aria-expanded`/`aria-controls` wired.
- **Re-parent, don't duplicate** (`docs/js/tab-controls-sheet.js`, new): the same DOM nodes move between band and sheet on the breakpoint via `matchMedia`, so listeners and state survive; on desktop the module inserts nothing and the DOM is identical to before.
- **Measured band height**: `shell.js` publishes `--bottomband-h` (ResizeObserver + `setBottomBand`); the previously hardcoded 60/72/120/132px offsets for container padding and drop-up pinning now derive from it, fixing the desktop case where the wrapped 88px band underlapped the old 72px padding.

## Desktop impact
DOM and controls unchanged (verified byte-identical geometry at 1200px against a baseline harness). The one visible change: container bottom padding now tracks the real band height (72 → 108px where the band wraps to two rows), which fixes previously-clipped content rather than altering layout.

## Testing
- vitest: 84 files / 1834 tests green (15 new: re-parent round-trip incl. 1200→390→1200 state retention, listener survival inside the sheet, open/close/Escape/outside-click, aria attributes, teardown on re-render).
- Live verification against a local build at 400×809: band 65px single row (`scrollWidth == clientWidth`), sheet opens above the band with all 7 rows populated, controls fire from inside the sheet (feel toggle updated the tempo display), Escape closes, playback starts. iOS unlock ordering in the Play handler untouched.
- Known trade-offs: 320px devices overflow by ~9px (thin visible scrollbar as affordance); the key drop-up opened from inside the sheet overlays the sheet rather than stacking above it.
