### PR TITLE
Resume 'interrupted' AudioContext after route changes

### DIFF
--- a/docs/js/__tests__/audio-unlock.test.js
+++ b/docs/js/__tests__/audio-unlock.test.js
@@ -39,4 +39,10 @@ describe('audio unlock', () => {
         expect(ctx.resume).not.toHaveBeenCalled();
         expect(unlockAudioContext(null)).toBe(null);
     });
+
+    it("resumes Safari's 'interrupted' state (route change, phone call)", () => {
+        const ctx = { state: 'interrupted', resume: vi.fn(() => Promise.resolve()) };
+        unlockAudioContext(ctx);
+        expect(ctx.resume).toHaveBeenCalledTimes(1);
+    });
 });

--- a/docs/js/__tests__/tab-player-lifecycle.test.js
+++ b/docs/js/__tests__/tab-player-lifecycle.test.js
@@ -6,9 +6,9 @@ import { TabPlayer } from '../renderers/tab-player.js';
 
 /** A fake AudioContext. `runs: false` never leaves 'suspended' (iOS with a
  *  spent gesture activation — the clock stays frozen and nothing sounds). */
-function stubAudio({ runs = true } = {}) {
+function stubAudio({ runs = true, state = 'suspended' } = {}) {
     const ctx = {
-        state: 'suspended',
+        state,
         resume: vi.fn(() => {
             if (runs) ctx.state = 'running';
             return Promise.resolve();
@@ -105,6 +105,18 @@ describe('TabPlayer iOS audio unlock', () => {
             .rejects.toThrow(/blocked/i);
         expect(ctx.state).toBe('suspended');
         expect(p.isPlaying).toBe(false);   // no Pause button left hanging
+    });
+
+    it("_awaitRunningContext() resumes an 'interrupted' context (route change)", async () => {
+        // AirPods disconnecting mid-session parks Safari in 'interrupted',
+        // not 'suspended' — resume() clears it the same way.
+        const { ctx } = stubAudio({ state: 'interrupted' });
+        const p = new TabPlayer();
+        p.audioContext = ctx;
+
+        await p._awaitRunningContext();
+        expect(ctx.resume).toHaveBeenCalled();
+        expect(ctx.state).toBe('running');
     });
 
     it('init() throws instead of half-initializing without Web Audio', async () => {

--- a/docs/js/audio-unlock.js
+++ b/docs/js/audio-unlock.js
@@ -53,7 +53,10 @@ export function primeAudioSession() {
 export function unlockAudioContext(ctx) {
     if (!ctx) return ctx;
     primeAudioSession();
-    if (ctx.state === 'suspended') {
+    // Not just 'suspended': a route change (AirPods disconnecting, a phone
+    // call) parks Safari in the nonstandard 'interrupted' state, which
+    // resume() also clears. 'closed' rejects, which the catch absorbs.
+    if (ctx.state !== 'running') {
         try {
             ctx.resume()?.catch(err => console.warn('AudioContext resume failed:', err));
         } catch (e) {

--- a/docs/js/renderers/tab-player.js
+++ b/docs/js/renderers/tab-player.js
@@ -295,7 +295,9 @@ export class TabPlayer {
      */
     async _awaitRunningContext() {
         const ctx = this.audioContext;
-        if (ctx.state === 'suspended') {
+        if (ctx.state !== 'running') {
+            // 'suspended' or Safari's 'interrupted' (route change, phone
+            // call) — both clear via resume()
             try { await ctx.resume(); } catch (e) { /* reported below */ }
         }
         const deadline = Date.now() + this.resumeGraceMs;


### PR DESCRIPTION
## Problem
Mike hit a transient "Sound is blocked by this browser — tap Play again" toast on iPhone speaker right after disconnecting AirPods. A route change (AirPods off, phone call, Siri) parks Safari's AudioContext in the nonstandard **`interrupted`** state; both the unlock helper and `_awaitRunningContext()` only called `resume()` when the state was `suspended`, so the interrupted context sat un-resumed through the 1s grace window and play() failed honestly. The retry worked because iOS eventually flips the state back on its own.

## Fix
Treat any non-`running` state as resumable in `audio-unlock.js` and `tab-player.js` — `resume()` clears `interrupted` exactly like `suspended`; a `closed` context's rejection is absorbed by the existing catch and still fails through the honest error path.

## Testing
vitest 1836 green, 2 new tests: `unlockAudioContext` resumes an interrupted context; `_awaitRunningContext` resumes and proceeds instead of throwing.