### PR TITLE
Inject secrets at run time instead of writing them to disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,13 @@ work still resolves by direct URL and can be restored to search — see
 ./scripts/utility build-posts        # Build blog posts manifest
 ```
 
+## Secrets
+
+Never written to disk. `.env.tpl` holds 1Password `op://` references (committed);
+values are injected per-command by `scripts/lib/with-secrets`, which
+`./scripts/utility` already uses for everything needing them. Run `op signin`
+once per session. Details in `scripts/lib/CLAUDE.md`.
+
 ## CRITICAL: Cost Controls
 
 **NEVER submit paid API calls without explicit user confirmation.** This includes:

--- a/analytics/scripts/server
+++ b/analytics/scripts/server
@@ -50,7 +50,11 @@ echo "Dashboard will open at: http://localhost:$PORT/notebooks/dashboard.ipynb"
 echo ""
 
 cd "$REPO_ROOT"
-uv run --extra analytics jupyter notebook \
+# Secrets reach the notebook through the environment (1Password injection),
+# not through analytics/.env — the dashboard reads a service-role key, and a
+# plaintext copy per worktree is the exposure this avoids.
+./scripts/lib/with-secrets --tpl analytics/.env.tpl -- \
+    uv run --extra analytics jupyter notebook \
     --notebook-dir="$ANALYTICS_ROOT" \
     --port="$PORT" \
     --no-browser \

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -41,31 +41,35 @@ done
 echo "=== Bluegrass Songbook Bootstrap ==="
 echo ""
 
-# Materialize secrets from 1Password. Templates (*.env.tpl) hold op://
-# references only; real values come from the "API Keys" vault via the
-# 1Password CLI. Non-fatal if op is unavailable — secrets are only needed
-# for the analytics dashboard and a few local maintenance scripts.
-materialize_secret() {
-    local tpl="$1" out="$2"
-    [ -f "$tpl" ] || return 0
-    [ -f "$out" ] && return 0  # never clobber an existing .env
-    if ! command -v op >/dev/null 2>&1; then
-        echo "  ⚠ 1Password CLI (op) not found; skipped $out (see $tpl)."
-        return 0
-    fi
-    if op inject -i "$tpl" -o "$out" 2>/dev/null; then
-        chmod 600 "$out"
-        echo "  $out created from 1Password."
+# Secrets are NOT materialized to disk. `scripts/lib/with-secrets` injects them
+# into a command's environment with `op run` at the moment it runs, so
+# SUPABASE_SERVICE_ROLE_KEY — a key that bypasses every RLS policy — stops
+# living in plaintext in every worktree. Templates (*.env.tpl) hold op://
+# references only and stay committed.
+#
+# A .env is still honoured if one exists (machines without `op`, and CI, where
+# secrets arrive as real environment variables). But once 1Password is
+# reachable there is nothing for it to do, so a stale one is cleared rather
+# than left lying around. It is regenerable at any time:
+#     op inject -i .env.tpl -o .env
+if command -v op >/dev/null 2>&1; then
+    if op whoami >/dev/null 2>&1; then
+        for stale in .env analytics/.env; do
+            if [ -f "$stale" ]; then
+                rm -f "$stale"
+                echo "Removed $stale — secrets now come from 1Password at run time."
+            fi
+        done
+    elif [ -f .env ] || [ -f analytics/.env ]; then
+        echo "⚠ 1Password is locked; keeping the existing .env as a fallback."
+        echo "  Run 'op signin', then re-run bootstrap to clear it."
     else
-        rm -f "$out"  # remove any partial/empty output
-        echo "  ⚠ Could not read secrets (run 'op signin'); skipped $out."
+        echo "⚠ 1Password is locked. Run 'op signin' before commands that need secrets."
     fi
-}
-
-if [ -f .env.tpl ] || [ -f analytics/.env.tpl ]; then
-    echo "Provisioning secrets from 1Password..."
-    materialize_secret ".env.tpl" ".env"
-    materialize_secret "analytics/.env.tpl" "analytics/.env"
+    echo ""
+elif [ ! -f .env ]; then
+    echo "⚠ 1Password CLI (op) not found and no .env present."
+    echo "  Commands needing secrets will fail; see .env.tpl."
     echo ""
 fi
 

