### PR TITLE
Make the sync scripts fail instead of serving a stale cache

### DIFF
--- a/scripts/lib/CLAUDE.md
+++ b/scripts/lib/CLAUDE.md
@@ -74,6 +74,13 @@ Some operations require external APIs/databases and only run locally. Others run
 | **Genre suggestions export** | Scheduled CI + local | `user_genre_suggestions.json` | same workflow as tag overrides, or `./scripts/utility export-suggestions`; review-only, never auto-applied |
 | **TuneArch fetch** | Local only | - | Fetches new instrumentals |
 
+**A sync that cannot reach Supabase fails.** `fetch_deleted_songs.py`,
+`fetch_promoted_songs.py` and `fetch_tag_overrides.py` exit non-zero rather
+than warning and serving the on-disk copy — a broken sync used to look like a
+successful one and let the build ship stale data. `scripts/lib/supabase_client.py`
+holds the shared connect/fail logic, including telling a genuinely missing
+`supabase` package apart from a broken dependency inside it.
+
 **How caching works:**
 1. Run local command to populate cache (e.g., `refresh-tags`, `strum-machine-match`)
 2. Commit the cache file to git

--- a/scripts/lib/fetch_deleted_songs.py
+++ b/scripts/lib/fetch_deleted_songs.py
@@ -14,28 +14,20 @@ Or via the utility script:
 
 import json
 import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from supabase_client import connect, fetch_failed  # noqa: E402
 
 
 def fetch_deleted_songs():
     """Fetch deleted song IDs from Supabase."""
     cache_file = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'deleted_songs.json'
 
-    supabase_url = os.environ.get('SUPABASE_URL')
-    supabase_key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_KEY')
-
-    if not supabase_url or not supabase_key:
-        print("Warning: SUPABASE_URL or SUPABASE_KEY not set, using cached deleted_songs.json")
-        return load_cached_deleted_songs()
+    client = connect('deleted songs')
 
     try:
-        from supabase import create_client
-    except ImportError:
-        print("Warning: supabase-py not installed, using cached deleted_songs.json")
-        return load_cached_deleted_songs()
-
-    try:
-        client = create_client(supabase_url, supabase_key)
 
         # Fetch all deleted songs
         result = client.table('deleted_songs').select('song_id, deleted_at, reason').execute()
@@ -55,23 +47,9 @@ def fetch_deleted_songs():
         print(f"Fetched {len(deleted)} deleted songs, saved to {cache_file}")
         return deleted
 
-    except Exception as e:
-        print(f"Warning: Failed to fetch from Supabase: {e}")
-        return load_cached_deleted_songs()
+    except Exception as exc:                       # noqa: BLE001
+        fetch_failed('deleted songs', exc)
 
-
-def load_cached_deleted_songs():
-    """Load deleted songs from cache file."""
-    cache_file = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'deleted_songs.json'
-
-    if cache_file.exists():
-        with open(cache_file) as f:
-            data = json.load(f)
-            print(f"Loaded {len(data)} deleted songs from cache")
-            return data
-
-    print("No deleted songs cache found")
-    return {}
 
 
 if __name__ == '__main__':

--- a/scripts/lib/fetch_promoted_songs.py
+++ b/scripts/lib/fetch_promoted_songs.py
@@ -16,28 +16,20 @@ Or via the utility script:
 
 import json
 import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from supabase_client import connect, fetch_failed  # noqa: E402
 
 
 def fetch_promoted_songs():
     """Fetch promoted song IDs from Supabase."""
     cache_file = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'promoted_songs.json'
 
-    supabase_url = os.environ.get('SUPABASE_URL')
-    supabase_key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_KEY')
-
-    if not supabase_url or not supabase_key:
-        print("Warning: SUPABASE_URL or SUPABASE_KEY not set, using cached promoted_songs.json")
-        return load_cached_promoted_songs()
+    client = connect('promoted songs')
 
     try:
