### PR TITLE
Seed the Supabase link at bootstrap

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -69,6 +69,22 @@ if [ -f .env.tpl ] || [ -f analytics/.env.tpl ]; then
     echo ""
 fi
 
+# Seed the Supabase CLI's project link. `supabase/.temp/` is gitignored CLI
+# state, so every new worktree started out unlinked and `supabase db push`
+# failed with "Cannot find project ref" until someone copied the file across by
+# hand. The ref is not a secret — it is the subdomain of the public
+# SUPABASE_URL — so it lives in a tracked file and gets seeded here.
+#
+# The access token and database password are NOT seeded: the CLI caches those
+# per-machine (macOS keychain) after a single `supabase login`, and they are
+# shared across worktrees already.
+if [ -f supabase/project-ref ] && [ ! -f supabase/.temp/project-ref ]; then
+    mkdir -p supabase/.temp
+    cp supabase/project-ref supabase/.temp/project-ref
+    echo "Linked Supabase CLI to project $(cat supabase/project-ref)."
+    echo ""
+fi
+
 # Install dependencies (unless --quick)
 if [ "$QUICK" = false ]; then
     STAGE_START=$SECONDS

--- a/scripts/utility
+++ b/scripts/utility
@@ -38,6 +38,7 @@ show_help() {
     echo ""
     echo "  sync-deleted-songs"
     echo "  sync-promoted-songs"
+    echo "  db-push                 apply pending Supabase migrations (dry-run first)"
     echo "      Sync deleted songs list from Supabase"
     echo "      (requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars)"
     echo ""
@@ -157,6 +158,36 @@ case "$COMMAND" in
         echo ""
         echo "Done! Deleted songs synced and index rebuilt."
         ;;
+    db-push)
+        # Wraps `supabase db push` with the two things that bit us:
+        #   1. A dry run first. It is the only way to see an out-of-order
+        #      migration before it is a surprise — one dated February sorted
+        #      before the last applied one, and a plain push refuses it with a
+        #      message that reads like a failure.
+        #   2. The link, seeded by bootstrap. Without it the CLI reports
+        #      "Cannot find project ref" from any fresh worktree.
+        # Credentials are the CLI's own (`supabase login`, cached per machine),
+        # so nothing secret is read or written here.
+        if [ ! -f supabase/.temp/project-ref ]; then
+            echo "Not linked. Run ./scripts/bootstrap (seeds supabase/.temp/project-ref)."
+            exit 1
+        fi
+        echo "Pending migrations:"
+        if ! supabase migration list 2>/dev/null | awk -F'|' '$1 ~ /[0-9]/ && $2 !~ /[0-9]/ {print "  " $1}' | grep .; then
+            echo "  (none — local and remote agree)"
+            exit 0
+        fi
+        echo ""
+        echo "Dry run:"
+        supabase db push --dry-run 2>&1 | sed 's/^/  /'
+        echo ""
+        echo "Re-run with:  supabase db push            (in-order migrations)"
+        echo "          or:  supabase db push --include-all   (if the dry run asked for it)"
+        echo ""
+        echo "Read the dry run before choosing. --include-all applies EVERY pending"
+        echo "migration, including any that predate the last one already applied."
+        ;;
+
     sync-promoted-songs)
         echo "Fetching promoted songs list from Supabase..."
         uv run python3 scripts/lib/fetch_promoted_songs.py

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -241,3 +241,34 @@ Edge functions require:
 - `GITHUB_REPO` - Repository name (e.g., "Bluegrass-Songbook")
 
 Set via Supabase dashboard > Edge Functions > Secrets.
+
+## Working with migrations from a worktree
+
+`supabase/.temp/` is gitignored CLI state, so a fresh worktree starts unlinked
+and every `supabase` command fails with *"Cannot find project ref"*.
+`scripts/bootstrap` now seeds it from the tracked `supabase/project-ref`. That
+value is not a secret — it is the subdomain of the public `SUPABASE_URL`, which
+every browser request already carries.
+
+The **access token and database password are not** seeded and are not in
+`.env.tpl`. The CLI caches them per machine (macOS keychain) after a single
+`supabase login`, and that cache is shared across worktrees — which is why a
+push works from any worktree once the link is present.
+
+```bash
+./scripts/utility db-push     # lists pending migrations, then dry-runs
+```
+
+Read the dry run before pushing. Two traps it exists to surface:
+
+* **Out-of-order migrations.** A migration dated earlier than the last one
+  already applied is refused by a plain `db push`, with a message that reads
+  like a failure. It needs `--include-all`, which applies *every* pending
+  migration — so check what else comes along for the ride.
+* **Never renumber or edit an applied migration.** Add a new one. Rewriting a
+  file that some environments have run and others haven't is how you get
+  databases that disagree about their own schema.
+
+A timestamp collision is silent and ugly: two files sharing a version prefix is
+ambiguous to the CLI. Check `ls supabase/migrations/ | sed 's/_.*//' | uniq -d`
+before naming a new one.

--- a/supabase/project-ref
+++ b/supabase/project-ref
@@ -1,0 +1,1 @@
+ofmqlrnyldlmvggihogt


### PR DESCRIPTION
`supabase/.temp/` is gitignored CLI state, so every new worktree starts unlinked and any `supabase` command fails with *"Cannot find project ref"*. That's what actually blocked the migration push earlier — not a missing credential, as I first reported.

The access token and DB password were already cached in the macOS keychain from an earlier `supabase login`, and that cache is shared across worktrees. Only the per-directory link was absent. So the fix is small, and the plumbing I was about to propose (`op://` refs for a token and DB password in `.env.tpl`) would have been machinery for a problem that doesn't exist on this machine.

## Changes

- `supabase/project-ref` — tracked. Not a secret: it's the subdomain of the public `SUPABASE_URL` that every browser request already carries.
- `scripts/bootstrap` seeds `supabase/.temp/project-ref` from it, idempotently.
- `./scripts/utility db-push` — lists pending migrations, then dry-runs, before anything happens.
- `supabase/CLAUDE.md` documents the workflow and the traps.

## Why the dry-run wrapper

Both traps it surfaces are ones this session hit:

- A February migration sorted *before* the last applied one. A plain `db push` refuses it with a message that reads like a failure; it needs `--include-all`, which applies **every** pending migration — worth seeing the list first.
- A timestamp collision, which I created by picking a round number without checking what was already there.

Plus the rule that earned itself: never edit or renumber an applied migration, add a new one.