--- a/scripts/lib/CLAUDE.md
+++ b/scripts/lib/CLAUDE.md
@@ -26,6 +26,37 @@ sources/*/parsed/*.pro  →  migrate_to_works.py  →  works/
 - `curate.py` - Convergence CLI for the curation registry
 - `build_index.py` - LEGACY: Builds from sources/ (kept for reference)
 
+## Secrets
+
+Nothing secret is written to disk. `.env.tpl` files hold 1Password `op://`
+references and are committed; the real values are injected into a command's
+environment at the moment it runs:
+
+```bash
+./scripts/lib/with-secrets -- uv run python3 scripts/lib/fetch_deleted_songs.py
+./scripts/lib/with-secrets --tpl analytics/.env.tpl -- <command>
+```
+
+`./scripts/utility` already routes the commands that need secrets through it —
+the sync commands, genre-suggestion export, Strum Machine matching, LLM
+tagging — and `analytics/scripts/server` launches Jupyter the same way. If you
+add a script that reads `SUPABASE_SERVICE_ROLE_KEY`, `ANTHROPIC_API_KEY` or
+`STRUM_MACHINE_API_KEY`, wrap its call site too.
+
+Why: `SUPABASE_SERVICE_ROLE_KEY` bypasses every RLS policy in the project.
+`op inject -o .env` used to leave a plaintext copy in each worktree — five
+worktrees, five copies at rest, none of them expiring. Injection at run time
+means it exists only for the life of the process, and 1Password decides whether
+to hand it over.
+
+`with-secrets` falls back in order: 1Password if signed in, then an existing
+`.env` (machines without `op`, and CI, where secrets arrive as real environment
+variables), then whatever is already exported. `scripts/bootstrap` deletes a
+stale `.env` once 1Password is reachable, since it is then redundant —
+regenerate one any time with `op inject -i .env.tpl -o .env`.
+
+Sign in once per session with `op signin`.
+
 ## Local vs CI Operations
 
 Some operations require external APIs/databases and only run locally. Others run everywhere.

--- a/scripts/lib/with-secrets
+++ b/scripts/lib/with-secrets
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# with-secrets - run a command with the repo's secrets in its environment
+#
+#   ./scripts/lib/with-secrets [--tpl FILE] -- <command> [args...]
+#
+# Prefers 1Password injection (`op run`), which puts secrets in the child
+# process's environment and never writes them to disk. The alternative — the
+# old `op inject -o .env` — left SUPABASE_SERVICE_ROLE_KEY, a key that bypasses
+# every RLS policy in the project, sitting in plaintext in every worktree.
+#
+# Order of preference:
+#   1. `op run` when the 1Password CLI is signed in. Nothing touches disk.
+#   2. An existing .env, sourced. Kept for machines without `op` and for CI,
+#      where secrets arrive as real environment variables anyway.
+#   3. Already-exported variables (CI). If the command's needs are already in
+#      the environment, neither of the above is required.
+#
+# Exits with the command's own status, so callers can rely on it.
+
+set -euo pipefail
+
+TPL=".env.tpl"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --tpl) TPL="$2"; shift 2 ;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+
+if [ $# -eq 0 ]; then
+    echo "with-secrets: no command given" >&2
+    exit 64
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# 1Password, if it is available AND unlocked. `op whoami` is the cheap probe;
+# checking first means we pick a path once, rather than running the command,
+# failing, and risking running it twice.
+if command -v op >/dev/null 2>&1 && [ -f "$TPL" ] && op whoami >/dev/null 2>&1; then
+    exec op run --env-file="$TPL" -- "$@"
+fi
+
+# A materialized .env. Legacy path — still correct, just less private.
+ENV_FILE="${TPL%.tpl}"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+    exec "$@"
+fi
+
+# Nothing to inject. That is fine when the caller already has what it needs —
+# CI exports secrets directly — so run the command and let it report its own
+# missing-variable error rather than second-guessing which vars it wants.
+if command -v op >/dev/null 2>&1 && [ -f "$TPL" ]; then
+    echo "with-secrets: 1Password is locked; run 'op signin' for secret-backed commands." >&2
+fi
+exec "$@"

--- a/scripts/utility
+++ b/scripts/utility
@@ -142,7 +142,7 @@ case "$COMMAND" in
         ;;
     sync-tag-votes)
         echo "Fetching tag overrides from trusted user votes..."
-        uv run python3 scripts/lib/fetch_tag_overrides.py
+        ./scripts/lib/with-secrets -- uv run python3 scripts/lib/fetch_tag_overrides.py
         echo ""
         echo "Rebuilding index..."
         ./scripts/bootstrap --quick
@@ -151,7 +151,7 @@ case "$COMMAND" in
         ;;
     sync-deleted-songs)
         echo "Fetching deleted songs list from Supabase..."
-        uv run python3 scripts/lib/fetch_deleted_songs.py
+        ./scripts/lib/with-secrets -- uv run python3 scripts/lib/fetch_deleted_songs.py
         echo ""
         echo "Rebuilding index..."
         ./scripts/bootstrap --quick
@@ -190,7 +190,7 @@ case "$COMMAND" in
 
     sync-promoted-songs)
         echo "Fetching promoted songs list from Supabase..."
-        uv run python3 scripts/lib/fetch_promoted_songs.py
+        ./scripts/lib/with-secrets -- uv run python3 scripts/lib/fetch_promoted_songs.py
         echo ""
         echo "Rebuilding index..."
         ./scripts/bootstrap --quick
@@ -239,7 +239,7 @@ case "$COMMAND" in
         ;;
     export-suggestions)
         echo "Exporting genre suggestions from Supabase..."
-        uv run python3 scripts/lib/export_genre_suggestions.py
+        ./scripts/lib/with-secrets -- uv run python3 scripts/lib/export_genre_suggestions.py
         ;;
     build-posts)
         echo "Building posts manifest..."
@@ -257,13 +257,13 @@ case "$COMMAND" in
             echo "Usage: ./scripts/utility strum-machine-test \"Song Title\""
             exit 1
         fi
-        uv run python3 -m scripts.lib.strum_machine "$@"
+        ./scripts/lib/with-secrets -- uv run python3 -m scripts.lib.strum_machine "$@"
         ;;
     strum-machine-match)
         echo "Matching all songs against Strum Machine..."
         echo "(This will take ~30 minutes for 17k songs at 10 req/sec)"
         echo ""
-        uv run python3 -m scripts.lib.strum_machine --batch
+        ./scripts/lib/with-secrets -- uv run python3 -m scripts.lib.strum_machine --batch
         ;;
     search)
         if [ -z "$1" ]; then


### PR DESCRIPTION
`SUPABASE_SERVICE_ROLE_KEY` bypasses every RLS policy in the project, and bootstrap's `op inject -o .env` left a plaintext copy in every worktree — five worktrees, five copies at rest, none expiring.

**Nothing was ever committed.** `.env` is gitignored and has never been added in any branch (verified with `--diff-filter=A` across `--all`), and the only JWT in tracked frontend code decodes to `role: anon`, which is public by design. This is about exposure on disk, not in git.

## How it works now

`scripts/lib/with-secrets` runs a command under `op run`, so values exist only for the life of that process and 1Password decides whether to hand them over.

```bash
./scripts/lib/with-secrets -- uv run python3 scripts/lib/fetch_deleted_songs.py
./scripts/lib/with-secrets --tpl analytics/.env.tpl -- <command>
```

Wired into every caller that needs secrets: the three sync commands, genre-suggestion export, Strum Machine matching and batch tagging in `scripts/utility`, plus the Jupyter launch in `analytics/scripts/server`, which reads a service-role key of its own.

## Nothing breaks

`with-secrets` falls back in order — 1Password when signed in, then an existing `.env` (machines without `op`, and CI where secrets arrive as real environment variables), then whatever is already exported. Both consumption patterns survive: scripts reading `os.environ` get the injected values, and `strum_machine.py`'s `load_dotenv(override=False)` no-ops harmlessly when the file is gone.

`bootstrap` no longer materializes `.env`, and clears a stale one **only once 1Password is reachable** — redundant at that point, and regenerable with `op inject -i .env.tpl -o .env`. While 1Password is locked the existing file is kept, so nobody is stranded mid-session.

pytest 630, vitest 1819.