-        from supabase import create_client
-    except ImportError:
-        print("Warning: supabase-py not installed, using cached promoted_songs.json")
-        return load_cached_promoted_songs()
-
-    try:
-        client = create_client(supabase_url, supabase_key)
 
         # Fetch all promoted songs
         result = client.table('promoted_songs').select('song_id, promoted_at, reason').execute()
@@ -57,23 +49,9 @@ def fetch_promoted_songs():
         print(f"Fetched {len(promoted)} promoted songs, saved to {cache_file}")
         return promoted
 
-    except Exception as e:
-        print(f"Warning: Failed to fetch from Supabase: {e}")
-        return load_cached_promoted_songs()
+    except Exception as exc:                       # noqa: BLE001
+        fetch_failed('promoted songs', exc)
 
-
-def load_cached_promoted_songs():
-    """Load promoted songs from cache file."""
-    cache_file = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'promoted_songs.json'
-
-    if cache_file.exists():
-        with open(cache_file) as f:
-            data = json.load(f)
-            print(f"Loaded {len(data)} promoted songs from cache")
-            return data
-
-    print("No promoted songs cache found")
-    return {}
 
 
 if __name__ == '__main__':

--- a/scripts/lib/fetch_tag_overrides.py
+++ b/scripts/lib/fetch_tag_overrides.py
@@ -17,28 +17,18 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from supabase_client import connect, fetch_failed  # noqa: E402
+
 # Output file
 OUTPUT_FILE = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'tag_overrides.json'
 
 def fetch_tag_overrides():
     """Fetch trusted user tag downvotes from Supabase."""
 
-    # Get Supabase credentials from environment
-    supabase_url = os.environ.get('SUPABASE_URL')
-    supabase_key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_KEY')
-
-    if not supabase_url or not supabase_key:
-        print("Warning: SUPABASE_URL or SUPABASE_KEY not set, using cached tag_overrides.json")
-        return None
+    client = connect('tag overrides')
 
     try:
-        from supabase import create_client
-    except ImportError:
-        print("Warning: supabase-py not installed, using cached tag_overrides.json")
-        return None
-
-    try:
-        client = create_client(supabase_url, supabase_key)
 
         # Get trusted user IDs
         trusted_response = client.table('trusted_users').select('user_id').execute()
@@ -57,9 +47,8 @@ def fetch_tag_overrides():
 
         return votes_response.data
 
-    except Exception as e:
-        print(f"Warning: Could not fetch from Supabase: {e}")
-        return None
+    except Exception as exc:                       # noqa: BLE001
+        fetch_failed('tag overrides', exc)
 
 
 def main():
@@ -67,15 +56,10 @@ def main():
 
     overrides = fetch_tag_overrides()
 
-    if overrides is None:
-        # Use existing cache
-        if OUTPUT_FILE.exists():
-            with open(OUTPUT_FILE) as f:
-                data = json.load(f)
-            print(f"Using cached tag_overrides.json ({len(data.get('exclude', {}))} songs with exclusions)")
-            return
-        else:
-            overrides = []
+    # fetch_tag_overrides() either returns rows or exits; it no longer
+    # signals failure with None and leaves the caller to reuse the cache.
+    # A sync that silently kept stale data reported success while the site
+    # served yesterday's answer.
 
     # Convert to {song_id: [excluded_tags]} format
     exclude_by_song = {}

--- a/scripts/lib/supabase_client.py
+++ b/scripts/lib/supabase_client.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Shared Supabase connection for the sync scripts.
+
+These scripts exist to *fetch* — the caller has asked for fresh data. So a
+failure to reach Supabase must be an error, not a warning. They used to print
+one and fall back to the on-disk cache, which meant a broken sync looked like a
+successful one and the build shipped stale data: a promotion made in the UI
+could silently never reach the site.
+
+`except ImportError` around `from supabase import ...` was its own trap. It
+catches anything raised while importing the package *or its dependencies*, so a
+broken sub-dependency was reported as "supabase-py not installed" — sending you
+to reinstall a package that was already there. `ModuleNotFoundError.name` tells
+the two apart.
+"""
+
+import os
+import sys
+
+
+def connect(what: str):
+    """Return a Supabase client, or exit non-zero explaining why not.
+
+    `what` names the thing being fetched, for the error message.
+    """
+    url = os.environ.get('SUPABASE_URL')
+    key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_KEY')
+
+    if not url or not key:
+        print(f"Error: cannot fetch {what} — Supabase credentials are not set.")
+        print("  Needs SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.")
+        print("  Locally these are injected from 1Password; if that is failing:")
+        print("    op signin")
+        print("  or fall back to a file:  op inject -i .env.tpl -o .env")
+        sys.exit(1)
+
+    try:
+        from supabase import create_client
+    except ImportError as exc:
+        missing = getattr(exc, 'name', None)
+        if missing in (None, 'supabase'):
+            print(f"Error: cannot fetch {what} — the supabase package is not installed.")
+            print("  Run: uv sync")
+        else:
+            # The package is present; something it imports is not. Saying "not
+            # installed" here would send you to reinstall the wrong thing.
+            print(f"Error: cannot fetch {what} — supabase is installed but "
+                  f"'{missing}' failed to import ({exc}).")
+            print("  The dependency tree is broken, not the package. Try: uv sync --reinstall")
+        sys.exit(1)
+
+    try:
+        return create_client(url, key)
+    except Exception as exc:                       # noqa: BLE001
+        print(f"Error: cannot fetch {what} — could not connect to Supabase: {exc}")
+        sys.exit(1)
+
+
+def fetch_failed(what: str, exc: Exception):
+    """Report a failed query and exit. Never falls back to the cache."""
+    print(f"Error: failed to fetch {what} from Supabase: {exc}")
+    print("  Refusing to fall back to the cached copy — that would let a build")
+    print("  ship stale data while reporting success.")
+    sys.exit(1)

--- a/tests/test_supabase_sync.py
+++ b/tests/test_supabase_sync.py
@@ -1,0 +1,113 @@
+"""The sync scripts must fail loudly rather than serve a stale cache.
+
+They used to warn and fall back to the on-disk copy, so a broken sync looked
+like a successful one and the build shipped yesterday's data — a promotion made
+in the UI could silently never reach the site.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'scripts' / 'lib'))
+
+import supabase_client  # noqa: E402
+import fetch_promoted_songs as fps  # noqa: E402
+
+
+class TestConnect:
+    def test_exits_without_credentials(self, monkeypatch):
+        monkeypatch.delenv('SUPABASE_URL', raising=False)
+        monkeypatch.delenv('SUPABASE_SERVICE_ROLE_KEY', raising=False)
+        monkeypatch.delenv('SUPABASE_KEY', raising=False)
+        with pytest.raises(SystemExit) as e:
+            supabase_client.connect('widgets')
+        assert e.value.code == 1
+
+    def test_names_the_missing_package_when_it_is_missing(self, monkeypatch, capsys):
+        monkeypatch.setenv('SUPABASE_URL', 'https://x.supabase.co')
+        monkeypatch.setenv('SUPABASE_SERVICE_ROLE_KEY', 'k')
+        real = __builtins__['__import__'] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def boom(name, *a, **kw):
+            if name == 'supabase':
+                raise ModuleNotFoundError("No module named 'supabase'", name='supabase')
+            return real(name, *a, **kw)
+
+        monkeypatch.setattr('builtins.__import__', boom)
+        with pytest.raises(SystemExit):
+            supabase_client.connect('widgets')
+        assert 'not installed' in capsys.readouterr().out
+
+    def test_distinguishes_a_broken_dependency_from_a_missing_package(self, monkeypatch, capsys):
+        # `except ImportError` around the supabase import also catches failures
+        # from its dependency tree. Reporting those as "not installed" sent you
+        # to reinstall a package that was already there.
+        monkeypatch.setenv('SUPABASE_URL', 'https://x.supabase.co')
+        monkeypatch.setenv('SUPABASE_SERVICE_ROLE_KEY', 'k')
+        real = __builtins__['__import__'] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def boom(name, *a, **kw):
+            if name == 'supabase':
+                raise ModuleNotFoundError("No module named 'httpx'", name='httpx')
+            return real(name, *a, **kw)
+
+        monkeypatch.setattr('builtins.__import__', boom)
+        with pytest.raises(SystemExit):
+            supabase_client.connect('widgets')
+        out = capsys.readouterr().out
+        assert 'httpx' in out and 'not installed' not in out
+
+
+class FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeTable:
+    def __init__(self, rows, fail=False):
+        self._rows, self._fail = rows, fail
+
+    def select(self, *_):
+        return self
+
+    def execute(self):
+        if self._fail:
+            raise RuntimeError('connection reset')
+        return FakeResult(self._rows)
+
+
+class FakeClient:
+    def __init__(self, rows, fail=False):
+        self._rows, self._fail = rows, fail
+
+    def table(self, _name):
+        return FakeTable(self._rows, self._fail)
+
+
+class TestFetchPromoted:
+    def test_success_writes_the_cache(self, monkeypatch, tmp_path):
+        # The script derives the cache path from its own __file__, so point
+        # that into tmp and let the real path logic run.
+        fake_lib = tmp_path / 'scripts' / 'lib'
+        fake_lib.mkdir(parents=True)
+        monkeypatch.setattr(fps, '__file__', str(fake_lib / 'fetch_promoted_songs.py'))
+        monkeypatch.setattr(fps, 'connect', lambda _what: FakeClient(
+            [{'song_id': 'cripple-creek', 'promoted_at': 'now', 'reason': 'canon'}]))
+
+        result = fps.fetch_promoted_songs()
+
+        assert result['cripple-creek']['reason'] == 'canon'
+        written = json.loads((tmp_path / 'docs' / 'data' / 'promoted_songs.json').read_text())
+        assert written['cripple-creek']['promoted_at'] == 'now'
+
+    def test_query_failure_exits_and_does_not_serve_cache(self, monkeypatch, capsys):
+        monkeypatch.setattr(fps, 'connect', lambda _what: FakeClient([], fail=True))
+        with pytest.raises(SystemExit) as e:
+            fps.fetch_promoted_songs()
+        assert e.value.code == 1
+        out = capsys.readouterr().out
+        assert 'Refusing to fall back' in out


### PR DESCRIPTION
`fetch_deleted_songs`, `fetch_promoted_songs` and `fetch_tag_overrides` each warned and fell back to the on-disk copy when they couldn't reach Supabase. A broken sync looked like a successful one and the build shipped yesterday's data — a promotion made in the UI could silently never reach the site.

That's what produced the misleading `using cached promoted_songs.json` during yesterday's manual run.

## Changes

- All three now exit non-zero. `export_genre_suggestions.py` already did this, so this brings the others in line rather than inventing a convention.
- `except ImportError` around the supabase import was a second trap: it catches anything raised while importing the package **or its dependencies**, so a broken sub-dependency reported as "supabase-py not installed" and sent you to reinstall a package that was already there. `ModuleNotFoundError.name` tells them apart and the messages now differ.
- Shared logic in `scripts/lib/supabase_client.py`, so three scripts stop carrying three copies of the same three failure branches. The two now-unreachable `load_cached_*` helpers are gone.

## Tests

`tests/test_supabase_sync.py` covers both failure modes, the missing-package vs broken-dependency distinction, and the success path — driving the real cache-path logic off a patched `__file__` rather than asserting by inspection, since this runs hourly in CI.

pytest 635.