### PR TITLE
Tab pipeline shakedown: deploy trigger, overlay routing, editor chrome, metadata editing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,36 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Trigger deploy after content-modifying workflows complete
-  # (Pushes from GITHUB_TOKEN don't trigger workflows, so we use workflow_run)
+  # Trigger deploy after content-modifying workflows complete.
+  #
+  # GitHub does not start workflows for pushes made with the default
+  # GITHUB_TOKEN (recursive-workflow prevention), so a bot commit lands in git
+  # and nothing rebuilds. This list is the only thing that turns those commits
+  # into a deploy.
+  #
+  # !! These strings match the triggering workflow's `name:` field, NOT its
+  # filename, and GitHub reports NOTHING when a name matches no workflow. A
+  # rename or a retirement silently unhooks deployment. That has already
+  # happened twice:
+  #   - "Process Song Submission" / "Process Song Correction" were deleted in
+  #     b1f61d46e (2026-08-15) and replaced by "Process Pending Submission",
+  #     which was never added here — so every song and tab submission since
+  #     then reached works/ and never reached the site.
+  #   - "Sync Deleted Songs" was renamed to "Sync Deleted + Promoted Songs" in
+  #     365d6bc4a (2026-08-14), unhooking admin deletes and Dungeon promotions.
+  # tests/test_workflow_deploy_triggers.py now asserts this list against the
+  # workflows that actually push, so the next rename fails CI instead of
+  # quietly stranding a feature.
+  #
+  # "Reconcile Pending Songs" is deliberately absent: it never pushes. It calls
+  # the reconcile-pending edge function, which fires a `pending-commit`
+  # repository_dispatch, and "Process Pending Submission" does the committing.
   workflow_run:
     workflows:
-      - "Process Song Submission"
-      - "Process Song Correction"
+      - "Process Pending Submission"
       - "Process Tune Request"
-      - "Sync Deleted Songs"
+      - "Sync Community Input"
+      - "Sync Deleted + Promoted Songs"
     types: [completed]
     branches: [main]
   # Manual escape hatch. Always rebuilds and deploys, bypassing the gate job —
@@ -42,6 +64,19 @@ jobs:
   #
   # Fails OPEN: any API hiccup leaves should_run=true, because a redundant deploy
   # is harmless and a missed one is not.
+  #
+  # `head` is read from the API (repos/:owner/:repo/commits/main), NOT from
+  # github.sha — which matters, because under workflow_run github.sha is the
+  # TRIGGERING run's head_sha, i.e. the commit that ran BEFORE the bot commit.
+  # Reading main live is what lets this gate see the new commit at all.
+  #
+  # Known, self-healing wart: actions/deploy-pages@v4 records the deployment's
+  # sha as GITHUB_SHA with no input to override it, so a workflow_run deploy
+  # publishes main@HEAD but files it under the triggering run's (older)
+  # head_sha. The next trigger therefore sees a mismatch and deploys the same
+  # tree once more — that second run stamps the correct sha (its trigger
+  # committed nothing, so its head_sha IS main@HEAD) and the gate converges.
+  # Cost: exactly one redundant deploy per content commit. Never a missed one.
   gate:
     # Skip if triggered by a failed workflow_run (verify/deploy skip in turn)
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,12 +403,23 @@ See `.claude/skills/chordpro/SKILL.md` for full syntax reference.
 
 | Workflow | Trigger | Action |
 |----------|---------|--------|
-| `build.yml` | Push to main, PRs | Runs tests, rebuilds search index, deploys to GitHub Pages only if tests pass |
+| `build.yml` | Push to main, PRs, **`workflow_run` after any content workflow named in its trigger list**, manual dispatch | Runs tests, rebuilds search index, deploys to GitHub Pages only if tests pass |
 | `process-pending.yml` | `pending-commit` repository_dispatch from `auto-commit-song` / `reconcile-pending` | Writes one `pending_songs` row into `works/` via `works_writer` (create / update / fork-to-arrangement), pushes, then marks the row committed |
 | `process-tune-request.yml` | Issue labeled `tune-request` | Processes tune requests |
-| `cleanup-pending.yml` | Scheduled | Cleans up stale pending songs |
+| `cleanup-pending.yml` | `workflow_run` after a successful `CI & Deploy` | Cleans up stale pending songs (so it only runs when a deploy actually happened) |
 | `reconcile-pending.yml` | Hourly (`42 * * * *`) + manual | Retries `pending_songs` rows that never reached `works/`, prints the drift count, and opens/updates one alert issue if any stay stuck |
 | `sync-community-input.yml` | Hourly (`27 * * * *`) + manual | Syncs trusted-user tag downvotes to `docs/data/tag_overrides.json` (auto-applied at next index build) and exports `genre_suggestions` to `docs/data/user_genre_suggestions.json` (review-only, not auto-applied) |
+| `sync-deleted-songs.yml` | Hourly (`17 * * * *`) + manual | Syncs Supabase `deleted_songs` + `promoted_songs` into `docs/data/*.json` so UI deletes and Dungeon promotions survive the next index build |
+
+> ⚠️ **A workflow that pushes to `main` does not trigger a deploy by itself.**
+> GitHub does not start workflows for pushes made with the default
+> `GITHUB_TOKEN`, so bot commits land in git and nothing rebuilds. `build.yml`
+> closes the gap with a `workflow_run` trigger that lists content workflows **by
+> their `name:` field** — a rename or a new pushing workflow silently unhooks
+> deployment with no error anywhere. If you add or rename a workflow that
+> commits to `main`, update `.github/workflows/build.yml`;
+> `tests/test_workflow_deploy_triggers.py` fails CI if you forget. Details:
+> "How a bot commit reaches the site" in `scripts/lib/CLAUDE.md`.
 
 ## Chrome DevTools MCP
 

--- a/docs/create.html
+++ b/docs/create.html
@@ -72,6 +72,13 @@
                         gap: 12px; align-items: center; max-width: 560px; }
         .editor-bar { display: flex; justify-content: space-between; align-items: center;
                       margin-bottom: 10px; gap: 12px; flex-wrap: wrap; }
+        .editor-bar-meta { display: flex; align-items: center; gap: 12px;
+                           flex-wrap: wrap; min-width: 0; }
+        .editor-bar-artist { display: flex; align-items: center; gap: 6px;
+                             font-size: 13px; color: var(--text-secondary); }
+        .editor-bar-artist input { padding: 4px 6px; font-size: 13px; width: 15ch;
+                                   background: var(--bg); color: var(--text);
+                                   border: 1px solid var(--border); border-radius: 4px; }
         #editor-host { min-height: 400px; }
         .import-zone { max-width: 560px; border: 2px dashed var(--border);
                        border-radius: 8px; padding: 22px 18px; margin-bottom: 18px;
@@ -182,7 +189,19 @@
 
         <div id="editor-wrap" class="hidden">
             <div class="editor-bar">
-                <strong id="editor-title"></strong>
+                <span class="editor-bar-meta">
+                    <strong id="editor-title"></strong>
+                    <!-- Artist rides in the EDITOR bar, not the create form,
+                         because the form is only one of two ways in: a .tef
+                         import opens the editor directly and never sees it.
+                         Hidden when this tab is headed for an existing work —
+                         that work already has an artist and this page is in no
+                         position to restate it. -->
+                    <label id="artist-field" class="editor-bar-artist">Artist
+                        <input id="f-artist" type="text" maxlength="200"
+                               placeholder="who plays it (optional)">
+                    </label>
+                </span>
                 <span>
                     <button id="btn-submit">🚀 Submit tab</button>
                     <button id="btn-download">⬇ Download OTF</button>
@@ -218,6 +237,9 @@
 
         function applyTarget() {
             if (!target?.workId) return;
+            // Attaching to an existing work: that work owns its artist, so the
+            // field goes away rather than offering an edit this page can't make.
+            $('artist-field').classList.add('hidden');
             const banner = $('target-banner');
             banner.textContent = '';
             banner.append('Adding a tab to ');
@@ -366,8 +388,14 @@
                 // Login gate at the action (Phase 2a): everything up to
                 // here — including Download — stays open to everyone.
                 // submitNewTab picks the corpus instrument name and passes
-                // the target work through as workId.
-                const result = await submitNewTab(doc, target);
+                // the target work through as workId. The artist is read HERE,
+                // at submit, not at openEditor: it is the only chance a
+                // tab-only work ever gets to be attributed — nothing minted
+                // this way is reachable by the metadata editor afterwards.
+                // submitNewTab itself drops it when there is a target work.
+                const result = await submitNewTab(doc, {
+                    ...target, artist: $('f-artist').value,
+                });
                 // No review gate any more: the tab is LIVE the moment
                 // submitNewTab resolves — its row is in the overlay and the
                 // work page renders it from there. The only thing left to

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -5399,6 +5399,22 @@ mark {
     vertical-align: middle;
 }
 
+/* "Just edited" badge — a metadata edit that is live in the overlay and
+   still syncing to works/. Cool where the placeholder badge is warm: this
+   one reports your own successful write, not something the song is missing. */
+.pending-meta-badge {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--text-secondary);
+    border: 1px solid rgba(34, 197, 94, 0.35);
+    margin-left: 0.4rem;
+    vertical-align: middle;
+}
+
 /* Placeholder badge — search results and song view */
 .placeholder-badge {
     display: inline-block;
@@ -5474,9 +5490,14 @@ mark {
     border-radius: 8px;
 }
 .placeholder-editor-header h3 {
-    margin: 0 0 1rem;
+    margin: 0 0 0.35rem;
     font-size: 1rem;
     color: var(--text);
+}
+.placeholder-editor-sub {
+    margin: 0 0 1rem;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
 }
 .placeholder-editor-form {
     display: flex;
@@ -10096,6 +10117,14 @@ body.has-bottomband .container {
     color: var(--text-secondary);
     font-size: var(--font-sm);
     margin-top: 2px;
+}
+
+/* The nudge in the artist's place on a work that has none. Shown only to
+   someone who can fix it (work-view.js updateWorkTopBar), so it reads as an
+   invitation rather than a complaint. */
+.song-artist-missing {
+    font-style: italic;
+    opacity: 0.7;
 }
 
 .song-pill-row {

--- a/docs/js/CLAUDE.md
+++ b/docs/js/CLAUDE.md
@@ -850,6 +850,69 @@ generic rule — no tab-specific branch. It used to sit at "Requested" until
 a human merged its PR, the inconsistency
 `docs/plans/contribution-pipeline.md:204-210` accepted on purpose.
 
+### Editing a work's details (`work-view.js` + `corpus.js` + `utils.js`)
+
+Title / artist / key / notes belong to the WORK, not to any part — so they
+get their own affordance and their own kind of pending row. The case that
+forced it: a tab-minted work (`works/welcome-to-new-york/`) arrived with a
+title and nothing else, and no surface could give it an artist. The metadata
+editor existed but was reachable only from `status: 'placeholder'`, which a
+tab-minted work never has.
+
+**The affordance**: `🏷️ Details` in the title row (`#edit-meta-btn`, the
+same `.focus-btn` shell as Edit — *not* `.qc-btn`, which is the icon-only
+32x32 tab-band button and must never hold a word). Deliberately NOT
+part-scoped the way `#edit-song-btn` is: a tablature part hides Edit (there
+is no chart to edit) but the work still has details, and that is exactly the
+work that needs them. It is gated on the viewer instead —
+`canEditWorkMetadata(song, {userId, trusted})` in `utils.js`: **own a part of
+this work, or be trusted.** The gate is re-asked on every `updateWorkTopBar`
+because both halves resolve late. The empty artist line shows an "Artist
+unknown" nudge only to someone who can act on it.
+
+**Ownership, client-side**, is read from what the index row publishes
+(`workSubmitters`): `submitted_by` (primary chart), `arrangements[]`,
+`document_parts[]`, `tablature_parts[].submitted_by`, plus `created_by` on a
+pending overlay row. ⚠️ **`build_works_index` does not publish
+`submitted_by` on `tablature_parts` yet** — the uuid is in
+`work.yaml` (`provenance.submitted_by`) but the row keeps only `author`, a
+display name that is not comparable to `auth.uid()`. So a tab submitter has
+the affordance from the overlay (corpus attaches `submitted_by` to a pending
+part) and loses it once their work is published, until the index carries the
+field. Trusted users are unaffected, and the server is authoritative either
+way.
+
+**The row** (`submitWorkMetadata`) is neither a chart nor a part:
+
+| field | value |
+|---|---|
+| `id` | `meta:<slug>:<rand>` — its own namespace (DB CHECK), memoized per work so a double-click updates one row |
+| `part_type` | `'metadata'` |
+| `content` | `null` — the row owns no bytes |
+| `replaces_id` | the work being edited, **required**: it is the row's whole address |
+| `title` / `artist` / `key` / `notes` / `created_by` | the edit |
+
+Then `POST {id}` to `auto-commit-song`, like every other contribution. One
+deliberate difference in how step 2 failing is read: for a tab, step 2 is
+only durability, so any failure is "syncing shortly". For metadata it is also
+where **permission** is decided, so a 4xx (403 no claim, 404 no such work,
+400 no target — but not 429) means REFUSED: the row is deleted again so the
+overlay stops advertising an edit that will never land, and the server's own
+message is raised.
+
+**The overlay** (`corpus.applyPendingMetadata`, run last in `mergeCorpus`)
+merges the fields onto the work it names and nothing else: it never mints a
+row (unlike a tab, there is no song behind it), never touches the parts, and
+never flags the work `source: 'pending'`. It drops `_stems` so search follows
+the new title, and the newest `created_at` wins when two edits are in flight.
+A `pending_metadata` marker on the row drives the "Just edited" badge.
+
+The `savePlaceholderMetadata` path is **gone**, replaced entirely — it wrote
+`status: 'placeholder'` and round-tripped the chart through `content`, which
+on a tab-only work read `''` and would have stamped `status: placeholder`
+onto a legitimate work. `showMetadataEditor` (formerly `showPlaceholderEditor`)
+still serves real placeholders through `handleEditAction`, unchanged.
+
 ### Bounty board dedupe (`title-match.js` + `bounty-view.js`)
 
 The wanted list used to advertise songs the book already had — "Can the Circle

--- a/docs/js/__tests__/corpus.test.js
+++ b/docs/js/__tests__/corpus.test.js
@@ -4,7 +4,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
     parseJsonl, fetchJsonl, markArchived, mergeCorpus, countDistinctTitles,
     ensureStems, whenIdle, transformPendingRow, isPendingTablature,
-    overlayPendingTabParts, applyPendingTabs,
+    isPendingMetadata, overlayPendingTabParts, applyPendingTabs,
+    applyPendingMetadata,
 } from '../corpus.js';
 
 const CANON = [
@@ -450,5 +451,174 @@ describe('applyPendingTabs — a tab that mints a new work', () => {
 
     it('drops a titleless row rather than minting an empty slug', () => {
         expect(applyPendingTabs([], [tabRow({ title: '' })])).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------
+// The third kind of pending row: a METADATA edit
+// ---------------------------------------------------------------------
+//
+// It owns no bytes at all — `content` is null and `replaces_id` names the work
+// whose title / artist / key / notes are being changed. Two things it must
+// never do: become a row of its own (there is no song behind it), or cost the
+// work its parts (renaming a work must not lose its tabs).
+
+/** A raw pending_songs row for a metadata edit, run through the transform. */
+const metaRow = (over = {}) => transformPendingRow({
+    id: 'meta:welcome-to-new-york:bciu053d',
+    replaces_id: 'welcome-to-new-york',
+    title: 'Welcome to New York',
+    artist: 'Bill Emerson',
+    key: 'G',
+    notes: null,
+    content: null,
+    part_type: 'metadata',
+    created_by: 'u1',
+    ...over,
+});
+
+const TAB_ONLY_CANON = [{
+    id: 'welcome-to-new-york',
+    title: 'Welcome to New York',
+    artist: '',
+    tablature_parts: [
+        { instrument: 'banjo', src_file: 'banjo.otf.json',
+          file: 'data/tabs/welcome-to-new-york-banjo-1.otf.json' },
+    ],
+}];
+
+describe('transformPendingRow — metadata rows', () => {
+    it('becomes a metadata edit, never a song row', () => {
+        const row = metaRow();
+        expect(isPendingMetadata(row)).toBe(true);
+        expect(isPendingTablature(row)).toBe(false);
+        // None of the song-row machinery may attach to it: no source flag, no
+        // lyrics, no content — the merge must not read it as a work.
+        expect(row.source).toBeUndefined();
+        expect(row.lyrics).toBeUndefined();
+        expect(row.content).toBeUndefined();
+        expect(row.pending_metadata).toEqual({
+            title: 'Welcome to New York', artist: 'Bill Emerson', key: 'G',
+        });
+    });
+
+    it('carries only the fields the edit actually set', () => {
+        // An absent field means "unchanged", which is what lets an edit leave
+        // the key alone instead of blanking it.
+        const row = metaRow({ key: null, artist: undefined });
+        expect(row.pending_metadata).toEqual({ title: 'Welcome to New York' });
+    });
+});
+
+describe('applyPendingMetadata', () => {
+    it('is a no-op — same array — when there are no metadata rows', () => {
+        const songs = TAB_ONLY_CANON;
+        expect(applyPendingMetadata(songs, [])).toBe(songs);
+        expect(applyPendingMetadata(songs, null)).toBe(songs);
+        // …and when every row is unaddressed, so the zero-cost path holds for
+        // a corpus rebuild that has nothing to apply.
+        expect(applyPendingMetadata(songs, [metaRow({ replaces_id: null })])).toBe(songs);
+    });
+
+    it('overlays the edited fields onto the work it names', () => {
+        const [song] = applyPendingMetadata(TAB_ONLY_CANON, [metaRow()]);
+        expect(song.artist).toBe('Bill Emerson');
+        expect(song.key).toBe('G');
+        expect(song.pending_metadata).toEqual({
+            id: 'meta:welcome-to-new-york:bciu053d', created_by: 'u1',
+        });
+    });
+
+    it('keeps the work\'s parts — a rename must not cost it its tabs', () => {
+        const [song] = applyPendingMetadata(
+            TAB_ONLY_CANON, [metaRow({ title: 'Welcome To New York City' })]);
+        expect(song.title).toBe('Welcome To New York City');
+        expect(song.tablature_parts).toHaveLength(1);
+        expect(song.tablature_parts[0].file)
+            .toBe('data/tabs/welcome-to-new-york-banjo-1.otf.json');
+        expect(song.id).toBe('welcome-to-new-york');   // the URL is permanent
+    });
+
+    it('drops an edit whose target is not in the corpus — it mints nothing', () => {
+        // Unlike a tab, which legitimately mints the work it is the first part
+        // of. A synthesized row here would be a title with nothing behind it,
+        // competing in search with the real work the moment the archive loads.
+        const out = applyPendingMetadata(TAB_ONLY_CANON, [
+            metaRow({ replaces_id: 'a-work-nobody-loaded' }),
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0].id).toBe('welcome-to-new-york');
+        expect(out[0].artist).toBe('');
+    });
+
+    it('lets the newest edit of one work win, whatever order the rows arrive', () => {
+        // `select('*')` promises no order, and two people may hold an unlanded
+        // edit of the same work at once — that is why the ids are namespaced.
+        const older = metaRow({
+            id: 'meta:welcome-to-new-york:aaaaaa', artist: 'Somebody Else',
+            created_at: '2026-08-18T10:00:00Z',
+        });
+        const newer = metaRow({
+            id: 'meta:welcome-to-new-york:bbbbbb', artist: 'Bill Emerson',
+            created_at: '2026-08-18T11:00:00Z',
+        });
+        for (const rows of [[older, newer], [newer, older]]) {
+            expect(applyPendingMetadata(TAB_ONLY_CANON, rows)[0].artist)
+                .toBe('Bill Emerson');
+        }
+    });
+
+    it('drops the stale stem set so search follows the new title', () => {
+        const stemmed = ensureStems([{ ...TAB_ONLY_CANON[0] }]);
+        expect(stemmed[0]._stems).toBeDefined();
+        const [song] = applyPendingMetadata(stemmed, [metaRow({ title: 'Gold Rush' })]);
+        expect(song._stems).toBeUndefined();
+    });
+});
+
+describe('mergeCorpus with metadata rows', () => {
+    it('applies the edit without adding a row or flagging the work pending', () => {
+        const { songs } = mergeCorpus({ canon: TAB_ONLY_CANON, pending: [metaRow()] });
+        expect(songs).toHaveLength(1);
+        expect(songs[0].artist).toBe('Bill Emerson');
+        // Same rule a pending tab part follows: the WORK is as durable as it
+        // was a second ago, so flagging it `source: 'pending'` would report
+        // every other contribution to it as gone from the songbook.
+        expect(songs[0].source).toBeUndefined();
+        expect(songs[0].tablature_parts).toHaveLength(1);
+    });
+
+    it('re-stems the merged row, so the new artist is searchable', () => {
+        const { songs } = mergeCorpus({ canon: TAB_ONLY_CANON, pending: [metaRow()] });
+        expect(songs[0]._stems).toBeDefined();
+        expect([...songs[0]._stems].some(s => s.startsWith('emerson'))).toBe(true);
+    });
+
+    it('does not let a metadata row hide the work the way a song row would', () => {
+        // Both kinds name a work in `replaces_id`, and for a SONG row that
+        // means "hide that row, show this one". Read that way, a metadata row
+        // would delete the work and leave a contentless stub in its place.
+        const { songs } = mergeCorpus({ canon: TAB_ONLY_CANON, pending: [metaRow()] });
+        expect(songs.map(s => s.id)).toEqual(['welcome-to-new-york']);
+        expect(songs[0].id).not.toContain('meta:');
+    });
+
+    it('lands on top of a pending tab for the same work', () => {
+        // Submitting a tab and then naming its artist is the whole motivating
+        // case, and both rows are in flight at once.
+        const tab = transformPendingRow({
+            id: 'tab:welcome-to-new-york:bciu053d',
+            replaces_id: null, title: 'Welcome to New York',
+            part_type: 'tablature', instrument: 'banjo',
+            content: '{"tracks":[{"id":"banjo"}]}', created_by: 'u1',
+        });
+        const { songs } = mergeCorpus({ canon: [], pending: [tab, metaRow()] });
+        expect(songs).toHaveLength(1);
+        expect(songs[0].id).toBe('welcome-to-new-york');
+        expect(songs[0].artist).toBe('Bill Emerson');
+        expect(songs[0].tablature_parts).toHaveLength(1);
+        // …and the submitter owns that part, which is what makes the edit
+        // affordance visible in the seconds before any build has run.
+        expect(songs[0].tablature_parts[0].submitted_by).toBe('u1');
     });
 });

--- a/docs/js/__tests__/corpus.test.js
+++ b/docs/js/__tests__/corpus.test.js
@@ -399,3 +399,56 @@ describe('whenIdle', () => {
         vi.unstubAllGlobals();
     });
 });
+
+describe('applyPendingTabs — a tab that mints a new work', () => {
+    // REGRESSION. The row id used to BE the work slug, so filing the overlay
+    // row under row.id worked. Once tab rows moved into their own
+    // `tab:<slug>:<rand>` namespace (to stop two submitters colliding on the
+    // primary key), that fallback filed the new work under an id nothing links
+    // to — the submit page's "View it" link, search and any shared URL all use
+    // the real slug — so a freshly submitted tab 404'd at its own address.
+    // Built through transformPendingRow so the test exercises the real chain
+    // a raw pending_songs row takes on its way into the corpus.
+    const tabRow = (over = {}) => transformPendingRow({
+        id: 'tab:welcome-to-new-york:bciu053d',
+        replaces_id: null,
+        title: 'Welcome to New York',
+        part_type: 'tablature',
+        instrument: 'banjo',
+        content: '{"tracks":[{"id":"banjo"}]}',
+        ...over,
+    });
+
+    it('files the work under the slug derived from its title', () => {
+        const out = applyPendingTabs([], [tabRow()]);
+        expect(out).toHaveLength(1);
+        expect(out[0].id).toBe('welcome-to-new-york');
+        expect(out[0].id).not.toContain('tab:');
+        expect(out[0].tablature_parts).toHaveLength(1);
+    });
+
+    it('merges onto the published row once the work exists, not beside it', () => {
+        // The window this closes: after the durable commit deploys, the real
+        // row and the pending row would otherwise both be in the corpus and
+        // the song would appear twice in search until cleanup-pending reaped
+        // the row.
+        const published = { id: 'welcome-to-new-york', title: 'Welcome to New York', tablature_parts: [] };
+        const out = applyPendingTabs([published], [tabRow()]);
+        expect(out).toHaveLength(1);
+        expect(out[0].id).toBe('welcome-to-new-york');
+        expect(out[0].tablature_parts).toHaveLength(1);
+    });
+
+    it('still honours replaces_id when the tab names an existing work', () => {
+        const published = { id: 'salt-creek', title: 'Salt Creek', tablature_parts: [] };
+        const out = applyPendingTabs(
+            [published],
+            [tabRow({ id: 'tab:salt-creek:zz9911', replaces_id: 'salt-creek', title: 'Salt Creek' })]);
+        expect(out).toHaveLength(1);
+        expect(out[0].tablature_parts).toHaveLength(1);
+    });
+
+    it('drops a titleless row rather than minting an empty slug', () => {
+        expect(applyPendingTabs([], [tabRow({ title: '' })])).toHaveLength(0);
+    });
+});

--- a/docs/js/__tests__/otf-editor/create-tab-entry.test.js
+++ b/docs/js/__tests__/otf-editor/create-tab-entry.test.js
@@ -170,6 +170,32 @@ describe('submitNewTab', () => {
         expect(payload.title).toBe('Gold Rush');    // from the document
     });
 
+    // A tab-only work is minted from this row and nothing else, and the
+    // minted work is not a `status: placeholder` one — so the work-page
+    // metadata editor never renders for it. Submit is the ONLY moment an
+    // artist can be attached; dropping it here is how
+    // works/welcome-to-new-york ended up with a title and nothing else.
+    it('carries the artist on a mint, so the new work is attributed', async () => {
+        const submit = vi.fn(async () => ({}));
+        await submitNewTab(otf(), { artist: '  Bill Emerson  ' },
+            { requireLogin: loggedIn, submit });
+        expect(submit.mock.calls[0][0].artist).toBe('Bill Emerson');
+    });
+
+    it('drops the artist when the tab joins an existing work', async () => {
+        // That work already has an artist; a tab contributor doesn't restate it.
+        const submit = vi.fn(async () => ({}));
+        await submitNewTab(otf(), { workId: 'gold-rush', artist: 'Bill Emerson' },
+            { requireLogin: loggedIn, submit });
+        expect('artist' in submit.mock.calls[0][0]).toBe(false);
+    });
+
+    it('sends no artist key at all when the field was left blank', async () => {
+        const submit = vi.fn(async () => ({}));
+        await submitNewTab(otf(), { artist: '   ' }, { requireLogin: loggedIn, submit });
+        expect('artist' in submit.mock.calls[0][0]).toBe(false);
+    });
+
     it('refuses to submit without a session', async () => {
         const submit = vi.fn();
         loggedOut.mockClear();

--- a/docs/js/__tests__/otf-editor/work-edit.test.js
+++ b/docs/js/__tests__/otf-editor/work-edit.test.js
@@ -243,4 +243,26 @@ describe('createTabEditSession', () => {
         expect(editor.destroy).toHaveBeenCalledTimes(1);
         expect(onExit).not.toHaveBeenCalled();
     });
+
+    // jsdom computes no layout, so this guards the CLASS CONTRACT that the
+    // layout depends on rather than the pixels. `.qc-btn` is the site's
+    // 32x32 icon shell (a hard width, used everywhere else for −/+ only):
+    // put a word in one and the label can't shrink past its min-content, so
+    // it wraps and spills out of the box — which is how these four buttons
+    // came to be drawn on top of each other over the toolbar. Labelled
+    // buttons take `.qc-toggle-btn`, which is padded and auto-width.
+    it('labelled buttons never wear the icon-only qc-btn shell', () => {
+        session = createTabEditSession({
+            mount, otf: multiTrackOtf(), trackId: 'banjo',
+            editorFactory: (options) => { editor.factoryOptions = options; return editor; },
+            onApply, onExit, onSubmit: vi.fn(),
+        });
+        const buttons = [...mount.querySelectorAll('button')];
+        expect(buttons.length).toBeGreaterThan(4);   // actions + submit panel
+        for (const btn of buttons) {
+            // A label is anything past a lone glyph — every button here has one.
+            expect(btn.textContent.trim().length).toBeGreaterThan(1);
+            expect([...btn.classList]).not.toContain('qc-btn');
+        }
+    });
 });

--- a/docs/js/__tests__/work-meta-edit.test.js
+++ b/docs/js/__tests__/work-meta-edit.test.js
@@ -1,0 +1,448 @@
+// @vitest-environment jsdom
+// Editing a work's METADATA — title / artist / key / notes — from the work
+// page.
+//
+// The case that forced this: a tab-minted work (`works/welcome-to-new-york/`)
+// arrives with a title and nothing else, and until now no surface could give
+// it an artist. The metadata editor existed but was reachable only from
+// `status: 'placeholder'`, which a tab-minted work never has.
+//
+// Widening that gate alone would have been a bug, not a fix: the old save
+// wrote `status: 'placeholder'` plus `content: existingContent || null`, and
+// on a tab-only work `getSongContent` resolves to `''` — so the row went down
+// the CHART path server-side and stamped `status: placeholder` onto a real
+// work. These tests pin the row that replaced it.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+    metaRowId, submitWorkMetadata, canEditMetadataHere, configureWorkPage,
+    openWork,
+} from '../work-view.js';
+import { canEditWorkMetadata, ownsPartOfWork, workSubmitters } from '../utils.js';
+import { setAllSongs, setSongGroups } from '../state.js';
+
+/**
+ * Copied from the `pending_songs_meta_id_namespace` CHECK. A row id that
+ * fails this is a rejected INSERT in production, so the client's minting is
+ * asserted against the constraint rather than against a literal.
+ */
+const META_ID_CHECK = /^meta:[a-z0-9-]*:[a-z0-9]{6,}$/;
+
+/** Install a fake SupabaseAuth with (or without) an active session. */
+function mockAuth(token, { userId = 'u1' } = {}) {
+    globalThis.window.SupabaseAuth = {
+        isLoggedIn: () => !!token,
+        signInWithGoogle: () => {},
+        getUser: () => (token ? { id: userId } : null),
+        supabase: {
+            auth: {
+                getSession: async () => ({
+                    data: { session: token ? { access_token: token } : null },
+                }),
+            },
+        },
+    };
+}
+
+/** A stub `supabase` recording upserts and deletes. */
+function mockDb({ error = null } = {}) {
+    const calls = [];
+    const deletes = [];
+    return {
+        calls,
+        deletes,
+        from(table) {
+            return {
+                upsert(row, options) {
+                    calls.push({ table, row, options });
+                    return Promise.resolve({ error });
+                },
+                delete() {
+                    return {
+                        eq(column, value) {
+                            deletes.push({ table, column, value });
+                            return Promise.resolve({ error: null });
+                        },
+                    };
+                },
+            };
+        },
+    };
+}
+
+const okFetch = (result = { success: true, mode: 'update' }) =>
+    vi.fn(async () => ({ ok: true, json: async () => result }));
+
+const failFetch = (status, error) => vi.fn(async () => ({
+    ok: false, status, json: async () => ({ error }),
+}));
+
+afterEach(() => {
+    delete globalThis.window.SupabaseAuth;
+    vi.restoreAllMocks();
+});
+
+describe('metaRowId', () => {
+    it('satisfies the database CHECK, including for awkward work ids', () => {
+        expect(metaRowId('welcome-to-new-york')).toMatch(META_ID_CHECK);
+        expect(metaRowId('Café Olé!!')).toMatch(META_ID_CHECK);
+        // The constraint allows an empty slug half; an id that slugifies to
+        // nothing must still be legal rather than throwing at the table.
+        expect(metaRowId('')).toMatch(META_ID_CHECK);
+    });
+
+    it('is namespaced, never the bare work slug', () => {
+        // The work slug as a primary key is what this namespace exists to
+        // avoid: two people holding an unlanded edit of one work would collide
+        // on the PK, and the owner-gated UPDATE policy turns that collision
+        // into a permissions error that describes nothing.
+        const id = metaRowId('gold-rush');
+        expect(id).not.toBe('gold-rush');
+        expect(id.startsWith('meta:gold-rush:')).toBe(true);
+    });
+
+    it('reuses one id for repeated saves of the same work', () => {
+        // A double-click must update one row, not queue two edits of the same
+        // fields against each other.
+        const first = metaRowId('salt-creek');
+        expect(metaRowId('salt-creek')).toBe(first);
+    });
+
+    it('gives different works different rows', () => {
+        expect(metaRowId('cripple-creek')).not.toBe(metaRowId('blackberry-blossom'));
+    });
+
+    it('does not collide across editors of the same work', () => {
+        const rands = new Set();
+        for (let i = 0; i < 200; i++) {
+            rands.add(metaRowId(`collide-${i}`).split(':')[2]);
+        }
+        expect(rands.size).toBe(200);
+    });
+});
+
+describe('submitWorkMetadata', () => {
+    it('writes a metadata row: no content, no status, and it names its target', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        const f = okFetch();
+
+        const out = await submitWorkMetadata({
+            workId: 'welcome-to-new-york',
+            title: 'Welcome to New York',
+            artist: 'Bill Emerson',
+            key: 'G',
+            notes: 'Emerson instrumental',
+        }, { fetchImpl: f, supabase: db });
+
+        expect(db.calls).toHaveLength(1);
+        const { table, row, options } = db.calls[0];
+        expect(table).toBe('pending_songs');
+        expect(options).toEqual({ onConflict: 'id' });
+
+        expect(row.id).toMatch(META_ID_CHECK);
+        expect(row.part_type).toBe('metadata');
+        // The two fields the old save got wrong, pinned. `content: null` keeps
+        // the row off the chart path; `replaces_id` is the row's whole address.
+        expect(row.content).toBeNull();
+        expect(row.replaces_id).toBe('welcome-to-new-york');
+        // Nothing here may claim the work is a placeholder — it has a tab.
+        expect(row.status).toBeUndefined();
+        expect(row.title).toBe('Welcome to New York');
+        expect(row.artist).toBe('Bill Emerson');
+        expect(row.key).toBe('G');
+        expect(row.notes).toBe('Emerson instrumental');
+        expect(row.created_by).toBe('u1');
+
+        // Step 2 names the row and nothing else — the server classifies.
+        const [url, init] = f.mock.calls[0];
+        expect(url).toContain('/functions/v1/auto-commit-song');
+        expect(JSON.parse(init.body)).toEqual({ id: row.id });
+        expect(init.headers.Authorization).toBe('Bearer user-jwt');
+
+        expect(out).toEqual({
+            id: row.id,
+            workId: 'welcome-to-new-york',
+            live: true,
+            synced: true,
+            mode: 'update',
+            syncError: null,
+        });
+    });
+
+    it('blanks empty optional fields rather than writing empty strings', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        await submitWorkMetadata(
+            { workId: 'gold-rush', title: '  Gold Rush  ', artist: '   ' },
+            { fetchImpl: okFetch(), supabase: db });
+
+        const { row } = db.calls[0];
+        expect(row.title).toBe('Gold Rush');
+        expect(row.artist).toBeNull();
+        expect(row.key).toBeNull();
+        expect(row.notes).toBeNull();
+    });
+
+    it('surfaces a 403 as a refusal and withdraws the row', async () => {
+        // auto-commit-song is where permission is decided. A refused edit is
+        // NOT "syncing shortly": leaving the row behind would leave the
+        // overlay advertising a title change that is never going to land.
+        mockAuth('user-jwt');
+        const db = mockDb();
+        const f = failFetch(403, 'You have not contributed to this song.');
+
+        await expect(submitWorkMetadata(
+            { workId: 'gold-rush', title: 'Gold Rush' },
+            { fetchImpl: f, supabase: db },
+        )).rejects.toThrow('You have not contributed to this song.');
+
+        expect(db.calls).toHaveLength(1);              // it was written…
+        expect(db.deletes).toEqual([                    // …and taken back
+            { table: 'pending_songs', column: 'id', value: db.calls[0].row.id },
+        ]);
+    });
+
+    it('withdraws on any permanent 4xx — a 404 target is as dead as a 403', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        await expect(submitWorkMetadata(
+            { workId: 'ghost-work', title: 'Ghost Work' },
+            { fetchImpl: failFetch(404, 'No such song.'), supabase: db },
+        )).rejects.toThrow('No such song.');
+        expect(db.deletes).toHaveLength(1);
+    });
+
+    it('keeps a rate-limited edit live — 429 is about when, not what', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const out = await submitWorkMetadata(
+            { workId: 'gold-rush', title: 'Gold Rush' },
+            { fetchImpl: failFetch(429, 'Slow down'), supabase: db });
+        expect(out.synced).toBe(false);
+        expect(db.deletes).toHaveLength(0);
+    });
+
+    it('treats a transient failure as live-but-not-synced, keeping the row', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const out = await submitWorkMetadata(
+            { workId: 'gold-rush', title: 'Gold Rush' },
+            { fetchImpl: failFetch(500, 'boom'), supabase: db });
+
+        expect(out.live).toBe(true);
+        expect(out.synced).toBe(false);
+        expect(out.syncError).toMatch(/boom/);
+        expect(db.deletes).toHaveLength(0);   // the reconciler owns the retry
+    });
+
+    it('refuses to write without a session', async () => {
+        mockAuth(null);
+        const db = mockDb();
+        const f = okFetch();
+        await expect(submitWorkMetadata(
+            { workId: 'gold-rush', title: 'Gold Rush' },
+            { fetchImpl: f, supabase: db },
+        )).rejects.toThrow(/Sign in/);
+        expect(db.calls).toHaveLength(0);
+        expect(f).not.toHaveBeenCalled();
+    });
+
+    it('refuses a row with no target work — it would have nothing to edit', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        await expect(submitWorkMetadata(
+            { title: 'Orphan' }, { fetchImpl: okFetch(), supabase: db },
+        )).rejects.toThrow(/no song/);
+        expect(db.calls).toHaveLength(0);
+    });
+
+    it('refuses a titleless edit', async () => {
+        mockAuth('user-jwt');
+        const db = mockDb();
+        await expect(submitWorkMetadata(
+            { workId: 'gold-rush', title: '   ' },
+            { fetchImpl: okFetch(), supabase: db },
+        )).rejects.toThrow(/title/);
+        expect(db.calls).toHaveLength(0);
+    });
+
+    it('surfaces a failed row write — nothing is live then', async () => {
+        mockAuth('user-jwt');
+        const f = okFetch();
+        await expect(submitWorkMetadata(
+            { workId: 'gold-rush', title: 'Gold Rush' },
+            { fetchImpl: f, supabase: mockDb({ error: { message: 'row rejected' } }) },
+        )).rejects.toThrow('row rejected');
+        expect(f).not.toHaveBeenCalled();
+    });
+});
+
+describe('canEditWorkMetadata — the affordance gate', () => {
+    const tabWork = {
+        id: 'welcome-to-new-york',
+        title: 'Welcome to New York',
+        tablature_parts: [{ instrument: 'banjo', submitted_by: 'u1' }],
+    };
+
+    it('lets a part owner edit', () => {
+        expect(canEditWorkMetadata(tabWork, { userId: 'u1' })).toBe(true);
+    });
+
+    it('refuses a stranger', () => {
+        expect(canEditWorkMetadata(tabWork, { userId: 'u2' })).toBe(false);
+    });
+
+    it('lets a trusted user edit anything', () => {
+        expect(canEditWorkMetadata(tabWork, { userId: 'u2', trusted: true })).toBe(true);
+    });
+
+    it('refuses anonymous visitors, trusted flag or not', () => {
+        expect(canEditWorkMetadata(tabWork, { userId: null })).toBe(false);
+        expect(canEditWorkMetadata(tabWork, { userId: null, trusted: true })).toBe(false);
+    });
+
+    it('reads every kind of part the index row publishes', () => {
+        expect([...workSubmitters({
+            submitted_by: 'chart-owner',
+            arrangements: [{ slug: 'default' }, { slug: 'x', submitted_by: 'fork-owner' }],
+            tablature_parts: [{ instrument: 'banjo', submitted_by: 'tab-owner' }],
+            document_parts: [{ submitted_by: 'doc-owner' }],
+            created_by: 'overlay-author',
+        })].sort()).toEqual([
+            'chart-owner', 'doc-owner', 'fork-owner', 'overlay-author', 'tab-owner',
+        ]);
+    });
+
+    it('never mistakes a tab AUTHOR name for a submitter uuid', () => {
+        // `tablature_parts[].author` is a display name ('schlange'), which is
+        // what an imported Hangout tab carries. Comparing it to auth.uid()
+        // would be nonsense; the ownership field is `submitted_by`.
+        const imported = {
+            id: 'gold-rush',
+            tablature_parts: [{ instrument: 'banjo', author: 'schlange' }],
+        };
+        expect(ownsPartOfWork(imported, 'schlange')).toBe(false);
+        expect(canEditWorkMetadata(imported, { userId: 'schlange' })).toBe(false);
+    });
+});
+
+describe('canEditMetadataHere — the page asking the gate', () => {
+    beforeEach(() => configureWorkPage({ isTrusted: () => false }));
+
+    it('reads the signed-in user from the live auth module', () => {
+        mockAuth('user-jwt', { userId: 'u1' });
+        const work = { id: 'w', tablature_parts: [{ submitted_by: 'u1' }] };
+        expect(canEditMetadataHere(work)).toBe(true);
+        expect(canEditMetadataHere({ id: 'w2' })).toBe(false);
+    });
+
+    it('picks up trusted status when it resolves late', () => {
+        mockAuth('user-jwt', { userId: 'stranger' });
+        const work = { id: 'w', tablature_parts: [{ submitted_by: 'u1' }] };
+        expect(canEditMetadataHere(work)).toBe(false);
+        configureWorkPage({ isTrusted: () => true });
+        expect(canEditMetadataHere(work)).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------
+// The affordance on the page
+// ---------------------------------------------------------------------
+//
+// This is where the feature was actually stranded. `updateWorkTopBar` hid the
+// title-row Edit button whenever `partUsesSongActions` was false — which it is
+// for a tablature part — so on the one kind of work that most needs its
+// details filled in, nothing was clickable at all.
+
+const OTF = '{"otf_version":"1.0","tracks":[{"id":"banjo","tuning":["D4","B3","G3","D3","G4"]}],"notation":{"banjo":[]}}';
+
+const TAB_WORK = {
+    id: 'welcome-to-new-york',
+    title: 'Welcome to New York',
+    tablature_parts: [{
+        instrument: 'banjo', file: null, content: OTF, pending: true,
+        pending_id: 'tab:welcome-to-new-york:bciu053d', submitted_by: 'u1',
+    }],
+};
+
+const settle = () => new Promise(r => setTimeout(r, 0));
+
+async function openTabWork(work = TAB_WORK) {
+    document.body.innerHTML = '<div id="song-content"></div>';
+    setAllSongs([work]);
+    setSongGroups({});
+    await openWork(work.id);
+    await settle();
+}
+
+describe('the Details affordance on a tab-only work', () => {
+    beforeEach(() => {
+        configureWorkPage({ isTrusted: () => false });
+        window.matchMedia = () => ({ matches: false, addEventListener() {} });
+        global.fetch = vi.fn(async () => ({ ok: false, status: 404, text: async () => '' }));
+    });
+
+    it('is offered to the submitter of the work\'s tab', async () => {
+        mockAuth('user-jwt', { userId: 'u1' });
+        await openTabWork();
+
+        const metaBtn = document.getElementById('edit-meta-btn');
+        expect(metaBtn).toBeTruthy();
+        expect(metaBtn.classList.contains('hidden')).toBe(false);
+        // The chart Edit stays hidden — this part has no chart to edit. That
+        // rule is not what was broken; reaching the DETAILS through it was.
+        expect(document.getElementById('edit-song-btn').classList.contains('hidden'))
+            .toBe(true);
+        // …and the empty artist line becomes an invitation instead of a blank.
+        expect(document.querySelector('.song-artist-missing').classList.contains('hidden'))
+            .toBe(false);
+    });
+
+    it('is hidden from a visitor with no stake in the work', async () => {
+        mockAuth('user-jwt', { userId: 'somebody-else' });
+        await openTabWork();
+        expect(document.getElementById('edit-meta-btn').classList.contains('hidden'))
+            .toBe(true);
+        expect(document.querySelector('.song-artist-missing').classList.contains('hidden'))
+            .toBe(true);
+    });
+
+    it('is offered to a trusted user on a work they have never touched', async () => {
+        mockAuth('user-jwt', { userId: 'somebody-else' });
+        configureWorkPage({ isTrusted: () => true });
+        await openTabWork();
+        expect(document.getElementById('edit-meta-btn').classList.contains('hidden'))
+            .toBe(false);
+    });
+
+    it('opens the details editor rather than the ChordPro editor', async () => {
+        const onEdit = vi.fn();
+        mockAuth('user-jwt', { userId: 'u1' });
+        configureWorkPage({ isTrusted: () => false, onEdit });
+        await openTabWork();
+
+        document.getElementById('edit-meta-btn').click();
+        await settle();
+
+        const form = document.querySelector('.placeholder-editor');
+        expect(form).toBeTruthy();
+        expect(form.querySelector('#ph-edit-title').value).toBe('Welcome to New York');
+        expect(form.querySelector('#ph-edit-artist').value).toBe('');
+        expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it('announces an edit that is live in the overlay and still syncing', async () => {
+        mockAuth('user-jwt', { userId: 'u1' });
+        await openTabWork({
+            ...TAB_WORK, artist: 'Bill Emerson',
+            pending_metadata: { id: 'meta:welcome-to-new-york:aaaaaa', created_by: 'u1' },
+        });
+        expect(document.querySelector('.pending-meta-badge')).toBeTruthy();
+        expect(document.querySelector('.song-artist-line').textContent)
+            .toContain('Bill Emerson');
+    });
+});

--- a/docs/js/corpus.js
+++ b/docs/js/corpus.js
@@ -6,8 +6,9 @@
 //                        archived works still resolve
 // - pending_songs      — Supabase overlay: every logged-in user's submission,
 //                        live in seconds while the git commit catches up.
-//                        A row is a SONG or a PART (`part_type`); see
-//                        transformPendingRow / applyPendingTabs below
+//                        A row is a SONG, a PART, or a METADATA edit
+//                        (`part_type`); see transformPendingRow /
+//                        applyPendingTabs / applyPendingMetadata below
 // - deleted/promoted   — Supabase curation overlays: the same suppression and
 //                        prune-rescue the index build applies, but instant
 //
@@ -137,6 +138,20 @@ export function isPendingTablature(row) {
     return row?.part_type === 'tablature';
 }
 
+/**
+ * Is this pending row a METADATA edit — the work's title / artist / key /
+ * notes, and nothing else?
+ *
+ * The third kind of row, and the one that owns no bytes at all: `content` is
+ * null and `replaces_id` names the work being edited (required — a metadata
+ * row with no target has nothing to say). It is not a song and not a part, so
+ * it neither becomes a row nor attaches one; applyPendingMetadata overlays the
+ * fields onto the work already in the corpus.
+ */
+export function isPendingMetadata(row) {
+    return row?.part_type === 'metadata';
+}
+
 /** First lyric line of a ChordPro body (chord brackets stripped). */
 function extractFirstLine(content) {
     for (const line of String(content || '').split('\n')) {
@@ -207,6 +222,12 @@ function transformPendingTabRow(pending) {
         pending_part: {
             instrument: pending.instrument || '',
             ...(pending.part_file ? { src_file: pending.part_file } : {}),
+            // The submitter, in the same field name the published parts use
+            // (`build_works_index` reads `provenance.submitted_by`). It is
+            // what lets the work page know you own a part of this work in the
+            // seconds after you submit a tab — which is precisely when a
+            // tab-minted work still has no artist and wants one.
+            ...(pending.created_by ? { submitted_by: pending.created_by } : {}),
             content: pending.content || '',
             pending: true,
             pending_id: pending.id,
@@ -214,11 +235,37 @@ function transformPendingTabRow(pending) {
     };
 }
 
+/**
+ * A pending METADATA row: the four editable fields plus the work it targets.
+ *
+ * Nothing here is an index row either. `part_type` rides along so the merge's
+ * discriminator keeps working after the transform, and only fields the editor
+ * actually submitted are carried — an absent field means "unchanged", which is
+ * what lets a metadata edit leave `key` alone instead of blanking it.
+ */
+function transformPendingMetadataRow(pending) {
+    const fields = {};
+    for (const field of ['title', 'artist', 'key', 'notes']) {
+        if (typeof pending[field] === 'string') fields[field] = pending[field];
+    }
+    return {
+        id: pending.id,
+        part_type: 'metadata',
+        replaces_id: pending.replaces_id || null,
+        created_by: pending.created_by || null,
+        // Two people can hold an unlanded edit of the same work at once (the
+        // id namespace exists so they don't collide on the PK), so the overlay
+        // has to pick one — and `select('*')` promises no order.
+        created_at: pending.created_at || null,
+        pending_metadata: fields,
+    };
+}
+
 /** Transform a raw `pending_songs` row into what the merge expects. */
 export function transformPendingRow(pending) {
-    return isPendingTablature(pending)
-        ? transformPendingTabRow(pending)
-        : transformPendingSongRow(pending);
+    if (isPendingTablature(pending)) return transformPendingTabRow(pending);
+    if (isPendingMetadata(pending)) return transformPendingMetadataRow(pending);
+    return transformPendingSongRow(pending);
 }
 
 /**
@@ -324,6 +371,58 @@ export function applyPendingTabs(songs, tabRows) {
 }
 
 /**
+ * Overlay every pending metadata edit onto the work it names.
+ *
+ * Three things this deliberately does NOT do:
+ *
+ * 1. **Mint a row.** A metadata row whose target isn't in the corpus is
+ *    dropped, not turned into a song — unlike a tab, which legitimately mints
+ *    the work it is the first part of. There is no work here to mint: the row
+ *    carries no content of any kind, so a synthesized row would be a title
+ *    with nothing behind it, competing in search with the real work as soon as
+ *    the archive finished loading.
+ * 2. **Touch the parts.** The copy keeps `tablature_parts`, `arrangements`,
+ *    `has_content`, everything — renaming a work must not cost it its tabs.
+ * 3. **Flag the work `source: 'pending'`.** Same reasoning as a pending tab
+ *    part: the work is exactly as durable as it was, and claiming otherwise
+ *    would report every other contribution to it as no-longer-in-the-songbook
+ *    in My Submissions. The edit announces itself in `pending_metadata`.
+ *
+ * `_stems` is dropped from the copy because the title and artist are two of
+ * the four strings it is built from — mergeCorpus re-stems right after.
+ */
+const stamp = (row) => Date.parse(row?.created_at || '') || 0;
+
+export function applyPendingMetadata(songs, metaRows) {
+    if (!metaRows?.length) return songs;
+
+    const byTarget = new Map();
+    for (const row of metaRows) {
+        // `replaces_id` is the whole address. A metadata row's id is
+        // `meta:<slug>:<rand>` — its own namespace, for the reason tab rows
+        // have one: two people editing one work's details must not collide on
+        // the primary key. The slug inside it is decorative and is never
+        // parsed back out.
+        if (!row?.replaces_id) continue;
+        const held = byTarget.get(row.replaces_id);
+        if (!held || stamp(row) >= stamp(held)) byTarget.set(row.replaces_id, row);
+    }
+    if (!byTarget.size) return songs;
+
+    return songs.map(song => {
+        const row = byTarget.get(song.id);
+        const fields = row?.pending_metadata;
+        if (!fields) return song;
+        const { _stems, ...rest } = song;
+        return {
+            ...rest,
+            ...fields,
+            pending_metadata: { id: row.id, created_by: row.created_by },
+        };
+    });
+}
+
+/**
  * Merge the row sources into the corpus the app runs on.
  *
  * Pending rows overlay static rows: a pending SONG row with `replaces_id`
@@ -363,11 +462,14 @@ export function mergeCorpus({
         ));
     }
 
-    // Two kinds of pending row, two different jobs. Split before either
-    // rule runs so a tablature row can never be mistaken for a song that
-    // replaces a work.
+    // Three kinds of pending row, three different jobs. Split before any of
+    // the rules run so a tablature or metadata row can never be mistaken for a
+    // song that replaces a work — both name a work in `replaces_id`, which is
+    // exactly the field the song rule reads as "hide that row, show this one".
     const tabRows = pendingRows.filter(isPendingTablature);
-    const songRows = pendingRows.filter(p => !isPendingTablature(p));
+    const metaRows = pendingRows.filter(isPendingMetadata);
+    const songRows = pendingRows.filter(
+        p => !isPendingTablature(p) && !isPendingMetadata(p));
 
     const staticMap = {};
     for (const row of staticRows) staticMap[row.id] = row;
@@ -387,10 +489,13 @@ export function mergeCorpus({
 
     // Tabs go on last, so a pending part lands on the pending SONG row when a
     // work has both (an edited chart and a new tab arrive as one work page).
-    const songs = applyPendingTabs([
+    // Then metadata, which is last of all: it is the only row that edits the
+    // work's own fields, so whatever else landed on this work, the details the
+    // user just typed are what they see.
+    const songs = applyPendingMetadata(applyPendingTabs([
         ...staticRows.filter(row => !replacedIds.has(row.id)),
         ...mergedPending,
-    ], tabRows);
+    ], tabRows), metaRows);
 
     ensureStems(songs);
 

--- a/docs/js/corpus.js
+++ b/docs/js/corpus.js
@@ -15,6 +15,7 @@
 // the whole app.
 
 import { buildStemSet } from './stem.js';
+import { generateSlug } from './utils.js';
 
 /** Parse a JSONL payload into rows (blank lines tolerated). */
 export function parseJsonl(text) {
@@ -253,10 +254,10 @@ export function overlayPendingTabParts(published = [], rows = []) {
  * build already emits for such works (`tablature_parts`, no `has_content`),
  * so work-view builds exactly the page it would build after the commit lands.
  */
-function pendingTabOnlyRow(rows) {
+function pendingTabOnlyRow(rows, workId) {
     const first = rows[0];
     return {
-        id: first.id,
+        id: workId,
         title: first.title,
         artist: first.artist || '',
         composer: first.composer || '',
@@ -283,7 +284,21 @@ export function applyPendingTabs(songs, tabRows) {
 
     const byTarget = new Map();
     for (const row of tabRows) {
-        const target = row.replaces_id || row.id;
+        // NOT `row.id`. A tab row's id is `tab:<slug>:<rand>` — its own
+        // namespace, because keying a pending tab by the work it targets
+        // collided when two people tabbed the same song. The slug inside it is
+        // decorative and must never be parsed back out (submit-tab.js says so,
+        // and process_pending.tab_work_slug re-derives rather than trusts it).
+        //
+        // So a tab that targets an existing work says so in `replaces_id`, and
+        // a tab MINTING a work has no target to name — we derive the same slug
+        // the server will, from the title, with the same rule. Using row.id
+        // here filed the new work under `tab:welcome-to-new-york:bciu053d`,
+        // which nothing links to: the submit page's "View it" link, search, and
+        // any shared URL all point at the real slug, so the work was
+        // unreachable at its own address until the deploy landed.
+        const target = row.replaces_id || generateSlug(row.title, null);
+        if (!target) continue;   // titleless row: the server refuses it too
         if (!byTarget.has(target)) byTarget.set(target, []);
         byTarget.get(target).push(row);
     }
@@ -299,7 +314,12 @@ export function applyPendingTabs(songs, tabRows) {
     });
 
     // Whatever is left targets nothing published — a brand-new tab-only work.
-    for (const rows of byTarget.values()) merged.push(pendingTabOnlyRow(rows));
+    // It lands under the derived slug, so the moment the real row appears in
+    // index.jsonl the overlay row merges ONTO it in the loop above instead of
+    // standing beside it as a duplicate title in search.
+    for (const [workId, rows] of byTarget) {
+        merged.push(pendingTabOnlyRow(rows, workId));
+    }
     return merged;
 }
 

--- a/docs/js/otf-editor/create-tab-entry.js
+++ b/docs/js/otf-editor/create-tab-entry.js
@@ -193,6 +193,14 @@ export function launchTabCreator(target = {}, {
  * and the writer appends the part to that work.yaml. Omit it and the
  * submission mints its own work (a tab-only one, until someone adds a chart).
  *
+ * `artist` is the mirror image of `workId` and only travels with a MINT.
+ * A tab-only work is created from this row alone, so if the artist isn't
+ * here it is nowhere: works_writer omits the key entirely and the minted
+ * work.yaml carries a title and nothing else (that is how
+ * works/welcome-to-new-york ended up artist-less). When there IS a target
+ * work the field is deliberately dropped — that work already has its own
+ * artist, and a tab contributor is not the person who gets to restate it.
+ *
  * Resolves once the tab is LIVE — see submit-tab.js for the return shape.
  * Nothing here waits on a review any more; there is no review.
  */
@@ -205,11 +213,14 @@ export async function submitNewTab(otf, target = {}, {
     }
     const title = (target.title || otf?.metadata?.title || 'Untitled').trim()
         || 'Untitled';
+    const artist = String(target.artist || '').trim().slice(0, 200);
     return submit({
         type: 'tab-submission',
         otf,
         title,
         instrument: partInstrumentFor(otf, target.instrument),
-        ...(target.workId ? { workId: target.workId } : {}),
+        ...(target.workId
+            ? { workId: target.workId }
+            : (artist ? { artist } : {})),
     });
 }

--- a/docs/js/otf-editor/submit-tab.js
+++ b/docs/js/otf-editor/submit-tab.js
@@ -99,8 +99,28 @@ const issuedRowIds = new Map();
  * the id has to be unique across every submitter tabbing the same song.
  */
 export function tabRowId(slug, instrument, file = null) {
-    const key = `${slug || ''}|${instrument || ''}|${file || ''}`;
-    const seen = issuedRowIds.get(key);
+    return namespacedRowId(
+        'tab', slug, `${slug || ''}|${instrument || ''}|${file || ''}`);
+}
+
+/**
+ * `<namespace>:<slug>:<rand>` — the row-id shape every non-song `pending_songs`
+ * row uses, memoized per `key`.
+ *
+ * Shared because there is now more than one of them: `tab:` for a tablature
+ * part and `meta:` for a metadata edit (work-view.js), each with its own
+ * database CHECK of the same form. The two properties that matter are the
+ * same in both cases — the slug half is sanitized so it can never fail the
+ * constraint, and a repeat of the SAME submission reuses its id so a
+ * double-click updates one row instead of minting two.
+ *
+ * @param {string} namespace - 'tab' | 'meta'
+ * @param {string} slug - decorative, human-scannable half
+ * @param {string} key - what makes two calls "the same submission"
+ */
+export function namespacedRowId(namespace, slug, key) {
+    const memoKey = `${namespace}|${key}`;
+    const seen = issuedRowIds.get(memoKey);
     if (seen) return seen;
 
     // The slug is decorative, but it still has to satisfy the CHECK, so it
@@ -121,8 +141,8 @@ export function tabRowId(slug, instrument, file = null) {
     }
     const rand = Array.from(bytes, b => (b % 36).toString(36)).join('');
 
-    const id = `tab:${safeSlug}:${rand}`;
-    issuedRowIds.set(key, id);
+    const id = `${namespace}:${safeSlug}:${rand}`;
+    issuedRowIds.set(memoKey, id);
     return id;
 }
 
@@ -151,8 +171,15 @@ export function tabWorkSlug(title, artist = null) {
  * write was NOT accepted, so the caller can say so, and resolve with the
  * function's body (`{success, mode, workId, reason}`) when it was. The body
  * is where the client finds out what the server decided the write was.
+ *
+ * The rejection carries `status` and `detail` as well as its message, because
+ * not every caller can treat every failure the same way. A tab is LIVE the
+ * moment its row lands, so any failure here is "syncing shortly". A metadata
+ * edit is not: the function is where permission is decided, so a 403 there
+ * means REFUSED, and the caller has to be able to tell that apart from a
+ * network blip (work-view.js `submitWorkMetadata`).
  */
-async function requestDurableWrite(id, token, fetchImpl) {
+export async function requestDurableWrite(id, token, fetchImpl) {
     const response = await fetchImpl(`${SUPABASE_URL}/functions/v1/auto-commit-song`, {
         method: 'POST',
         headers: {
@@ -170,8 +197,11 @@ async function requestDurableWrite(id, token, fetchImpl) {
         } catch {
             // non-JSON error body; the status is enough
         }
-        throw new Error(
+        const error = new Error(
             `auto-commit-song returned ${response.status}${detail ? `: ${detail}` : ''}`);
+        error.status = response.status;
+        error.detail = detail;
+        throw error;
     }
 
     try {

--- a/docs/js/otf-editor/work-edit.js
+++ b/docs/js/otf-editor/work-edit.js
@@ -59,12 +59,20 @@ export function createTabEditSession({
     const bar = document.createElement('div');
     bar.className = 'tab-edit-bar';
     bar.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:8px;margin:0 0 8px;flex-wrap:wrap;';
+    // LABELLED buttons take `qc-toggle-btn`, never `qc-btn`. `.qc-btn` is the
+    // site's 32x32 ICON shell (the −/+ steppers): a hard `width: 32px` plus
+    // `display:flex; justify-content:center`. Give it a word and the text
+    // can't shrink past its min-content, so it wraps to ~55px of centred
+    // lines that spill out of a 32px box on a 40px pitch — four labels drawn
+    // on top of each other and over the toolbar below. `qc-toggle-btn` is
+    // the labelled variant (padded, auto width) and is what ✓ Done and the
+    // panel's Send already use.
     bar.innerHTML = `
         <span class="tab-edit-title"></span>
-        <span class="tab-edit-actions" style="display:flex;gap:8px;">
-            ${onSubmit ? '<button type="button" class="tab-edit-submit qc-btn" title="Submit this correction for review">🚀 Submit correction</button>' : ''}
-            <button type="button" class="tab-edit-download qc-btn" title="Download the edited OTF">⬇ Download</button>
-            <button type="button" class="tab-edit-cancel qc-btn" title="Discard changes and go back">Cancel</button>
+        <span class="tab-edit-actions" style="display:flex;gap:8px;flex-wrap:wrap;">
+            ${onSubmit ? '<button type="button" class="tab-edit-submit qc-toggle-btn" title="Submit this correction for review">🚀 Submit correction</button>' : ''}
+            <button type="button" class="tab-edit-download qc-toggle-btn" title="Download the edited OTF">⬇ Download</button>
+            <button type="button" class="tab-edit-cancel qc-toggle-btn" title="Discard changes and go back">Cancel</button>
             <button type="button" class="tab-edit-done qc-toggle-btn" title="Apply changes to the view">✓ Done</button>
         </span>
     `;
@@ -85,7 +93,7 @@ export function createTabEditSession({
                    placeholder="Describe your changes (required)"
                    style="flex:1;min-width:220px;padding:6px 8px;">
             <button type="button" class="tab-edit-submit-send qc-toggle-btn">Send</button>
-            <button type="button" class="tab-edit-submit-cancel qc-btn">Back</button>
+            <button type="button" class="tab-edit-submit-cancel qc-toggle-btn">Back</button>
             <span class="tab-edit-submit-status"></span>
         `;
         root.appendChild(submitPanel);

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -142,6 +142,60 @@ export function isPlaceholder(song) {
 }
 
 /**
+ * Every uuid the index row records as having submitted something ON this work.
+ *
+ * The published fields, and where the build puts them
+ * (`scripts/lib/build_works_index.py`):
+ *
+ *   song.submitted_by            the PRIMARY lead sheet's submitter
+ *   arrangements[].submitted_by  each forked lead sheet's submitter
+ *   document_parts[].submitted_by  a document part's submitter
+ *   tablature_parts[].submitted_by a tab part's submitter — see the caveat
+ *   song.created_by              the pending overlay's own author (a row the
+ *                                browser is holding before any build ran)
+ *
+ * CAVEAT, and it is the interesting one: `build_works_index` does NOT publish
+ * `submitted_by` on `tablature_parts` today. The uuid IS in
+ * `works/<id>/work.yaml` (`parts[].provenance.submitted_by` — that is what
+ * `process_pending.owns_content` and the edge function's `tabPartOwners` both
+ * read), but the row shape drops it, keeping only `author` (a DISPLAY NAME:
+ * 'schlange', 'Mike Beaumier'), which is not comparable to `auth.uid()`. So a
+ * tab submitter loses this client-side signal the moment their work is
+ * published — until the index publishes the field, which is why it is read
+ * here rather than worked around. The server is authoritative either way: it
+ * reads work.yaml and answers 403.
+ */
+export function workSubmitters(song) {
+    const ids = new Set();
+    const add = (id) => { if (typeof id === 'string' && id) ids.add(id); };
+    add(song?.submitted_by);
+    add(song?.created_by);
+    for (const a of song?.arrangements || []) add(a.submitted_by);
+    for (const p of song?.tablature_parts || []) add(p.submitted_by);
+    for (const d of song?.document_parts || []) add(d.submitted_by);
+    return ids;
+}
+
+/** Does `userId` own at least one part of this work, as far as the row shows? */
+export function ownsPartOfWork(song, userId) {
+    return !!userId && workSubmitters(song).has(userId);
+}
+
+/**
+ * May this viewer edit the work's metadata (title / artist / key / notes)?
+ *
+ * Mike's rule: own a part of the work, or be trusted. This is the AFFORDANCE
+ * gate only — a hint, computed from what the index row happens to carry. The
+ * decision is the server's (`auto-commit-song` reads `work.yaml` and refuses
+ * with 403), so this errs toward showing the button and surfacing a refusal
+ * rather than silently hiding an edit the server would have allowed.
+ */
+export function canEditWorkMetadata(song, { userId = null, trusted = false } = {}) {
+    if (!song || !userId) return false;
+    return !!trusted || ownsPartOfWork(song, userId);
+}
+
+/**
  * Check if a work has multiple viewable parts (lead sheet + tab, etc.)
  * Used to decide whether to show the dashboard or go straight to content.
  */

--- a/docs/js/work-view.js
+++ b/docs/js/work-view.js
@@ -33,11 +33,17 @@ import {
     initKeyState
 } from './song-view.js';
 import {
-    getSongContent, peekSongContent, songHasContent, songHasAbc,
+    peekSongContent, songHasContent, songHasAbc,
     getArrangementContent, peekArrangementContent,
 } from './song-content.js';
 import { CHROMATIC_MAJOR_KEYS } from './chords.js';
-import { escapeHtml, partUsesSongActions, isPlaceholder, requireLogin, slugify, tabLabel } from './utils.js';
+import {
+    escapeHtml, partUsesSongActions, isPlaceholder, requireLogin, slugify,
+    tabLabel, canEditWorkMetadata,
+} from './utils.js';
+import {
+    accessToken, namespacedRowId, requestDurableWrite,
+} from './otf-editor/submit-tab.js';
 import { openAddSongPicker } from './add-song-picker.js';
 import { launchTabCreator } from './otf-editor/create-tab-entry.js';
 import { tabEntryPlan, renderExistingTabsPanel } from './otf-editor/existing-tabs.js';
@@ -801,17 +807,28 @@ function renderTitleHeader() {
     header.className = 'song-header';
     const title = currentWork.title || 'Untitled';
     const artist = currentWork.artist || '';
+    // The details button is always in the DOM and hidden by class, because
+    // trust/login resolve AFTER the first render — updateWorkTopBar is called
+    // again when they land (main.js updateDeleteButtonVisibility) and just
+    // flips the class, the same contract #edit-song-btn has.
     header.innerHTML = `
         <div class="song-header-left">
             <div class="song-title-row">
                 <span class="song-title">${escapeHtml(title)}</span>
                 ${isPlaceholder(currentWork) ? '<span class="placeholder-badge">Placeholder</span>' : ''}
+                ${currentWork.pending_metadata ? '<span class="pending-meta-badge" title="Your edit is live here and syncing to the songbook">Just edited</span>' : ''}
                 <button id="edit-song-btn" class="focus-btn" title="Edit this song">&#x270F;&#xFE0F; Edit</button>
+                <button id="edit-meta-btn" class="focus-btn hidden" title="Edit this song's title, artist, key and notes">&#x1F3F7;&#xFE0F; Details</button>
             </div>
-            ${artist ? `<div class="song-artist-line">${escapeHtml(artist)}</div>` : ''}
+            ${artist
+                ? `<div class="song-artist-line">${escapeHtml(artist)}</div>`
+                : '<div class="song-artist-line song-artist-missing hidden">Artist unknown</div>'}
         </div>
     `;
-    // #edit-song-btn is wired via main.js's songContent delegation
+    // #edit-song-btn is wired via main.js's songContent delegation; the
+    // details button is wired here so the feature needs nothing from main.js.
+    header.querySelector('#edit-meta-btn')
+        ?.addEventListener('click', () => showMetadataEditor());
     return header;
 }
 
@@ -1394,14 +1411,35 @@ export function configureWorkPage(hooks = {}) {
 /**
  * Title-row Edit action (delegated from main.js): placeholders get the
  * metadata editor, real songs the ChordPro editor.
+ *
+ * Unchanged by the metadata work on purpose. Edit means "edit the chart"
+ * everywhere it is offered — a work with no chart still wants that door open
+ * (that is how a placeholder gains one). Editing the work's DETAILS is a
+ * different ask and gets its own button; routing both through one control was
+ * what made the details of a tab-minted work unreachable in the first place.
  */
 export function handleEditAction() {
     if (!currentWork) return;
     if (isPlaceholder(currentWork)) {
-        showPlaceholderEditor();
+        showMetadataEditor();
     } else {
         workPageHooks.onEdit?.(currentWork);
     }
+}
+
+/**
+ * May the viewer edit THIS work's metadata?
+ *
+ * Own a part of it, or be trusted (Mike's rule). Exported for tests; the page
+ * asks it on every top-bar update because both halves resolve late — the
+ * trusted flag arrives from Supabase after first paint, and the overlay row
+ * that proves you just submitted a tab arrives from refreshPendingSongs.
+ */
+export function canEditMetadataHere(song = currentWork) {
+    return canEditWorkMetadata(song, {
+        userId: globalThis.window?.SupabaseAuth?.getUser?.()?.id || null,
+        trusted: !!workPageHooks.isTrusted?.(),
+    });
 }
 
 export function updateWorkTopBar() {
@@ -1417,6 +1455,17 @@ export function updateWorkTopBar() {
         editBtn.classList.toggle('hidden',
             !(partUsesSongActions(activePart) || isPlaceholder(currentWork)));
     }
+
+    // Details (title / artist / key / notes) is NOT part-scoped — the work has
+    // one set of details whichever part you are reading, and a tab part is the
+    // case that needs it most: a tab-minted work arrives with a title and
+    // nothing else. Gated on the viewer instead: own a part here, or trusted.
+    const metaBtn = document.getElementById('edit-meta-btn');
+    const mayEditMeta = canEditMetadataHere();
+    if (metaBtn) metaBtn.classList.toggle('hidden', !mayEditMeta);
+    // The "Artist unknown" nudge only appears to someone who can act on it.
+    document.querySelector('#song-content .song-artist-missing')
+        ?.classList.toggle('hidden', !mayEditMeta);
 
     actions.push({
         id: 'list-picker-btn',
@@ -1776,23 +1825,54 @@ function openBountyRequestInline(section, work) {
 }
 
 // ============================================
-// PLACEHOLDER METADATA EDITOR
+// WORK METADATA EDITOR
 // ============================================
+//
+// The work's OWN fields — title, artist, key, notes — as opposed to any part's
+// bytes. It used to be reachable only from a `status: placeholder` work, which
+// left a tab-minted work stranded: `works/welcome-to-new-york/` had a title and
+// nothing else, and no surface anywhere could give it an artist.
+//
+// Widening the gate alone would have been wrong, which is why this is a
+// rewrite rather than a flag flip. The old save wrote `status: 'placeholder'`
+// and `content: existingContent || null` — on a tab-only work `getSongContent`
+// returns `''`, so the row went down the CHART path server-side and stamped
+// `status: placeholder` onto a legitimate work. A metadata edit now writes a
+// row that is neither a chart nor a part:
+//
+//   part_type   'metadata'
+//   content     null — this row owns no bytes and must never be read as a chart
+//   replaces_id the work being edited (REQUIRED: it is the row's whole address)
+//   id          `meta:<slug>:<rand>`, its own namespace, because two people
+//               editing one work's details must not collide on the PK
+//
+// Permission is the SERVER's answer (own a part, or be trusted). The button is
+// gated on the same rule client-side so the affordance isn't a lie, but a 403
+// from `auto-commit-song` is surfaced verbatim, never swallowed.
 
 /**
- * Show inline editor for placeholder metadata (title, artist, key, notes).
- * Replaces the dashboard content area with an edit form.
+ * Show the inline editor for the work's details (title, artist, key, notes).
+ * Replaces the page content with an edit form.
  */
-function showPlaceholderEditor() {
-    if (!requireLogin('edit placeholder metadata')) return;
+function showMetadataEditor() {
+    if (!requireLogin('edit song details')) return;
     if (!currentWork) return;
 
     const container = document.getElementById('song-content');
     if (!container) return;
 
+    // The form replaces the whole page body, which on a tab work means
+    // detaching a live tablature view. Its renderers own documentElement
+    // observers and its player owns audio, so they have to be torn down here
+    // rather than left re-rendering into DOM nobody can see. Cancel/Save
+    // re-render the part from scratch (renderWorkView).
+    teardownTablatureView();
+    setBottomBand(null);
+
     // Replace content with edit form
     container.innerHTML = '';
 
+    const work = currentWork;
     const form = document.createElement('div');
     form.className = 'placeholder-editor';
 
@@ -1806,7 +1886,8 @@ function showPlaceholderEditor() {
 
     form.innerHTML = `
         <div class="placeholder-editor-header">
-            <h3>Edit Placeholder</h3>
+            <h3>Song details</h3>
+            <p class="placeholder-editor-sub">These describe the song itself — every tab and chart on this page shares them.</p>
         </div>
         <div class="placeholder-editor-form">
             <div class="placeholder-editor-field">
@@ -1815,7 +1896,7 @@ function showPlaceholderEditor() {
             </div>
             <div class="placeholder-editor-field">
                 <label for="ph-edit-artist">Artist</label>
-                <input type="text" id="ph-edit-artist" value="${escapeHtml(currentWork.artist || '')}" />
+                <input type="text" id="ph-edit-artist" value="${escapeHtml(currentWork.artist || '')}" placeholder="As performed by…" />
             </div>
             <div class="placeholder-editor-field">
                 <label for="ph-edit-key">Key</label>
@@ -1863,17 +1944,23 @@ function showPlaceholderEditor() {
         statusDiv.className = 'placeholder-editor-status';
 
         try {
-            // Metadata edits take the one pipeline (phase 2b): any logged-in
-            // user writes pending_songs and it goes live.
-            await savePlaceholderMetadata({ title, artist, key, notes });
+            // Metadata edits take the one pipeline: write the row, then ask
+            // for the durable commit. Permission is decided there.
+            const out = await submitWorkMetadata({
+                workId: work.id, title, artist, key, notes,
+            });
 
-            statusDiv.innerHTML = '<span style="color: var(--success)">Saved!</span>';
+            statusDiv.innerHTML = out.synced
+                ? '<span style="color: var(--success)">Saved!</span>'
+                : '<span style="color: var(--success)">Saved — syncing shortly.</span>';
 
-            // Update in-memory work data and re-render after brief delay
-            currentWork.title = title;
-            currentWork.artist = artist;
-            currentWork.key = key;
-            currentWork.notes = notes;
+            // Update in-memory work data and re-render after brief delay.
+            // refreshPendingSongs rebuilds the corpus underneath us, so this
+            // is the on-screen copy catching up, not the source of truth.
+            work.title = title;
+            work.artist = artist;
+            work.key = key;
+            work.notes = notes;
             setTimeout(() => renderWorkView(), 600);
         } catch (e) {
             statusDiv.textContent = `Error: ${e.message}`;
@@ -1884,44 +1971,128 @@ function showPlaceholderEditor() {
 }
 
 /**
- * Save placeholder metadata via Supabase pending_songs — live immediately,
- * durable when the pending-commit dispatch lands it in works/.
+ * The `pending_songs.id` for a metadata edit: `meta:<slug>:<rand>`.
+ *
+ * Enforced in the database (`^meta:[a-z0-9-]*:[a-z0-9]{6,}$`), for the reason
+ * tab rows are namespaced: the primary key cannot be the work slug when two
+ * people may hold an unlanded edit of the same work — the second writer's
+ * upsert would fail the owner-gated UPDATE policy and surface as a
+ * *permissions* error that says nothing about the actual collision.
+ *
+ * Memoized per work, so a double-click, or a second save from the same page
+ * session, updates ONE row rather than minting a queue of them. A metadata
+ * edit is a state, not a take: the newest wins and older ones are noise.
  */
-async function savePlaceholderMetadata({ title, artist, key, notes }) {
-    const supabase = window.SupabaseAuth?.supabase;
-    if (!supabase) throw new Error('Not connected to database');
+export function metaRowId(workId) {
+    return namespacedRowId('meta', workId, String(workId || ''));
+}
 
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) throw new Error('Not logged in');
+/**
+ * Write a metadata edit and ask for the durable commit.
+ *
+ * Two steps, the same two every contribution takes — with one deliberate
+ * difference in how step 2 failing is read. For a tab, step 2 is only
+ * durability: the row is live and the hourly reconciler retries, so a failure
+ * is "syncing shortly". For metadata, step 2 is also where PERMISSION is
+ * decided, so a 401/403 means the edit was REFUSED and will never land. That
+ * cannot be reported as success, and the row must not be left behind
+ * advertising an edit in the overlay forever — so it is deleted and the
+ * server's own message is raised. Anything else (5xx, offline) stays
+ * live-but-unsynced, exactly like a tab.
+ *
+ * @param {Object} p
+ * @param {string} p.workId - the work being edited (becomes `replaces_id`)
+ * @param {string} p.title
+ * @param {string} [p.artist]
+ * @param {string} [p.key]
+ * @param {string} [p.notes]
+ * @param {Object} [deps] - injectable for tests
+ * @returns {Promise<{id, workId, live: true, synced: boolean,
+ *   mode: string|null, syncError: string|null}>}
+ */
+export async function submitWorkMetadata(p, deps = {}) {
+    const { workId, title, artist = '', key = '', notes = '' } = p || {};
+    const {
+        fetchImpl = (...args) => globalThis.fetch(...args),
+        supabase = globalThis.window?.SupabaseAuth?.supabase || null,
+    } = deps;
 
-    const user = window.SupabaseAuth?.getUser?.();
+    const token = await accessToken();
+    if (!token) {
+        throw new Error('Sign in to edit song details — your account is the attribution.');
+    }
+    if (!supabase) {
+        throw new Error('Not connected to the songbook — reload and try again.');
+    }
+    // A metadata row with no target has nothing to say: it is not a song, so
+    // there is no work for the server to mint from it.
+    if (!workId) {
+        throw new Error('This edit has no song to attach to.');
+    }
+    const cleanTitle = String(title || '').trim();
+    if (!cleanTitle) throw new Error('A song needs a title.');
 
-    // A metadata-only save must not blank out existing ChordPro, which now
-    // lives in data/songs/{id}.pro — fetch it before writing the row back
-    const existingContent = await getSongContent(currentWork).catch(() => null);
-
-    const entry = {
-        id: currentWork.id,
-        replaces_id: currentWork.id,
-        title,
-        artist: artist || null,
-        content: existingContent || null,
+    const id = metaRowId(workId);
+    const row = {
+        id,
+        replaces_id: workId,
+        title: cleanTitle,
+        artist: String(artist || '').trim() || null,
         key: key || null,
-        notes: notes || null,
-        status: 'placeholder',
-        tags: currentWork.tags || {},
-        created_by: user?.id || null,
+        notes: String(notes || '').trim() || null,
+        // NOT the work's ChordPro. The old save round-tripped the chart
+        // through this column so a metadata edit wouldn't blank it; on a
+        // tab-only work that read `''` and wrote a chart row for a work that
+        // has no chart. `null` says what is true: this row edits fields.
+        content: null,
+        part_type: 'metadata',
+        created_by: globalThis.window?.SupabaseAuth?.getUser?.()?.id || null,
     };
 
     const { error } = await supabase
         .from('pending_songs')
-        .upsert(entry, { onConflict: 'id' });
+        .upsert(row, { onConflict: 'id' });
+    if (error) {
+        throw new Error(error.message || 'Could not save these details.');
+    }
 
-    if (error) throw new Error(error.message);
+    // Live for this browser the moment the row lands: the overlay applies it
+    // (corpus.applyPendingMetadata) on the next corpus rebuild.
+    if (globalThis.window?.refreshPendingSongs) {
+        await globalThis.window.refreshPendingSongs();
+    }
 
-    // Refresh to merge into allSongs
-    if (window.refreshPendingSongs) {
-        await window.refreshPendingSongs();
+    try {
+        const result = await requestDurableWrite(id, token, fetchImpl);
+        return {
+            id, workId, live: true, synced: true,
+            mode: result?.mode || null, syncError: null,
+        };
+    } catch (e) {
+        // Any 4xx is the server saying the row itself is wrong and always
+        // will be — refused (403 no claim on this work), unaddressed (404 no
+        // such work), malformed (400). The one exception is 429: a rate limit
+        // is about WHEN, not what, so it stays live and the reconciler retries.
+        const refused = e?.status >= 400 && e?.status < 500 && e?.status !== 429;
+        if (refused) {
+            // Refused. Take the row back out so the overlay stops showing an
+            // edit that is never going to be real, then say what the server
+            // said — the client does not get to translate a 403 into a shrug.
+            try {
+                await supabase.from('pending_songs').delete().eq('id', id);
+                if (globalThis.window?.refreshPendingSongs) {
+                    await globalThis.window.refreshPendingSongs();
+                }
+            } catch (cleanup) {
+                console.warn('Could not withdraw the refused metadata row:', cleanup);
+            }
+            throw new Error(e.detail
+                || 'You can only edit the details of a song you have contributed to.');
+        }
+        console.warn('Details are live but not yet synced to the songbook:', e);
+        return {
+            id, workId, live: true, synced: false, mode: null, syncError: e.message,
+        };
     }
 }
 

--- a/docs/plans/contribution-pipeline.md
+++ b/docs/plans/contribution-pipeline.md
@@ -189,6 +189,18 @@ the Deferred rate-limiting item lands here, not later.
 *Deviation, 2026-08-15:* the tab half shipped separately — 2b delivered the
 lead-sheet pipeline and retired the song-issue flow, while `create-tab-pr` /
 `process-tab-pr.yml` stayed live pending 4c.
+
+*Regression, 2026-08-15 → 2026-08-18:* "durable in minutes" ended at git, not
+at the site. Retiring `process-song-submission.yml` /
+`process-song-correction.yml` left their names in `build.yml`'s `workflow_run`
+trigger list and never added the replacement, `"Process Pending Submission"`.
+Since pushes made with the default `GITHUB_TOKEN` do not start workflows,
+every submission for three days reached `works/` and never deployed — and
+`cleanup-pending.yml`, which keys on `CI & Deploy` succeeding, stopped reaping
+the rows it committed. Fixed by correcting the list; `tests/
+test_workflow_deploy_triggers.py` now fails CI if it drifts again. **Anyone
+retiring or renaming a content workflow must update that list** — it matches
+`name:` strings and GitHub reports nothing when an entry matches nothing.
 *Closed, 2026-08-18:* the tab half landed as written above — OTF rows on
 `pending_songs`, validation in the pipeline, `create-tab-pr` and
 `process-tab-pr.yml` deleted. See the reversal note under 4c below.

--- a/docs/plans/contribution-pipeline.md
+++ b/docs/plans/contribution-pipeline.md
@@ -205,6 +205,29 @@ retiring or renaming a content workflow must update that list** — it matches
 `pending_songs`, validation in the pipeline, `create-tab-pr` and
 `process-tab-pr.yml` deleted. See the reversal note under 4c below.
 
+*Third column, 2026-08-18 — metadata edits.* The first tab through the new
+pipeline minted a work with a title and nothing else, and there was no way
+to give it an artist: the metadata editor keyed on `status: 'placeholder'`,
+which a tab-minted work never gets. So `pending_songs` grew a third
+`part_type`, `'metadata'` — content null, `replaces_id` required, its own
+`meta:<slug>:<rand>` id namespace for the same primary-key reason tab rows
+have one — and `works_writer.update_metadata` writes work-level fields
+through a whitelist that cannot name `parts` or `id`.
+
+It is the one mode that can be **refused**. Every other column ends
+somewhere safe: a chart edit you don't own forks, a tab correction you
+don't own lands beside the original. There is no alternate arrangement of a
+title, so a caller with no claim on the work gets a 403 rather than a
+silent second opinion.
+
+Two ownership questions now exist and must not be merged. `submittersOf(yaml,
+partType)` is type-scoped because its answer buys an in-place rewrite of
+someone's *content* — unscoping it is the escalation where contributing a
+banjo tab bought edit rights over a stranger's lyrics. `anyPartOwners(yaml)`
+is deliberately looser because its answer buys only work-level fields, and
+the owner's rule is that contributing any part earns them. Trusted users
+("superusers") get metadata on any work.
+
 *Resolved at 4c, 2026-08-15 — **tabs keep the PR flow**.* The overlay this
 paragraph assumes doesn't exist for tabs: `pending_songs` is one row per
 SONG with a `content text` column holding ChordPro, no notion of parts or

--- a/scripts/lib/CLAUDE.md
+++ b/scripts/lib/CLAUDE.md
@@ -781,6 +781,7 @@ durable.
    - `create` → `create_work(on_collision='suffix')`
    - `update` → `update_part` on the chart the actor OWNS (`update_target`)
    - `fork` → `fork_to_arrangement`, `x_version_*` from the submitter identity
+   - `metadata` → `update_metadata` — work-level fields only, no part
 3. The workflow commits, pushes with rebase-retry, then marks the row
    `github_committed`.
 
@@ -825,9 +826,37 @@ the whole build when that id disagrees with `provenance.source_id` — which
 is the idempotence marker here. The displaced identity is kept as
 `provenance.x_derived_from`.
 
+**Metadata** (2026-08-18, `apply_metadata_row`). A row with
+`part_type = 'metadata'` carries NO content, names its target in
+`replaces_id`, and edits only the work's own fields. It exists because a work
+minted by a TAB had a title and nothing else — no artist, no key — and no
+path to a fix: every other row shape edits a PART, and the work-level fields
+only ever rode along with a rewrite of the primary chart, which a tab-only
+work does not have.
+
+| mode | writer call | file |
+|---|---|---|
+| `metadata` | `update_metadata` (title / artist / key→`default_key` / notes) | none — no part is created, replaced, renamed or reordered |
+
+"Touches no part" is structural, not a promise: `update_metadata` accepts a
+whitelist of work-level keys and `parts` is not on it. Fields the row does
+not carry are DROPPED, never written — a null artist means "I didn't touch
+it", and there is no clear-a-field gesture in this pipeline. The dedup
+backstop is skipped explicitly (it guards a `create` minting a slug; this
+mints nothing, and there is no ChordPro to score). Who may send one is
+decided before the dispatch by `classifyChange`: own **any** part of the
+work, or be trusted — a looser question than the per-part-type ownership a
+content edit must pass, because naming an artist rewrites nobody's content.
+
 **Idempotence**: every part written carries
 `provenance.source_id = pending:<row id>:<content sha>`. A replayed dispatch
 finds the marker and no-ops; a genuine re-edit changes the sha and applies.
+A metadata row has no content to hash, so `metadata_marker` hashes the FIELDS
+it is applying (canonical sorted-key JSON) and stamps the result at the work
+level as `metadata_provenance.source_id` — same `pending:<row id>:<sha>`
+shape, same property in both directions. Hashing the always-null content
+instead would give every metadata row in the table the same marker, so the
+first edit of a work would make every later edit of it look like a replay.
 The mode is decided server-side in `supabase/functions/_shared/pending-dispatch.ts`
 — the client cannot claim "update" on somebody else's chart.
 

--- a/scripts/lib/CLAUDE.md
+++ b/scripts/lib/CLAUDE.md
@@ -469,8 +469,10 @@ with undo limited to the promoter or a trusted user. The
 `Sync Deleted + Promoted Songs` workflow
 (`.github/workflows/sync-deleted-songs.yml`, hourly cron + manual dispatch)
 writes both to the committed caches (`docs/data/deleted_songs.json`,
-`docs/data/promoted_songs.json`) and its commit triggers a rebuild + deploy,
-so UI deletes and promotions actually stick. A promotion has the same effect
+`docs/data/promoted_songs.json`). Its commit reaches the site **only via
+`build.yml`'s `workflow_run` trigger, and only while this workflow's `name:`
+is listed there** — see "How a bot commit reaches the site" below. A promotion
+has the same effect
 as `curate unprune` but lives in the JSON cache instead of `registry.yaml`;
 if a promoted work was also deleted, deletion wins (the build warns).
 Manual fallback:
@@ -481,6 +483,46 @@ Manual fallback:
 git add docs/data/deleted_songs.json docs/data/promoted_songs.json
 git commit -m "Sync deleted/promoted songs"
 ```
+
+### How a bot commit reaches the site
+
+**A commit pushed by a workflow does NOT trigger a deploy on its own.** GitHub
+refuses to start workflows for pushes made with the default `GITHUB_TOKEN`
+(recursive-workflow prevention), and every workflow here checks out with a
+plain `actions/checkout@v4`. So a `github-actions[bot]` commit lands in git and
+nothing rebuilds — the change is durable and invisible.
+
+The one thing that closes the gap is the `workflow_run` trigger in
+`.github/workflows/build.yml`:
+
+```yaml
+workflow_run:
+  workflows: ["Process Pending Submission", "Process Tune Request",
+              "Sync Community Input", "Sync Deleted + Promoted Songs"]
+  types: [completed]
+  branches: [main]
+```
+
+Two things about that list bite:
+
+1. **It matches the `name:` field, not the filename.** Renaming a workflow
+   unhooks deployment, and GitHub reports nothing — no warning, no error, no
+   failed run. It has drifted twice (submissions since 2026-08-15, deletes and
+   promotions since 2026-08-14, both fixed 2026-08-18).
+2. **A workflow missing from the list deploys nothing, ever.** Adding a new
+   workflow that pushes to main means adding its name here too.
+
+`tests/test_workflow_deploy_triggers.py` now enforces both directions: every
+workflow containing a `git push` must be listed, every listed name must exist
+and must actually push. A rename now fails CI.
+
+Downstream of that: `cleanup-pending.yml` triggers on `CI & Deploy` completing
+successfully, so while the trigger was broken, committed `pending_songs` rows
+were not being reaped either. Restoring the deploy restores the reaping.
+
+If a commit is already on `main` and the site is stale, the manual escape hatch
+is `gh workflow run build.yml --ref main` — `workflow_dispatch` bypasses the
+`gate` job and always rebuilds.
 
 ### Output Format
 

--- a/scripts/lib/build_works_index.py
+++ b/scripts/lib/build_works_index.py
@@ -712,6 +712,17 @@ def build_song_from_work(work_dir: Path) -> dict:
                 # `{instrument}.otf.json` — a different part.
                 'src_file': part.get('file'),
             }
+            # The contributor's uuid, when this take came from a person
+            # rather than a scrape. `author` above is a DISPLAY NAME
+            # ("schlange"), which can never be compared to an auth.uid() —
+            # so without this the frontend cannot tell that the signed-in
+            # user submitted this tab, and the "edit this work's details"
+            # affordance disappeared the moment their tab was published.
+            # Consistent with the row-level, arrangement and document parts,
+            # which already publish it; the uuid is in works/*/work.yaml
+            # either way. Omitted when absent, so imported tabs are unchanged.
+            if prov.get('submitted_by'):
+                tab_info['submitted_by'] = prov['submitted_by']
             # Arrangement-picker detail, when the listing had it
             if prov.get('difficulty'):
                 tab_info['difficulty'] = prov['difficulty']

--- a/scripts/lib/process_pending.py
+++ b/scripts/lib/process_pending.py
@@ -29,6 +29,11 @@ Modes (chosen server-side, never by the client):
     or a "correction" from somebody who does not own the tab they meant to
     fix. ``add_part`` appends; nothing published is read-modify-written.
     This is the tab column's ``fork``.
+``metadata``
+    Metadata only: the WORK's own title / artist / key / notes and nothing
+    else. No part is created, replaced, renamed or reordered and no part
+    file is written — ``works_writer.update_metadata`` is the entry point,
+    and it can only write work-level fields. See "Metadata" below.
 
 Tablature (2026-08-18)
 ----------------------
@@ -68,6 +73,36 @@ Three things a tab does differently, all for reasons that don't generalize:
   ``provenance.x_submission_notes`` / ``x_correction_notes`` — not in the
   work-level ``notes`` the chart path writes, which describes the song
   rather than one take of it.
+
+Metadata (2026-08-18)
+---------------------
+A work minted by a TAB was stranded: it had a title the submitter typed and
+nothing else — no artist, no key — and no way to fix that, because every row
+shape this pipeline understood edited a PART, and the work-level fields only
+ever rode along with a rewrite of the primary chart. A tab-only work has no
+chart to rewrite.
+
+So ``part_type = 'metadata'``: a row with NO content that names its target in
+``replaces_id`` and carries whichever of title / artist / key / notes the
+editor changed. It writes work.yaml through
+:func:`works_writer.update_metadata` and touches nothing else.
+
+Three things it does differently, each for its own reason:
+
+* **The dedup backstop is skipped**, like a tab's but for a different reason:
+  a tab has no lyrics to score, a metadata row has no *content at all*. There
+  is also nothing to dedupe — the row names an existing work, so no slug is
+  being minted, which is the only thing the backstop guards.
+* **Absent fields are dropped, not written.** The client sends what changed;
+  a null artist means "I didn't touch the artist", never "blank it".
+* **The idempotence marker is derived from the FIELDS**, not from ``content``
+  (which is null here) — see :func:`metadata_marker`.
+
+Who is allowed to send one is decided before the dispatch, in
+``supabase/functions/_shared/pending-dispatch.ts``: own any part of the work,
+or be trusted. That is a looser question than the per-part-type ownership the
+chart and tab columns ask, on purpose — no content is rewritten by naming the
+artist — and the two must not be collapsed into each other.
 
 Dedup backstop (phase 3b)
 -------------------------
@@ -113,6 +148,12 @@ work already has a part with that marker, the row has already been applied
 and this is a no-op. Re-editing the same row changes the sha, so a genuine
 second edit is never mistaken for a replay.
 
+A metadata row has no content to hash, so its marker hashes the FIELDS it is
+applying instead (:func:`metadata_marker`) and is stamped at the work level as
+``metadata_provenance.source_id``. Same property, same shape: replay the same
+edit and the marker matches (no-op); change one letter of the artist and it
+does not (applies).
+
 A redirect complicates this: the row landed on a work the dispatch never
 named, so looking for the marker under the dispatched id finds nothing. The
 backstop therefore checks the marker against its match candidates too — see
@@ -147,6 +188,23 @@ MODES = ('create', 'update', 'fork')
 #: mode from the wrong column ('fork' for a tab, 'add' for a chart) is a
 #: loud refusal rather than a surprising write.
 TAB_MODES = ('create', 'update', 'add')
+
+#: Modes a METADATA row may be dispatched in — one, because there is only
+#: one thing it can do. Kept as a tuple for symmetry with the two above, and
+#: so a mode from another column ('create' for a metadata row, which would
+#: mean minting a work out of a title with no content) is a loud refusal.
+METADATA_MODES = ('metadata',)
+
+#: ``pending_songs`` column -> ``work.yaml`` field, for a metadata row. Only
+#: these four: the row shape carries nothing else a work-level field wants,
+#: and ``works_writer.update_metadata`` refuses anything outside its own
+#: whitelist anyway.
+METADATA_COLUMNS = (
+    ('title', 'title'),
+    ('artist', 'artist'),
+    ('key', 'default_key'),
+    ('notes', 'notes'),
+)
 
 #: Instrument names and work ids both land inside works/ as path segments,
 #: so both are held to the slug shape the edge function, work_schema.slugify
@@ -522,6 +580,137 @@ def _provenance(row: dict, marker: str, actor: Optional[str]) -> dict:
 
 
 # ============================================
+# Metadata
+# ============================================
+
+
+def metadata_updates(row: dict) -> dict:
+    """The work-level fields this row is actually asking to change.
+
+    Only what the row CARRIES. A null or blank column is "I didn't touch
+    this", never "blank it" — the editor sends the fields it changed, and
+    there is no gesture in this pipeline for clearing one. Writing a missing
+    artist as an empty artist would let a client that forgot a field erase
+    work somebody else did, which is the same destruction the part-targeting
+    rules prevent one level down.
+    """
+    updates = {}
+    for column, field in METADATA_COLUMNS:
+        value = row.get(column)
+        if value is None:
+            continue
+        value = str(value).strip()
+        if value:
+            updates[field] = value
+    return updates
+
+
+def metadata_marker(row_id: str, updates: dict) -> str:
+    """The idempotence marker for a metadata row.
+
+    The part markers hash ``content``; a metadata row has none (a CHECK on
+    ``pending_songs`` refuses one), so hashing it would give every metadata
+    row in the table the SAME marker — the first edit of a work would then
+    make every later edit of it look like a replay and silently do nothing.
+
+    So the sha is taken over the fields being applied, serialized
+    canonically: sorted keys, so column order can never change the answer,
+    and the exact dict :func:`metadata_updates` produced, so a field the row
+    is not applying cannot influence it. The result goes through
+    :func:`content_marker` to keep the one ``pending:<row id>:<sha>`` shape
+    everything in this pipeline greps for.
+
+    The property that matters, in both directions:
+
+    * replay the same row unchanged -> same fields -> same sha -> the work
+      already carries this marker -> no-op.
+    * genuinely re-edit the row (fix a typo in the artist) -> different sha
+      -> applies.
+
+    Note this is last-writer-wins across DIFFERENT rows, exactly as the part
+    path is: a metadata row that never reached git keeps its uncommitted flag
+    and will be re-dispatched with its CURRENT values, so a stale edit cannot
+    resurrect old text — but two people editing one work land in the order
+    their dispatches complete.
+    """
+    canonical = json.dumps(updates, sort_keys=True, ensure_ascii=False,
+                           separators=(',', ':'))
+    return content_marker(row_id, canonical)
+
+
+def metadata_applied(repo_root, work_id: str, marker: str) -> bool:
+    """Has this exact metadata edit already landed on this work?
+
+    The part-level :func:`already_applied` cannot answer it: a metadata edit
+    writes no part, so there is no ``provenance.source_id`` for it to find.
+    The marker lives at the work level instead.
+    """
+    work = works_writer.load_work(repo_root, work_id)
+    if not work:
+        return False
+    return (work.get('metadata_provenance') or {}).get('source_id') == marker
+
+
+def apply_metadata_row(repo_root, row: dict, mode: str, work_id: str,
+                       actor: Optional[str] = None,
+                       verbose: bool = True) -> works_writer.WriteResult:
+    """Write one metadata row to ``works/``: work-level fields, nothing else.
+
+    No part is created, replaced, renamed or reordered, and no part file is
+    written — :func:`works_writer.update_metadata` is structurally incapable
+    of any of that (it accepts a whitelist of work-level keys, and ``parts``
+    is not on it).
+
+    The dedup backstop is NOT consulted, and the omission is deliberate. It
+    exists to stop a ``create`` minting a slug for a song that is already in
+    the corpus; a metadata row mints nothing — it names an existing work in
+    ``replaces_id``, which the edge function has already resolved and checked
+    — so there is no slug for it to guard. It also scores lyric containment
+    over a submission's ChordPro, and this row has no content at all.
+    """
+    if mode not in METADATA_MODES:
+        raise ProcessPendingError(
+            f"unknown metadata mode {mode!r} "
+            f"(expected one of {', '.join(METADATA_MODES)})")
+
+    row_id = row.get('id')
+    if not row_id:
+        raise ProcessPendingError('row has no id')
+
+    # A metadata row's id is `meta:<slug>:<rand>` so two people fixing one
+    # song's details cannot collide on the pending_songs primary key. Like a
+    # tab's, it is NOT a work slug and must never become a directory name —
+    # and unlike a tab's there is no title-minting fallback, because a
+    # metadata edit has nothing to create a work out of.
+    work_id = (work_id or '').strip()
+    if not SLUG_RE.match(work_id):
+        raise ProcessPendingError(
+            f"metadata row '{row_id}' has no usable target work id "
+            f"({work_id!r} is not a slug); it must be dispatched with the "
+            f"work named in replaces_id")
+
+    updates = metadata_updates(row)
+    if not updates:
+        raise ProcessPendingError(
+            f"metadata row '{row_id}' carries no fields to apply")
+
+    marker = metadata_marker(row_id, updates)
+    if metadata_applied(repo_root, work_id, marker):
+        if verbose:
+            print(f"Already applied: works/{work_id} carries {marker}")
+        return works_writer.WriteResult(
+            mode='update-metadata', work_id=work_id,
+            skipped_reason='already-applied')
+
+    return works_writer.update_metadata(
+        repo_root, work_id,
+        updates=updates,
+        provenance=_provenance(row, marker, actor),
+        verbose=verbose,
+    )
+
+
+# ============================================
 # Tablature
 # ============================================
 
@@ -873,14 +1062,20 @@ def apply_row(repo_root, row: dict, mode: str, work_id: str,
     check). See "Dedup backstop" in the module docstring.
 
     A tablature row (``part_type = 'tablature'``) goes to
-    :func:`apply_tablature_row` instead, before anything here reads
-    ``content`` as ChordPro — including the dedup backstop, which is skipped
-    for tabs on purpose (an OTF has no lyrics for a lyric-containment
-    scorer to contain).
+    :func:`apply_tablature_row` instead, and a metadata row
+    (``part_type = 'metadata'``) to :func:`apply_metadata_row` — both before
+    anything here reads ``content`` as ChordPro, and both before the dedup
+    backstop, which is skipped for each of them on purpose (an OTF has no
+    lyrics for a lyric-containment scorer to contain; a metadata row has no
+    content and mints no slug).
     """
-    if (row.get('part_type') or 'lead-sheet') == 'tablature':
+    part_type = row.get('part_type') or 'lead-sheet'
+    if part_type == 'tablature':
         return apply_tablature_row(repo_root, row, mode, work_id, actor,
                                    verbose=verbose)
+    if part_type == 'metadata':
+        return apply_metadata_row(repo_root, row, mode, work_id, actor,
+                                  verbose=verbose)
 
     if mode not in MODES:
         raise ProcessPendingError(

--- a/scripts/lib/works_writer.py
+++ b/scripts/lib/works_writer.py
@@ -36,6 +36,10 @@ Modes
 ``update_part``
     Replace a part's file and stamp provenance — for correction flows that
     legitimately own the content.
+``update_metadata``
+    Change the WORK's own fields — title, artist, key, notes — and no part
+    at all. The one mode that writes work.yaml without writing a file
+    beside it.
 ``fork_to_arrangement``
     A collision that is really a different arrangement: the incoming chart
     lands as an ADDITIONAL version part on the existing work with
@@ -73,8 +77,17 @@ WORK_YAML = 'work.yaml'
 _FIELD_ORDER = [
     'id', 'title', 'artist', 'composers', 'default_key', 'default_tempo',
     'time_signature', 'tags', 'exclude_tags', 'status', 'notes', 'external',
-    'parts',
+    'metadata_provenance', 'parts',
 ]
+
+#: Work-level fields :func:`update_metadata` may write. Everything a
+#: metadata edit is *for*, and nothing else — most importantly not ``parts``
+#: and not ``id``, so "a metadata edit touches no part" is a property of the
+#: function rather than a promise made by its callers.
+METADATA_FIELDS = (
+    'title', 'artist', 'composers', 'default_key', 'default_tempo',
+    'time_signature', 'notes',
+)
 
 _PART_FIELD_ORDER = [
     'type', 'format', 'file', 'default', 'instrument', 'label',
@@ -560,6 +573,71 @@ def update_part(repo_root, work_id: str, *,
     write_work_yaml(repo_root, work)
     return WriteResult(mode='update-part', work_id=work_id, work_dir=work_dir,
                        part_file=target, written=True)
+
+
+# ============================================
+# Mode: update-metadata
+# ============================================
+
+
+def update_metadata(repo_root, work_id: str, *,
+                    updates: dict,
+                    provenance: dict,
+                    on_suppressed: str = 'skip',
+                    guards: Optional[Guards] = None,
+                    verbose: bool = True) -> WriteResult:
+    """Change a work's own fields. Touches no part, writes no part file.
+
+    The entry point the metadata column of ``pending_songs`` lands through.
+    Deliberately NOT ``update_part(..., work_updates=...)``: that one has to
+    find a part to rewrite before it will write anything, and the works this
+    exists for — a song minted by a tab, with a title and no artist — have
+    no part their editor owns or wants to touch. Passing it a loose match
+    just to reach the work-level fields would rewrite whichever part the
+    match happened to pick, which is the exact destruction the part-targeting
+    rules elsewhere exist to prevent.
+
+    ``updates`` may only name :data:`METADATA_FIELDS`; anything else is a
+    ``ValueError`` rather than a silent write, so no caller can reach
+    ``parts`` (or ``id``) through here. Values that are ``None`` or empty are
+    DROPPED, not written: a client that sends only the artist must not blank
+    the key, and there is no "clear this field" gesture in this pipeline.
+
+    ``provenance`` is stamped at the work level as ``metadata_provenance``
+    (same shape a part's provenance has: source / source_id / submitted_by /
+    submitted_at). It is what makes a replayed dispatch a no-op — see
+    ``process_pending.metadata_applied`` — and the only record of who last
+    changed a work's details.
+    """
+    guards = guards or Guards.load(repo_root)
+    reason = guards.blocked(work_id)
+    if reason:
+        return _skip('update-metadata', work_id, reason, on_suppressed, verbose)
+
+    unknown = sorted(set(updates or {}) - set(METADATA_FIELDS))
+    if unknown:
+        raise ValueError(
+            f"update_metadata cannot write {', '.join(unknown)} — "
+            f"only {', '.join(METADATA_FIELDS)}")
+
+    work = load_work(repo_root, work_id)
+    if work is None:
+        raise WorkNotFoundError(
+            f"work '{work_id}' has no {WORK_YAML}; there is no metadata to "
+            f"edit")
+
+    applied = {k: v for k, v in (updates or {}).items()
+               if v is not None and v != '' and v != []}
+    if not applied:
+        raise ValueError('update_metadata was given no fields to apply')
+
+    work.update(applied)
+    work['metadata_provenance'] = clean_provenance(provenance)
+
+    write_work_yaml(repo_root, work)
+    return WriteResult(mode='update-metadata', work_id=work_id,
+                       work_dir=work_path(repo_root, work_id),
+                       part_file=None, written=True)
 
 
 # ============================================

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -23,9 +23,9 @@ Serverless functions that run on Supabase Edge (Deno runtime).
   `attributionFor`). The client never says who it is.
 - `pending-dispatch.ts` — the phase 2b change gate: durable per-user rate
   limit counted from `submission_log`, `classifyChange` (create / update /
-  fork-to-arrangement / add), and `dispatchPendingCommit`, which fires the
-  `pending-commit` repository_dispatch. **No edge function authors work.yaml
-  any more** — `.github/workflows/process-pending.yml` runs
+  fork-to-arrangement / add / metadata), and `dispatchPendingCommit`, which
+  fires the `pending-commit` repository_dispatch. **No edge function authors
+  work.yaml any more** — `.github/workflows/process-pending.yml` runs
   `scripts/lib/works_writer.py`, the repo's one writer.
   Ownership is answered **per part type**: `submittersOf(yaml, 'lead-sheet')`
   for a chart, `tabPartOwners(yaml, file)` for one tab. It used to be a
@@ -33,8 +33,20 @@ Serverless functions that run on Supabase Edge (Deno runtime).
   appeared on charts alone; tab rows carry it now, and the loose version
   would have let contributing a banjo tab buy an in-place overwrite of that
   work's primary chart (and its title/artist/key with it).
+  **`anyPartOwners(yaml)` is a deliberately different, LOOSER question** and
+  must not be "fixed" into `submittersOf`: it asks *do you have any stake in
+  this work?* and its only caller is the metadata column, which rewrites
+  nobody's content. Owning a tab does not buy a rewrite of a stranger's
+  lyrics; it does buy the right to say who wrote the song. Both functions
+  carry comments saying so, and both directions are pinned by tests.
+  `MetadataRefusedError` is the one typed refusal `classifyChange` can
+  return (403 no claim / 404 no such work / 400 no target) — the metadata
+  column is the only one with nothing additive to land a stranger's edit in.
 - `commit-song.ts` — the `PendingSong` shape, one Contents-API read used by
-  classification, and `unretryableReason`. Phase 2d deleted the
+  classification, and `unretryableReason` (which is **part-type aware**: a
+  metadata row carries no content by construction, so demanding one would
+  have made every metadata row permanently "unretryable" and opened an alert
+  issue about a well-formed row an hour after it was written). Phase 2d deleted the
   document-attachment path (and the write helpers only it used) along with
   the doc-upload feature; nothing in here writes to GitHub any more.
 
@@ -88,10 +100,12 @@ content or **beside** it, and a privilege escalation was found and fixed in it
 that decision shipped verified by nothing.
 
 - `functions/_shared/pending-dispatch.test.ts` — `partBlocks`, `submittersOf`,
-  `tabPartOwners`, the full `classifyChange` table for both columns, the
-  durable rate limit, and the escalation pinned in both directions (owning only
-  a tab must classify a chart edit `fork`; owning only a chart must classify a
-  tab correction `add`).
+  `tabPartOwners`, `anyPartOwners`, the full `classifyChange` table for all
+  three columns **including the metadata refusal**, the durable rate limit,
+  and the escalation pinned in both directions (owning only a tab must
+  classify a chart edit `fork`; owning only a chart must classify a tab
+  correction `add`). The metadata asymmetry is pinned side by side in one
+  test: same user, same work, chart edit → `fork`, metadata edit → `metadata`.
 - `functions/_shared/commit-song.test.ts` — `getFileContent`'s 404-is-the-only-
   null rule (a 500 read as "no work here" would let a placeholder overwrite a
   real `work.yaml`) and `unretryableReason`.
@@ -167,14 +181,22 @@ SQL migrations for the Supabase Postgres database. Version-controlled and applie
   200KB for a chart, 2MB for an OTF, because multi-track arrangements are
   genuinely that big and the chart cap would have rejected the best tabs at
   INSERT.
+  Since `20260818010000_pending_songs_metadata.sql` there is a third
+  `part_type`, **`metadata`**: no content at all (a CHECK refuses it), a
+  mandatory `replaces_id`, and a write that touches only the work's own
+  title / artist / key / notes. It exists because a work minted by a TAB had
+  a title and nothing else and no part anybody would want to rewrite in
+  order to fix that.
   **Row ids**: a chart row's `id` IS its work slug (one row per song). A tab
-  is a PART, so tab rows live in their own namespace — `tab:<slug>:<rand>`,
-  enforced by `pending_songs_tab_id_namespace` — and name their target work
-  in `replaces_id`. Keying them by the work id collided on the PK the moment
-  two people tabbed the same song, and surfaced as a *permissions* error
-  because the update policy gates on `created_by`. `notes` and `status` are
-  capped/enum-checked here too; the earlier cap pass skipped them on the
-  mistaken belief (in a comment, and in PR #237) that `notes` didn't exist
+  is a PART and a metadata edit is a per-user intent, so both live in their
+  own namespaces — `tab:<slug>:<rand>` and `meta:<slug>:<rand>`, enforced by
+  `pending_songs_tab_id_namespace` / `pending_songs_metadata_id_namespace` —
+  and name their target work in `replaces_id`. Keying them by the work id
+  collided on the PK the moment two people tabbed (or retitled) the same
+  song, and surfaced as a *permissions* error because the update policy
+  gates on `created_by`. `notes` and `status` are capped/enum-checked here
+  too; the earlier cap pass skipped them on the mistaken belief (in a
+  comment, and in PR #237) that `notes` didn't exist
 - `review_requests` - The destructive residue (phase 2d): trusted users request delete / suppress / merge-redirect, admins decide
 - `leaderboard_identities` - Opt-in real names for the High Scores board. **RLS on, zero policies** — only `get_leaderboard()` reads it
 - `leaderboard_salt` - One random uuid that salts the leaderboard aliases. **RLS on, zero policies.** Never expose it: contributor uuids are already public in `works/*/work.yaml` (`provenance.submitted_by`), so an unsalted alias hash would be a join key straight back to real contributors
@@ -253,6 +275,14 @@ rights, not speed:
 4. `.github/workflows/process-pending.yml` writes it to `works/` via
    `works_writer`, pushes, then flips `github_committed`.
 
+Metadata edits take the same four steps (2026-08-18), minus the content: the
+row carries `part_type: metadata`, no `content`, and whichever of
+title / artist / key / notes changed, and `process_pending.py` writes them
+through `works_writer.update_metadata`. A caller with no claim on the work is
+refused at step 3 with a 403 the client can show; the row stays in the table
+and the hourly reconciler files it as `unretryable` rather than retrying it
+forever.
+
 Tabs take the same four steps (2026-08-18). The row carries the serialized
 OTF in `content` plus `part_type: tablature` / `instrument` / `part_file`,
 and `process_pending.py` writes `works/<id>/<instrument>[-N].otf.json`
@@ -283,6 +313,32 @@ another take on the instrument rather than a rewrite. Ownership is asked of
 parts of the **same kind** on both sides of the dispatch
 (`submittersOf(yaml, partType)` / `process_pending.owns_content(..., part_type)`)
 — owning a tab is not owning a chart.
+
+Classification — **metadata** (the work's own title / artist / key / notes;
+no part is created, replaced, renamed or reordered and no part file is
+written):
+
+| Situation | Result |
+|---|---|
+| the caller is in `trusted_users` | `metadata` — full edit privileges, any work |
+| the caller's uuid appears on **any** part of the work (`submitted_by` on a chart or tab, `author` on a tab) | `metadata` |
+| anything else | **REFUSED** — 403 `MetadataRefusedError`, never a silent fork |
+| no work at `replaces_id` | **REFUSED** — 404. Never a `create`: there is no content to seed a work from |
+| no `replaces_id` at all | **REFUSED** — 400. The `meta:…` row id is a PK, not a work slug |
+
+This is the one column that refuses, and the one that asks the loose
+ownership question (`anyPartOwners`). Both follow from the same fact: no
+content is rewritten by naming an artist, so contributing anything earns the
+right — and a second opinion about a title is not an arrangement, so there
+is nowhere additive to put a stranger's edit. Silently forking one would put
+a duplicate work in the corpus every time somebody fixed a typo they were
+not entitled to fix.
+
+The action logged for it is **`metadata_edit`**, which `get_leaderboard()`
+does not count (it aggregates `song_submit`, `song_correction`, `tab_submit`,
+`tab_correction` only). A metadata tweak is neither a song nor a tab; it
+still lands in `submission_log`, so it still counts against the durable rate
+limit and is still auditable.
 
 **To add a trusted user:**
 ```sql

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -74,7 +74,7 @@ Both run in CI twice, and both gate:
 
 | Workflow | Job | Gates |
 |---|---|---|
-| `build.yml` | `verify` (with pytest + vitest) | every push and PR to main; `deploy` needs it |
+| `build.yml` | `verify` (with pytest + vitest) | every push and PR to main, plus every `workflow_run` from a content workflow named in its trigger list; `deploy` needs it |
 | `deploy-functions.yml` | `test` | `deploy` needs it — nothing reaches the edge runtime untested |
 
 The duplication is deliberate: the two workflows fire on separate triggers and

--- a/supabase/functions/_shared/commit-song.test.ts
+++ b/supabase/functions/_shared/commit-song.test.ts
@@ -183,3 +183,36 @@ Deno.test("unretryableReason: a tablature row is judged by the same three fields
   assertEquals(unretryableReason(tab), null)
   assertEquals(unretryableReason({ ...tab, content: null }), "missing content")
 })
+
+Deno.test("unretryableReason: a metadata row is retryable WITHOUT content", () => {
+  // The trap this pins: a metadata row carries no content by construction (a
+  // CHECK on pending_songs refuses one, because the row edits work.yaml and
+  // writes no part). Asking for content anyway would have made every metadata
+  // row permanently unretryable — filed for manual rescue an hour after it
+  // was written, with an alert issue opened about a perfectly well-formed row.
+  const meta = row({
+    id: "meta:salt-creek:9f3c2a",
+    part_type: "metadata",
+    replaces_id: "salt-creek",
+    content: null,
+  })
+  assertEquals(unretryableReason(meta), null)
+  assertEquals(unretryableReason({ ...meta, content: "" }), null)
+})
+
+Deno.test("unretryableReason: a metadata row must still name its target work", () => {
+  // It is what content is to the other columns: without it there is nothing
+  // to do, and no amount of waiting supplies one — a metadata edit can never
+  // mint a work, and its `meta:<slug>:<rand>` id is not a work slug.
+  const meta = row({
+    id: "meta:salt-creek:9f3c2a",
+    part_type: "metadata",
+    content: null,
+  })
+  assertEquals(unretryableReason(meta), "metadata row names no target work")
+  assertEquals(
+    unretryableReason({ ...meta, replaces_id: null }),
+    "metadata row names no target work",
+  )
+  assertEquals(unretryableReason({ ...meta, title: "" }), "missing title")
+})

--- a/supabase/functions/_shared/commit-song.ts
+++ b/supabase/functions/_shared/commit-song.ts
@@ -35,8 +35,9 @@ export interface PendingSong {
   /** Phase 3b: non-null means the dedup backstop refused to write this row. */
   dedup_hold?: string | null
   /**
-   * 'lead-sheet' (content is ChordPro) or 'tablature' (content is a
-   * serialized OTF JSON document). Absent on every row written before
+   * 'lead-sheet' (content is ChordPro), 'tablature' (content is a serialized
+   * OTF JSON document), or 'metadata' (NO content — the row edits the work's
+   * own title/artist/key/notes). Absent on every row written before
    * 2026-08-18; the column defaults to 'lead-sheet', so absent means chart.
    */
   part_type?: string | null
@@ -80,6 +81,18 @@ export async function getFileContent(path: string, githubToken: string): Promise
 export function unretryableReason(entry: PendingSong): string | null {
   if (!entry.id) return 'missing id'
   if (!entry.title) return 'missing title'
+
+  // A metadata row is the one shape with NOTHING in `content` — a CHECK on
+  // pending_songs refuses it there. Asking for content anyway would have
+  // made every metadata row permanently "unretryable", i.e. the reconciler
+  // would file it for manual rescue an hour after it was written and open an
+  // alert issue about a row that is perfectly well formed. What it must name
+  // instead is its target work, since a metadata edit can never mint one.
+  if ((entry.part_type || 'lead-sheet') === 'metadata') {
+    if (!entry.replaces_id) return 'metadata row names no target work'
+    return null
+  }
+
   if (!entry.content) return 'missing content'
   return null
 }

--- a/supabase/functions/_shared/pending-dispatch.test.ts
+++ b/supabase/functions/_shared/pending-dispatch.test.ts
@@ -25,7 +25,9 @@ import {
 } from "https://deno.land/std@0.168.0/testing/asserts.ts"
 
 import {
+  anyPartOwners,
   classifyChange,
+  MetadataRefusedError,
   partBlocks,
   RATE_LIMIT_PER_HOUR,
   slugify,
@@ -696,6 +698,219 @@ Deno.test("classifyChange tablature: a part_file pointing at a CHART -> add", as
       partFile: "lead-sheet.pro",
     })
     assertEquals(out.mode, "add")
+  })
+})
+
+// ============================================
+// anyPartOwners — the metadata column's LOOSER question
+// ============================================
+//
+// Deliberately a different question from submittersOf, and the tests are here
+// to stop a later reader "fixing" one into the other. submittersOf answers
+// "may you rewrite content of this kind in place?" and MUST stay scoped per
+// part type. This answers "do you have any stake in this work at all?" and is
+// only ever used to decide whether you may edit the work's own title / artist
+// / key / notes — where nobody's content is touched.
+
+Deno.test("anyPartOwners: everyone who contributed a part, of any kind", () => {
+  assertEquals(anyPartOwners(HOW_LONG), [PRIMARY_CHART_OWNER, FORK_OWNER, TAB_OWNER])
+})
+
+Deno.test("anyPartOwners: the tab owner IS here (this is the whole difference)", () => {
+  // submittersOf(HOW_LONG, 'lead-sheet') excludes TAB_OWNER — that exclusion
+  // is the escalation fix. This one includes them, on purpose.
+  assertEquals(submittersOf(HOW_LONG, "lead-sheet").includes(TAB_OWNER), false)
+  assertEquals(anyPartOwners(HOW_LONG).includes(TAB_OWNER), true)
+})
+
+Deno.test("anyPartOwners: a stranger is still a stranger", () => {
+  assertEquals(anyPartOwners(HOW_LONG).includes(STRANGER), false)
+})
+
+Deno.test("anyPartOwners: `author` counts on tablature parts (imports and the retired PR flow)", () => {
+  assertEquals(anyPartOwners(FOGGY).includes("schlange"), true)
+  assertEquals(anyPartOwners(ANGELINE).includes("Tim Purcell"), true)
+})
+
+Deno.test("anyPartOwners: `author` does NOT count on a chart part", () => {
+  // `author` is the tablature vocabulary — a display name credited on a tab.
+  // A chart's contributor is `submitted_by` (a verified uuid), and honouring
+  // a hand-written `author:` on a lead sheet would let an arbitrary string in
+  // a scraped work.yaml name an owner.
+  const yaml = `parts:
+- type: lead-sheet
+  file: lead-sheet.pro
+  provenance:
+    source: classic-country
+    author: ${STRANGER}
+`
+  assertEquals(anyPartOwners(yaml), [])
+})
+
+Deno.test("anyPartOwners: a block with no `type:` is not a part", () => {
+  // tags:/composers: entries are block-sequence entries too.
+  assertEquals(anyPartOwners(BLUE_MOON), [])
+  assertEquals(anyPartOwners(""), [])
+  assertEquals(anyPartOwners("id: x\nparts: []\n"), [])
+})
+
+// ============================================
+// classifyChange — metadata
+// ============================================
+
+Deno.test("classifyChange metadata: owning ANY part earns the edit", async () => {
+  await withGithub({ "works/how-long-blues/work.yaml": HOW_LONG }, async () => {
+    for (const uid of [PRIMARY_CHART_OWNER, FORK_OWNER, TAB_OWNER]) {
+      const out = await classify({
+        rowId: "meta:how-long-blues:9f3c2a",
+        replacesId: "how-long-blues",
+        userId: uid,
+        partType: "metadata",
+      })
+      assertEquals(out.mode, "metadata")
+      assertEquals(out.workId, "how-long-blues")
+      assertEquals(out.reason, "caller contributed a part of this work")
+    }
+  })
+})
+
+Deno.test("classifyChange metadata: owning only a TAB earns it — unlike a chart edit", async () => {
+  // The deliberate asymmetry, pinned side by side so the two questions can't
+  // be quietly merged. Same user, same work, two different asks:
+  await withGithub({ "works/how-long-blues/work.yaml": HOW_LONG }, async () => {
+    const chartEdit = await classify({
+      rowId: "row-1",
+      replacesId: "how-long-blues",
+      userId: TAB_OWNER,
+      partType: "lead-sheet",
+    })
+    // Rewriting somebody's lyrics: no. It forks.
+    assertEquals(chartEdit.mode, "fork")
+
+    const metadataEdit = await classify({
+      rowId: "meta:how-long-blues:9f3c2a",
+      replacesId: "how-long-blues",
+      userId: TAB_OWNER,
+      partType: "metadata",
+    })
+    // Saying the song is by the Stanley Brothers: yes. Nothing is rewritten.
+    assertEquals(metadataEdit.mode, "metadata")
+  })
+})
+
+Deno.test("classifyChange metadata: a trusted non-contributor -> metadata", async () => {
+  await withGithub({ "works/how-long-blues/work.yaml": HOW_LONG }, async () => {
+    const out = await classify({
+      rowId: "meta:how-long-blues:9f3c2a",
+      replacesId: "how-long-blues",
+      userId: STRANGER,
+      trusted: true,
+      partType: "metadata",
+    })
+    assertEquals(out.mode, "metadata")
+    assertEquals(out.reason, "trusted user metadata edit")
+  })
+})
+
+Deno.test("REFUSAL: a non-contributor's metadata edit is refused, never forked", async () => {
+  // The one column with no additive fallback. A second opinion about the
+  // artist is not an arrangement, so silently forking it would put a
+  // duplicate work in the corpus every time somebody fixed a typo they were
+  // not entitled to fix.
+  await withGithub({ "works/how-long-blues/work.yaml": HOW_LONG }, async () => {
+    const error = await assertRejects(
+      () =>
+        classify({
+          rowId: "meta:how-long-blues:9f3c2a",
+          replacesId: "how-long-blues",
+          userId: STRANGER,
+          partType: "metadata",
+        }),
+      MetadataRefusedError,
+    )
+    assertEquals(error.status, 403)
+    assertEquals(error.workId, "how-long-blues")
+  })
+})
+
+Deno.test("REFUSAL: an imported work nobody submitted refuses everyone untrusted", async () => {
+  // angeline-the-baker has no `submitted_by` anywhere — its tabs carry
+  // Hangout display names. A uuid never equals one, so no logged-in user
+  // owns a part here and only trust opens it.
+  await withGithub({ "works/angeline-the-baker/work.yaml": ANGELINE }, async () => {
+    await assertRejects(
+      () =>
+        classify({
+          rowId: "meta:angeline-the-baker:9f3c2a",
+          replacesId: "angeline-the-baker",
+          userId: STRANGER,
+          partType: "metadata",
+        }),
+      MetadataRefusedError,
+    )
+    const trusted = await classify({
+      rowId: "meta:angeline-the-baker:9f3c2a",
+      replacesId: "angeline-the-baker",
+      userId: STRANGER,
+      trusted: true,
+      partType: "metadata",
+    })
+    assertEquals(trusted.mode, "metadata")
+  })
+})
+
+Deno.test("REFUSAL: no work at the target is a 404, not a create", async () => {
+  // A metadata row has no content to seed a work from, so `create` is not one
+  // of its modes. Falling through to create would mint an empty work out of a
+  // typo'd slug.
+  await withGithub({}, async () => {
+    const error = await assertRejects(
+      () =>
+        classify({
+          rowId: "meta:nope:9f3c2a",
+          replacesId: "no-such-work",
+          userId: STRANGER,
+          trusted: true,
+          partType: "metadata",
+        }),
+      MetadataRefusedError,
+    )
+    assertEquals(error.status, 404)
+  })
+})
+
+Deno.test("REFUSAL: a metadata row with no target is a 400, and never reads the row id", async () => {
+  // `meta:<slug>:<rand>` is a pending_songs primary key, not a work slug. The
+  // chart column falls back to the row id; this one must not, or the id
+  // itself would become a directory name.
+  await withGithub({ "works/meta:how-long-blues:9f3c2a/work.yaml": HOW_LONG }, async () => {
+    for (const replacesId of [undefined, null, "", "   "]) {
+      const error = await assertRejects(
+        () =>
+          classify({
+            rowId: "meta:how-long-blues:9f3c2a",
+            replacesId,
+            userId: PRIMARY_CHART_OWNER,
+            trusted: true,
+            partType: "metadata",
+          }),
+        MetadataRefusedError,
+      )
+      assertEquals(error.status, 400, `replacesId=${JSON.stringify(replacesId)}`)
+    }
+  })
+})
+
+Deno.test("classifyChange metadata: part_file is ignored — this column edits no part", async () => {
+  await withGithub({ "works/how-long-blues/work.yaml": HOW_LONG }, async () => {
+    const out = await classify({
+      rowId: "meta:how-long-blues:9f3c2a",
+      replacesId: "how-long-blues",
+      userId: TAB_OWNER,
+      partType: "metadata",
+      partFile: "lead-sheet.pro",
+    })
+    assertEquals(out.mode, "metadata")
   })
 })
 

--- a/supabase/functions/_shared/pending-dispatch.ts
+++ b/supabase/functions/_shared/pending-dispatch.ts
@@ -34,8 +34,35 @@ export const DISPATCH_EVENT = 'pending-commit'
  * a shape the corpus has carried for years (foggy-mountain-breakdown has
  * eight banjo takes) and which PR #240 already made the tab flow's answer
  * to a same-instrument collision. Same rule, different noun.
+ *
+ * ``metadata`` is the odd one: it writes the WORK — title / artist / key /
+ * notes — and no part at all. It has no additive fallback because there is
+ * nothing to fall back into (an arrangement of a title is not a thing), so
+ * it is the one mode that can be REFUSED outright; see
+ * {@link MetadataRefusedError}.
  */
-export type ChangeMode = 'create' | 'update' | 'fork' | 'add'
+export type ChangeMode = 'create' | 'update' | 'fork' | 'add' | 'metadata'
+
+/**
+ * A metadata row that cannot be classified into a write.
+ *
+ * Every other column ends in something safe: a chart edit the caller does
+ * not own forks, a tab correction they do not own lands beside the original.
+ * A metadata edit has no such landing spot — "your alternate opinion of the
+ * artist" is not a part — so a caller with no claim on the work has to be
+ * told no. `status` is what the edge function returns; the message is
+ * written to be shown to a person.
+ */
+export class MetadataRefusedError extends Error {
+  readonly status: number
+  readonly workId: string
+  constructor(message: string, workId: string, status = 403) {
+    super(message)
+    this.name = 'MetadataRefusedError'
+    this.status = status
+    this.workId = workId
+  }
+}
 
 export interface Classification {
   mode: ChangeMode
@@ -153,6 +180,44 @@ export function submittersOf(workYaml: string, partType: string): string[] {
 }
 
 /**
+ * Everyone with a claim on ANY part of this work, of any kind.
+ *
+ * READ THIS BEFORE "FIXING" IT INTO {@link submittersOf}. The two functions
+ * ask deliberately different questions, and the difference is not sloppiness:
+ *
+ * - `submittersOf(yaml, type)` answers *may this caller rewrite CONTENT of
+ *   this kind in place?* That has to be scoped per part type, because owning
+ *   a banjo tab must not buy an in-place overwrite of a stranger's lyrics —
+ *   an escalation that was found, fixed, and is pinned by tests.
+ * - This one answers *does this caller have a stake in this work at all?*,
+ *   and its only consumer is the `metadata` column, which rewrites NOBODY'S
+ *   content — only the work's own title / artist / key / notes. The owner's
+ *   explicit rule (2026-08-18) is that contributing any part earns that.
+ *
+ * So the scoping that is load-bearing over there would be wrong here, and
+ * the looseness that is fine here would be an escalation over there. Keep
+ * them apart.
+ *
+ * `author` counts only on tablature parts, matching {@link tabPartOwners}:
+ * it is the display name the retired PR flow and every Hangout import
+ * record, so it identifies a person on exactly the parts that carry it.
+ */
+export function anyPartOwners(workYaml: string): string[] {
+  const out: string[] = []
+  for (const block of partBlocks(workYaml)) {
+    const type = blockValue(block, 'type')
+    if (!type) continue
+    const submitter = blockValue(block, 'submitted_by')
+    if (submitter) out.push(submitter)
+    if (type === 'tablature') {
+      const author = blockValue(block, 'author')
+      if (author) out.push(author)
+    }
+  }
+  return out
+}
+
+/**
  * Who owns the tablature part stored as `file`, or null if no part names it.
  *
  * One part, not the work: a work holding somebody else's banjo take and your
@@ -216,7 +281,10 @@ export interface ClassifyInput {
    * title. (The authoritative answer is still works_writer's — see below.)
    */
   title?: string | null
-  /** pending_songs.part_type — 'lead-sheet' (default) or 'tablature'. */
+  /**
+   * pending_songs.part_type — 'lead-sheet' (default), 'tablature', or
+   * 'metadata'.
+   */
   partType?: string | null
   /**
    * pending_songs.part_file — for a tab CORRECTION, the works/ filename it
@@ -251,6 +319,22 @@ export interface ClassifyInput {
  * A tab with no `part_file` is a submission, not a correction, so it skips
  * the ownership question entirely — there is no file to own yet.
  *
+ * Metadata (the work's own title / artist / key / notes, no part touched):
+ *
+ *   caller is trusted                        -> metadata (full edit rights)
+ *   caller owns ANY part of the work         -> metadata
+ *   otherwise                                -> REFUSED (403)
+ *
+ * The other two columns never refuse, because both have somewhere additive
+ * to land a stranger's edit. This one does not, and inventing one would be
+ * worse than saying no: a second opinion about the artist is not an
+ * arrangement, and silently forking one would put a duplicate work in the
+ * corpus every time somebody fixed a typo they weren't entitled to fix.
+ *
+ * Note the ownership question is {@link anyPartOwners}, NOT
+ * {@link submittersOf} — see the comment on `anyPartOwners` for why the two
+ * must not be collapsed into each other.
+ *
  * WHICH work a tab targets is not the row id. A chart row is keyed by its
  * work slug; a tab row is keyed by a synthetic `tab:<slug>:<rand>` so two
  * people can tab the same song without colliding on the primary key. So a
@@ -266,6 +350,19 @@ export interface ClassifyInput {
  */
 export async function classifyChange(input: ClassifyInput): Promise<Classification> {
   const isTab = input.partType === 'tablature'
+  const isMetadata = input.partType === 'metadata'
+
+  // A metadata row's id is `meta:<slug>:<rand>`, so — exactly as for a tab —
+  // it is never a work slug and must not become the fallback target. Unlike
+  // a tab it has no title-minting path either: there is no content to seed a
+  // work from, so a metadata row that names no target is simply malformed.
+  // The CHECK on pending_songs already refuses it; this is the answer for a
+  // hand-fired dispatch or a stale client.
+  if (isMetadata && !(input.replacesId || '').trim()) {
+    throw new MetadataRefusedError(
+      'A metadata edit has to say which work it edits.', '', 400)
+  }
+
   const fallbackId = isTab ? slugify(input.title || '') : input.rowId
   const workId = input.replacesId || fallbackId
   if (!workId) {
@@ -274,7 +371,31 @@ export async function classifyChange(input: ClassifyInput): Promise<Classificati
   const yaml = await getFileContent(`works/${workId}/work.yaml`, input.githubToken)
 
   if (yaml === null) {
+    if (isMetadata) {
+      // Not a create. There is nothing to create FROM, and minting an empty
+      // work out of a typo'd slug is the failure this refusal exists to
+      // avoid.
+      throw new MetadataRefusedError(
+        `There is no work at '${workId}' to edit.`, workId, 404)
+    }
     return { mode: 'create', workId: fallbackId, reason: 'no existing work at this id' }
+  }
+
+  if (isMetadata) {
+    if (input.trusted) {
+      return { mode: 'metadata', workId, reason: 'trusted user metadata edit' }
+    }
+    if (anyPartOwners(yaml).includes(input.userId)) {
+      return {
+        mode: 'metadata', workId,
+        reason: 'caller contributed a part of this work',
+      }
+    }
+    throw new MetadataRefusedError(
+      "You can edit a song's details once you've contributed one of its " +
+        'parts — a chart or a tab.',
+      workId,
+    )
   }
 
   if (isTab) {

--- a/supabase/functions/auto-commit-song/index.ts
+++ b/supabase/functions/auto-commit-song/index.ts
@@ -9,7 +9,8 @@
 //
 //   1. verify the caller owns the pending_songs row they are asking to commit
 //   2. durable per-user rate limit (counted from submission_log)
-//   3. classify the change — create / update / fork-to-arrangement
+//   3. classify the change — create / update / fork-to-arrangement / add /
+//      metadata, or refuse it (the metadata column is the only one that can)
 //   4. repository_dispatch to .github/workflows/process-pending.yml, which
 //      runs scripts/lib/process_pending.py -> works_writer (THE writer)
 //
@@ -29,6 +30,14 @@
 // carries the serialized OTF in `content` plus part_type / instrument /
 // part_file; the classification gains `add` (a sibling tab part) where a
 // chart would fork. See docs/plans/contribution-pipeline.md, phase 4c.
+//
+// Metadata edits (2026-08-18) are the third column: part_type = 'metadata',
+// no content at all, and the write touches only the work's own title /
+// artist / key / notes. They exist because a work minted by a TAB had a
+// title and nothing else, and no part anybody would want to rewrite in order
+// to fix that. Own any part of the work — or be trusted — and you may edit
+// its details; anyone else is refused, because unlike the other two columns
+// there is nothing additive to land a stranger's edit in.
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { type PendingSong } from "../_shared/commit-song.ts"
@@ -36,6 +45,7 @@ import { attributionFor, requireUser } from "../_shared/identity.ts"
 import {
   classifyChange,
   dispatchPendingCommit,
+  MetadataRefusedError,
   RATE_LIMIT_PER_HOUR,
   submissionsInLastHour,
 } from "../_shared/pending-dispatch.ts"
@@ -103,19 +113,30 @@ serve(async (req) => {
     if (row.created_by !== caller.id) {
       return json({ error: 'That submission belongs to someone else' }, 403)
     }
-    if (!row.title || !row.content) {
-      return json({ error: 'Missing required fields: title and content are required' }, 400)
-    }
-
-    // --- 1b. what KIND of part is this row? --------------------------------
+    // --- 1b. what KIND of row is this? -------------------------------------
     // The column has a default and a CHECK, so a well-formed row is already
-    // one of these two; the checks here exist so a client that guessed gets
+    // one of these three; the checks here exist so a client that guessed gets
     // a 400 it can show a person, instead of a CI failure it never sees.
     const partType = (row.part_type as string | null) || 'lead-sheet'
-    if (partType !== 'lead-sheet' && partType !== 'tablature') {
+    if (partType !== 'lead-sheet' && partType !== 'tablature' && partType !== 'metadata') {
       return json({ error: `Unknown part_type '${partType}'` }, 400)
     }
     const isTab = partType === 'tablature'
+    const isMetadata = partType === 'metadata'
+
+    if (!row.title) {
+      return json({ error: 'Missing required field: title' }, 400)
+    }
+    // A metadata row edits work.yaml and writes no part, so it carries no
+    // content at all (a CHECK on pending_songs enforces that). Demanding it
+    // here would reject the whole feature at the door.
+    if (!isMetadata && !row.content) {
+      return json({ error: 'Missing required field: content' }, 400)
+    }
+    if (isMetadata && !row.replaces_id) {
+      return json({ error: 'A metadata edit has to say which work it edits' }, 400)
+    }
+
     if (isTab) {
       if (!row.instrument) {
         return json({ error: 'A tablature row needs an instrument' }, 400)
@@ -164,18 +185,31 @@ serve(async (req) => {
     }, githubToken)
 
     // The action string is the contributor's whole public record: it is what
-    // get_leaderboard() counts (song_submit / song_correction / tab_submit /
-    // tab_correction, nothing else scores) and what My Submissions labels.
+    // get_leaderboard() counts and what My Submissions labels.
     // Only `update` is a correction — an `add` mints a NEW sibling part, so
     // it is a submission even when the user set out to fix somebody's tab.
-    const action = isTab
+    //
+    // `metadata_edit` is deliberately NOT one of the four scoring actions.
+    // get_leaderboard() (20260816120000_leaderboard.sql) aggregates exactly
+    // `song_submit, song_correction, tab_submit, tab_correction` and buckets
+    // them into `songs` and `tabs`; a new string is counted by neither, which
+    // is the whole point. Fixing a work's artist is worth doing and worth
+    // logging — it is not a song and it is not a tab, and letting a typo fix
+    // score the same as an arrangement would turn the board into a
+    // click-count. It still lands in submission_log, so it still counts
+    // against the durable rate limit and is still auditable.
+    const action = isMetadata
+      ? 'metadata_edit'
+      : isTab
       ? (classification.mode === 'update' ? 'tab_correction' : 'tab_submit')
       : 'song_submit'
 
     await supabaseAdmin.from('submission_log').insert({
       user_id: caller.id,
       action,
-      target_id: isTab ? classification.workId : row.id,
+      // A chart row's id IS its work slug; tab and metadata ids are synthetic
+      // (`tab:`/`meta:` namespaces), so those log the work they landed on.
+      target_id: (isTab || isMetadata) ? classification.workId : row.id,
       ip_address: req.headers.get('x-forwarded-for') || req.headers.get('cf-connecting-ip') || null,
       user_agent: req.headers.get('user-agent') || null,
       metadata: {
@@ -198,6 +232,14 @@ serve(async (req) => {
     })
 
   } catch (error) {
+    // A refused metadata edit is a decision, not a failure: the caller has no
+    // claim on this work (403), or named one that isn't there (404). Both
+    // carry a message written for a person, so pass it through rather than
+    // burying it in a 500 the client renders as "something went wrong".
+    if (error instanceof MetadataRefusedError) {
+      console.log(`Refused metadata edit of '${error.workId}': ${error.message}`)
+      return json({ error: error.message }, error.status)
+    }
     console.error('Error dispatching song commit:', error)
     const message = error instanceof Error ? error.message : String(error)
     return json({ error: message || 'Failed to commit song' }, 500)

--- a/supabase/functions/reconcile-pending/index.ts
+++ b/supabase/functions/reconcile-pending/index.ts
@@ -34,7 +34,11 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
 import { unretryableReason, type PendingSong } from "../_shared/commit-song.ts"
 import { attributionFor } from "../_shared/identity.ts"
-import { classifyChange, dispatchPendingCommit } from "../_shared/pending-dispatch.ts"
+import {
+  classifyChange,
+  dispatchPendingCommit,
+  MetadataRefusedError,
+} from "../_shared/pending-dispatch.ts"
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -102,6 +106,15 @@ serve(async (req) => {
     const { data: rows, error } = await supabase
       .from('pending_songs')
       // One string literal — supabase-js types the row off the literal.
+      //
+      // part_type / instrument / part_file are NOT optional here even though
+      // this function never reads them itself: they are what classifyChange
+      // needs to put the row in the right column. A retried tab that arrived
+      // without part_type would be re-classified as a chart and land as
+      // lead-sheet.pro holding an OTF; a retried METADATA row would be
+      // re-classified as a chart edit of the work named by its `meta:...` id
+      // — i.e. a create of a garbage slug. Both are data corruption, and both
+      // are invisible until somebody opens the work.
       .select('id, replaces_id, title, artist, composer, content, key, mode, tags, created_at, created_by, dedup_hold, part_type, instrument, part_file')
       .eq('github_committed', false)
       .order('created_at', { ascending: true })
@@ -166,10 +179,10 @@ serve(async (req) => {
           .eq('user_id', actorId)
           .maybeSingle()
 
-        // part_type / part_file ride along so a retried TAB is classified the
-        // way the live path would have classified it. Without them a tab row
-        // would be re-dispatched as a chart and land as lead-sheet.pro
-        // holding an OTF document.
+        // part_type / part_file ride along so a retried TAB or METADATA row
+        // is classified the way the live path would have classified it.
+        // Without them a tab row would be re-dispatched as a chart and land
+        // as lead-sheet.pro holding an OTF document.
         const classification = await classifyChange({
           rowId: row.id,
           replacesId: row.replaces_id,
@@ -204,6 +217,18 @@ serve(async (req) => {
         console.log(`Re-dispatched ${row.id} as ${classification.mode}`)
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e)
+        // A refused metadata edit will be refused identically every hour —
+        // ownership of a work does not change by waiting. It belongs in
+        // `unretryable` (needs a human to delete the row or grant trust), not
+        // in `stuck` (worth another GitHub call next hour). RLS lets any
+        // logged-in user INSERT a metadata row targeting any work, so this is
+        // a reachable state even though auto-commit-song already told them no
+        // in the browser.
+        if (e instanceof MetadataRefusedError) {
+          console.warn(`Refused metadata row ${row.id}:`, message)
+          unretryable.push({ id: row.id, title: row.title, created_at: row.created_at ?? null, error: message })
+          continue
+        }
         console.error(`Failed to reconcile ${row.id}:`, message)
         stuck.push({ id: row.id, title: row.title, created_at: row.created_at ?? null, error: message })
       }

--- a/supabase/migrations/20260818010000_pending_songs_metadata.sql
+++ b/supabase/migrations/20260818010000_pending_songs_metadata.sql
@@ -1,0 +1,117 @@
+-- A work's METADATA becomes editable on its own.
+--
+-- Every row shape this table has carried so far edits a PART: a chart's
+-- ChordPro, a tab's OTF. The work-level fields — title, artist, key, notes —
+-- have only ever ridden along as a side effect of rewriting the primary
+-- chart (`process_pending.apply_row`, the `work_updates` block). That leaves
+-- a work minted by a TAB stranded: it has a title taken from whatever the
+-- submitter typed, no artist, no key, and no part anybody would want to
+-- rewrite in order to fix them. There is no path to the fix at all.
+--
+-- So a third `part_type`, which is the honest name for "this row edits the
+-- work, not a part of it":
+--
+--     part_type   'lead-sheet' | 'tablature' | 'metadata'
+--
+-- The owner's rule for who may send one (2026-08-18):
+--
+--   * own a part of the work — ANY part, chart or tab — and you may edit its
+--     metadata;
+--   * trusted users get full edit privileges, on any work.
+--
+-- That is deliberately a LOOSER ownership question than the one the part
+-- columns ask, and the difference is what it buys. Owning a tab does not buy
+-- an in-place rewrite of a stranger's lyrics (see `submittersOf` in
+-- pending-dispatch.ts — that scoping is a fix for a real escalation and must
+-- not be relaxed). It does buy the right to say the song is in A and was
+-- written by the Stanley Brothers, because nobody's content is touched by
+-- saying so. The rule is enforced in the edge function, which is the only
+-- party that can see works/; SQL cannot answer "who owns a part" because the
+-- answer lives in git.
+--
+-- NOT APPLIED by this branch — apply with the rest of the phase.
+
+-- ============================================
+-- 1. part_type gains a third value
+-- ============================================
+
+-- 20260818000000 added this constraint and IS APPLIED, so it exists and has
+-- to be replaced rather than conditionally created. Dropping and re-adding a
+-- CHECK is a full-table validation; pending_songs is a working set of tens of
+-- rows, reaped by cleanup-pending, so that costs nothing.
+alter table pending_songs drop constraint if exists pending_songs_part_type;
+
+alter table pending_songs
+  add constraint pending_songs_part_type
+  check (part_type in ('lead-sheet', 'tablature', 'metadata'));
+
+comment on column pending_songs.part_type is
+  'lead-sheet (content is ChordPro), tablature (content is an OTF JSON '
+  'document), or metadata (no content — this row edits the work''s own '
+  'title/artist/key/notes and touches no part).';
+
+-- ============================================
+-- 2. What a metadata row must and must not carry
+-- ============================================
+
+do $$
+begin
+  -- A metadata edit has no work to mint. `create` is not one of its modes,
+  -- there is no content to seed a work from, and slugify(title) as a target
+  -- would let a typo mint an empty directory. It must name what it edits.
+  if not exists (select 1 from pg_constraint where conname = 'pending_songs_metadata_needs_target') then
+    alter table pending_songs
+      add constraint pending_songs_metadata_needs_target
+      check (part_type <> 'metadata' or replaces_id is not null);
+  end if;
+
+  -- ...and it must carry no content. The whole point of the row is that it
+  -- writes work.yaml and nothing else; a row with both would be ambiguous
+  -- about which part the bytes were for, and `process_pending` would have to
+  -- decide — which is exactly the kind of decision this table exists to keep
+  -- out of the writer. Refuse it here instead.
+  if not exists (select 1 from pg_constraint where conname = 'pending_songs_metadata_has_no_content') then
+    alter table pending_songs
+      add constraint pending_songs_metadata_has_no_content
+      check (part_type <> 'metadata' or content is null);
+  end if;
+
+  -- The id namespace, for exactly the reason tab rows got one
+  -- (20260818000000, `pending_songs_tab_id_namespace`): `id` is the PRIMARY
+  -- KEY and for a chart it IS the work slug, so keying a metadata row by the
+  -- work it targets means the second person to fix a song's artist collides
+  -- on the PK with the first — and, because the update policy gates on
+  -- `created_by = auth.uid()`, fails as a PERMISSIONS error that says nothing
+  -- about what actually went wrong. A pending chart and a pending metadata
+  -- edit for the same song could not coexist either.
+  --
+  --     meta:<slug>:<rand>
+  --       <slug>  the target work slug — human-scannable only; nothing
+  --               derives meaning from it (the target is replaces_id)
+  --       <rand>  >= 6 chars of [a-z0-9], which is what makes it unique
+  --
+  -- A chart slug can never contain `:` (slugify emits [a-z0-9-]), so the
+  -- three namespaces cannot overlap in any direction.
+  if not exists (select 1 from pg_constraint where conname = 'pending_songs_metadata_id_namespace') then
+    alter table pending_songs
+      add constraint pending_songs_metadata_id_namespace
+      check (part_type <> 'metadata' or id ~ '^meta:[a-z0-9-]*:[a-z0-9]{6,}$');
+  end if;
+end
+$$;
+
+-- The size cap (20260818000000, `pending_songs_content_size`) is left exactly
+-- as it is: it is already `content is null or ...`, and a metadata row's
+-- content is null by the constraint above. `notes` keeps its own 5000-char
+-- cap, which is the only free text one of these rows carries.
+
+-- ============================================
+-- 3. Index
+-- ============================================
+
+-- Same shape as idx_pending_songs_tablature, same reason: metadata rows are a
+-- small minority of the table and the surfaces that want them (My
+-- Submissions) want only them.
+create index if not exists idx_pending_songs_metadata
+  on pending_songs(created_by, created_at desc)
+  where part_type = 'metadata';

--- a/tests/test_process_pending.py
+++ b/tests/test_process_pending.py
@@ -1291,3 +1291,331 @@ class TestTabNotes:
 
         prov = read_work(tmp_path, 'salt-creek')['parts'][0]['provenance']
         assert 'x_submission_notes' not in prov
+
+
+# ============================================
+# Metadata
+# ============================================
+#
+# The third column (2026-08-18). A work minted by a TAB had a title and
+# nothing else — no artist, no key — and no path to a fix, because every row
+# shape this pipeline understood edited a PART and the work-level fields only
+# ever rode along with a rewrite of the primary chart. A tab-only work has no
+# chart to rewrite.
+#
+# What is worth guarding here, and what a regression would cost:
+#
+#   - the write is work-level ONLY. A metadata row that moved, renamed or
+#     rewrote a part would be destroying content its sender was never
+#     authorized to touch (the ownership question that let them in is
+#     deliberately looser than the one a content edit has to pass).
+#   - a field the row does not carry must not be blanked. The editor sends
+#     what changed; treating "absent" as "clear it" turns a one-field fix
+#     into an erasure of somebody else's work.
+#   - a replay is a no-op and a genuine re-edit applies, off a marker that
+#     cannot hash `content` because there isn't any.
+
+
+def meta_row(**kw):
+    # A metadata row's id is `meta:<slug>:<rand>` — its own namespace, for
+    # the same reason tab rows got one: two people fixing one song's details
+    # must not collide on the pending_songs primary key.
+    base = {
+        'id': 'meta:salt-creek:ab12cd',
+        'replaces_id': 'salt-creek',
+        'part_type': 'metadata',
+        'content': None,
+        'title': 'Salt Creek',
+        'artist': 'Bill Monroe',
+        'key': 'A',
+        'notes': None,
+        'created_by': SUBMITTER,
+        'created_at': '2026-08-18T12:00:00+00:00',
+    }
+    base.update(kw)
+    return base
+
+
+def parts_snapshot(tmp_path, work_id):
+    """The work's parts plus the bytes of every file in its directory.
+
+    Compared before and after a metadata write: "no part is created,
+    replaced, renamed or reordered, and no part file is written" is one
+    assertion this way, and it catches a reordering that a per-field check
+    would miss.
+    """
+    work_dir = tmp_path / 'works' / work_id
+    return (
+        json.dumps(read_work(tmp_path, work_id).get('parts'), sort_keys=True),
+        {p.name: p.read_bytes() for p in sorted(work_dir.iterdir())
+         if p.name != 'work.yaml'},
+    )
+
+
+class TestMetadataWrite:
+    def test_the_stranded_tab_work_gets_its_details(self, tmp_path):
+        """The case the column exists for: title only, nothing else."""
+        seed_tab_work(tmp_path)
+        before = parts_snapshot(tmp_path, 'salt-creek')
+
+        result = apply_row(tmp_path, meta_row(title='Salt Creek',
+                                              artist='Bill Monroe', key='A',
+                                              notes='Fiddle tune in A'),
+                           'metadata', 'salt-creek', actor='Jane Picker',
+                           verbose=False)
+
+        assert result.written
+        assert result.mode == 'update-metadata'
+        assert result.part_file is None
+
+        work = read_work(tmp_path, 'salt-creek')
+        assert work['title'] == 'Salt Creek'
+        assert work['artist'] == 'Bill Monroe'
+        assert work['default_key'] == 'A'
+        assert work['notes'] == 'Fiddle tune in A'
+
+        # ...and not one byte of the tab moved.
+        assert parts_snapshot(tmp_path, 'salt-creek') == before
+
+    def test_it_records_who_changed_the_details(self, tmp_path):
+        seed_tab_work(tmp_path)
+
+        apply_row(tmp_path, meta_row(), 'metadata', 'salt-creek',
+                  actor='Jane Picker', verbose=False)
+
+        prov = read_work(tmp_path, 'salt-creek')['metadata_provenance']
+        assert prov['source'] == 'user-submission'
+        assert prov['source_id'].startswith('pending:meta:salt-creek:ab12cd:')
+        assert prov['submitted_by'] == SUBMITTER
+        assert prov['submitted_at'] == '2026-08-18'
+
+    def test_it_works_on_a_work_whose_only_part_is_a_chart(self, tmp_path):
+        """Nothing about this column is tab-specific — a chart-only work is
+        the same write, and the chart is just as untouched."""
+        seed_work(tmp_path, 'blue-moon-of-kentucky', submitted_by=OTHER_USER)
+        before = parts_snapshot(tmp_path, 'blue-moon-of-kentucky')
+
+        apply_row(tmp_path,
+                  meta_row(id='meta:blue-moon-of-kentucky:ab12cd',
+                           replaces_id='blue-moon-of-kentucky',
+                           title='Blue Moon of Kentucky', artist='Bill Monroe',
+                           key='A'),
+                  'metadata', 'blue-moon-of-kentucky', verbose=False)
+
+        assert read_work(tmp_path, 'blue-moon-of-kentucky')['artist'] == \
+            'Bill Monroe'
+        assert parts_snapshot(tmp_path, 'blue-moon-of-kentucky') == before
+
+
+class TestMetadataPartialUpdates:
+    """An absent field means "I didn't touch this", never "blank it"."""
+
+    def test_a_field_the_row_does_not_carry_survives(self, tmp_path):
+        seed_tab_work(tmp_path)
+        works_writer.update_metadata(
+            tmp_path, 'salt-creek',
+            updates={'artist': 'Kenny Baker', 'default_key': 'A',
+                     'notes': 'From the 1974 record'},
+            provenance={'source': 'manual', 'source_id': 'seed'},
+            verbose=False)
+
+        apply_row(tmp_path,
+                  meta_row(title='Salt Creek', artist=None, key=None,
+                           notes=None),
+                  'metadata', 'salt-creek', verbose=False)
+
+        work = read_work(tmp_path, 'salt-creek')
+        assert work['title'] == 'Salt Creek'
+        assert work['artist'] == 'Kenny Baker'
+        assert work['default_key'] == 'A'
+        assert work['notes'] == 'From the 1974 record'
+
+    def test_an_empty_string_is_not_a_clear_either(self, tmp_path):
+        # A client that sends '' for an untouched input must not erase it —
+        # there is no "clear this field" gesture in this pipeline, and if one
+        # is ever wanted it has to be explicit rather than a side effect of a
+        # blank form control.
+        seed_tab_work(tmp_path)
+        works_writer.update_metadata(
+            tmp_path, 'salt-creek', updates={'artist': 'Kenny Baker'},
+            provenance={'source': 'manual', 'source_id': 'seed'},
+            verbose=False)
+
+        apply_row(tmp_path, meta_row(artist='   ', key=''), 'metadata',
+                  'salt-creek', verbose=False)
+
+        work = read_work(tmp_path, 'salt-creek')
+        assert work['artist'] == 'Kenny Baker'
+        assert 'default_key' not in work
+
+    def test_a_row_carrying_nothing_at_all_is_refused(self, tmp_path):
+        seed_tab_work(tmp_path)
+
+        with pytest.raises(ProcessPendingError, match='no fields to apply'):
+            apply_row(tmp_path,
+                      meta_row(title=None, artist=None, key=None, notes=None),
+                      'metadata', 'salt-creek', verbose=False)
+
+
+class TestMetadataReplay:
+    """The marker cannot hash `content` — there is none. It hashes the fields.
+
+    Hashing the (always null) content would give every metadata row in the
+    table the same marker, so the first edit of a work would make every later
+    edit of it look like a replay and silently do nothing.
+    """
+
+    def test_a_second_dispatch_of_the_same_row_is_a_no_op(self, tmp_path):
+        seed_tab_work(tmp_path)
+
+        first = apply_row(tmp_path, meta_row(), 'metadata', 'salt-creek',
+                          verbose=False)
+        after_first = (tmp_path / 'works/salt-creek/work.yaml').read_text()
+        second = apply_row(tmp_path, meta_row(), 'metadata', 'salt-creek',
+                           verbose=False)
+
+        assert first.written
+        assert not second.written
+        assert second.skipped_reason == 'already-applied'
+        assert (tmp_path / 'works/salt-creek/work.yaml').read_text() \
+            == after_first
+
+    def test_a_real_second_edit_is_not_treated_as_a_replay(self, tmp_path):
+        seed_tab_work(tmp_path)
+
+        apply_row(tmp_path, meta_row(artist='Bill Monroe'), 'metadata',
+                  'salt-creek', verbose=False)
+        edited = apply_row(tmp_path, meta_row(artist='Kenny Baker'),
+                           'metadata', 'salt-creek', verbose=False)
+
+        assert edited.written
+        assert read_work(tmp_path, 'salt-creek')['artist'] == 'Kenny Baker'
+
+    def test_two_rows_editing_one_work_do_not_shadow_each_other(self, tmp_path):
+        # Different rows, identical fields: the marker is row-scoped, so the
+        # second one is a genuine write rather than "already applied".
+        seed_tab_work(tmp_path)
+
+        apply_row(tmp_path, meta_row(), 'metadata', 'salt-creek',
+                  verbose=False)
+        other = apply_row(tmp_path, meta_row(id='meta:salt-creek:zz99xx'),
+                          'metadata', 'salt-creek', verbose=False)
+
+        assert other.written
+
+    def test_the_marker_is_field_scoped_not_order_scoped(self, tmp_path):
+        # Canonical (sorted-key) serialization: the same edit described in a
+        # different column order is the same edit.
+        from process_pending import metadata_marker
+
+        assert metadata_marker('r', {'title': 'T', 'artist': 'A'}) == \
+            metadata_marker('r', {'artist': 'A', 'title': 'T'})
+        assert metadata_marker('r', {'artist': 'A'}) != \
+            metadata_marker('r', {'artist': 'B'})
+        assert metadata_marker('r', {'artist': 'A'}) != \
+            metadata_marker('s', {'artist': 'A'})
+        assert metadata_marker('r', {'artist': 'A'}).startswith('pending:r:')
+
+    def test_the_marker_is_not_the_null_content_marker(self, tmp_path):
+        """The bug this whole scheme exists to avoid, stated directly."""
+        from process_pending import metadata_marker
+
+        assert metadata_marker('r', {'artist': 'A'}) != content_marker('r', '')
+
+
+class TestMetadataSkipsTheDedupBackstop:
+    def test_the_backstop_is_never_consulted(self, tmp_path):
+        """Not "it happened to say proceed" — it is not asked at all.
+
+        The backstop guards ONE thing: a `create` minting a slug for a song
+        already in the corpus. A metadata row mints nothing — it names an
+        existing work in replaces_id — so there is no slug to guard. It also
+        scores lyric containment over ChordPro, and this row has no content
+        at all to score.
+        """
+        seed_chart(tmp_path, 'salt-creek', 'Salt Creek', CHORDPRO)
+        backstop = DedupBackstop(tmp_path)
+
+        result = apply_row(tmp_path, meta_row(), 'metadata', 'salt-creek',
+                           verbose=False, backstop=backstop)
+
+        assert result.written
+        assert backstop.decision is None
+
+
+class TestMetadataRefusals:
+    def test_a_mode_from_another_column(self, tmp_path):
+        seed_tab_work(tmp_path)
+        for mode in ('create', 'update', 'fork', 'add'):
+            with pytest.raises(ProcessPendingError,
+                               match='unknown metadata mode'):
+                apply_row(tmp_path, meta_row(), mode, 'salt-creek',
+                          verbose=False)
+
+    def test_the_row_id_is_never_used_as_a_work_slug(self, tmp_path):
+        # `meta:salt-creek:ab12cd` is a pending_songs primary key. If a stale
+        # dispatch (or a hand-fired one) puts it where the work id belongs,
+        # refuse — do not mint `works/meta:salt-creek:ab12cd/`.
+        seed_tab_work(tmp_path)
+
+        with pytest.raises(ProcessPendingError, match='not a slug'):
+            apply_row(tmp_path, meta_row(), 'metadata',
+                      'meta:salt-creek:ab12cd', verbose=False)
+
+        assert not (tmp_path / 'works' / 'meta:salt-creek:ab12cd').exists()
+
+    def test_a_work_that_is_not_there(self, tmp_path):
+        (tmp_path / 'works').mkdir()
+
+        with pytest.raises(works_writer.WorkNotFoundError):
+            apply_row(tmp_path, meta_row(replaces_id='nothing-here'),
+                      'metadata', 'nothing-here', verbose=False)
+
+    def test_a_suppressed_work_is_skipped_not_written(self, tmp_path):
+        seed_tab_work(tmp_path)
+        registry = tmp_path / 'curation' / 'registry.yaml'
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        registry.write_text(yaml.dump({
+            'groups': {},
+            'suppressed': {'salt-creek': {'reason': 'merged away'}},
+        }))
+
+        result = apply_row(tmp_path, meta_row(artist='Kenny Baker'),
+                           'metadata', 'salt-creek', verbose=False)
+
+        assert not result.written
+        assert 'artist' not in read_work(tmp_path, 'salt-creek')
+
+
+class TestMetadataTouchesNoPart:
+    """The structural guarantee, asked of the writer rather than the caller.
+
+    `works_writer.update_metadata` accepts a whitelist of work-level keys and
+    `parts` is not on it, so "a metadata edit touches no part" is a property
+    of the function — not a promise `process_pending` has to keep.
+    """
+
+    def test_the_writer_refuses_to_write_parts(self, tmp_path):
+        seed_tab_work(tmp_path)
+
+        with pytest.raises(ValueError, match='cannot write parts'):
+            works_writer.update_metadata(
+                tmp_path, 'salt-creek', updates={'parts': []},
+                provenance={'source': 'user-submission', 'source_id': 'x'},
+                verbose=False)
+
+    def test_a_work_with_several_parts_keeps_all_of_them_in_order(self, tmp_path):
+        seed_work(tmp_path, 'salt-creek', submitted_by=OTHER_USER)
+        apply_row(tmp_path, tab_row(), 'add', 'salt-creek', actor='Alice',
+                  verbose=False)
+        apply_row(tmp_path,
+                  tab_row(id='tab:salt-creek:ef34gh',
+                          content=json.dumps(otf_doc(fret=7))),
+                  'add', 'salt-creek', actor='Bob', verbose=False)
+        before = parts_snapshot(tmp_path, 'salt-creek')
+
+        apply_row(tmp_path, meta_row(artist='Kenny Baker', key='A'),
+                  'metadata', 'salt-creek', verbose=False)
+
+        assert parts_snapshot(tmp_path, 'salt-creek') == before
+        assert len(read_work(tmp_path, 'salt-creek')['parts']) == 3

--- a/tests/test_tab_arrangements.py
+++ b/tests/test_tab_arrangements.py
@@ -414,3 +414,39 @@ class TestIndexContract:
         part = {'instrument': 'banjo',
                 'provenance': {'source_id': 'issue #42/v2'}}
         assert published_tab_name('w', part) == 'w-banjo-issue-42-v2.otf.json'
+
+
+class TestTabSubmitterIsPublished:
+    """A user-submitted tab publishes the contributor's uuid.
+
+    ``author`` is a DISPLAY NAME ("schlange"), which can never be compared to
+    an ``auth.uid()``. Without ``submitted_by`` the frontend cannot tell that
+    the signed-in user contributed this tab, so the "edit this work's details"
+    affordance vanished the moment their tab was published — which is exactly
+    what the first tab through the instant pipeline hit. The row level,
+    arrangements and document parts already published it; tablature was the
+    one omission.
+    """
+
+    def test_a_user_submitted_tab_carries_submitted_by(self, tmp_path):
+        work_dir = make_work(tmp_path, parts=[
+            tab_part('banjo', 'pending:tab:x:abc', source='user-submission',
+                     author='Mike Beaumier', submitted_by='u-123'),
+        ])
+        write_otf(work_dir / 'banjo.otf.json')
+        part = build_song_from_work(work_dir)['tablature_parts'][0]
+        assert part['submitted_by'] == 'u-123'
+        # The display name still rides along for attribution.
+        assert part['author'] == 'Mike Beaumier'
+
+    def test_an_imported_tab_publishes_no_submitter_key(self, tmp_path):
+        # Scraped tabs have an author and no uuid. The key must be OMITTED,
+        # not emitted as None, so the published row shape is byte-identical
+        # for the ~18k imported tabs.
+        work_dir = make_work(tmp_path, parts=[
+            tab_part('banjo', '111', author='schlange'),
+        ])
+        write_otf(work_dir / 'banjo.otf.json')
+        part = build_song_from_work(work_dir)['tablature_parts'][0]
+        assert 'submitted_by' not in part
+        assert part['author'] == 'schlange'

--- a/tests/test_workflow_deploy_triggers.py
+++ b/tests/test_workflow_deploy_triggers.py
@@ -1,0 +1,112 @@
+"""Every workflow that pushes to main must be wired to trigger a deploy.
+
+GitHub does not start workflows for pushes made with the default GITHUB_TOKEN
+(recursive-workflow prevention). So a workflow that commits to main produces a
+commit that nothing rebuilds — the change is durable in git and invisible on
+the site. `build.yml` compensates with a `workflow_run` trigger listing the
+content workflows by name.
+
+That list matches the triggering workflow's `name:` field, not its filename,
+and GitHub reports nothing at all when an entry matches no workflow. It has
+silently drifted twice:
+
+  - b1f61d46e (2026-08-15) deleted "Process Song Submission" / "Process Song
+    Correction"; their replacement "Process Pending Submission" was never
+    added, so every song and tab submission landed in works/ and never
+    deployed.
+  - 365d6bc4a (2026-08-14) renamed "Sync Deleted Songs" to "Sync Deleted +
+    Promoted Songs", unhooking admin deletes and Dungeon promotions.
+
+These tests make the next rename a red CI run instead of a stranded feature.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_DIR = Path(__file__).parent.parent / '.github' / 'workflows'
+BUILD_WORKFLOW = WORKFLOW_DIR / 'build.yml'
+
+# build.yml itself deploys; it must never appear in its own trigger list.
+SELF_NAME = 'CI & Deploy'
+
+
+def _load(path):
+    # PyYAML parses the `on:` key as the boolean True (YAML 1.1 truthiness).
+    return yaml.safe_load(path.read_text())
+
+
+def _triggers(cfg):
+    return cfg.get('on', cfg.get(True, {})) or {}
+
+
+def _workflow_files():
+    return sorted(
+        p for p in WORKFLOW_DIR.glob('*.y*ml') if p.name not in {'build.yml'}
+    )
+
+
+def _pushes_to_main(path):
+    """True if the workflow runs `git push` in a job step."""
+    return re.search(r'^\s*(?:if\s+)?git push\b', path.read_text(), re.M) is not None
+
+
+def _name_of(path):
+    name = _load(path).get('name')
+    assert name, f'{path.name} has no `name:` field'
+    return name
+
+
+@pytest.fixture(scope='module')
+def listed_names():
+    trig = _triggers(_load(BUILD_WORKFLOW))
+    assert 'workflow_run' in trig, (
+        'build.yml lost its workflow_run trigger — bot commits will stop deploying'
+    )
+    return list(trig['workflow_run']['workflows'])
+
+
+@pytest.fixture(scope='module')
+def pushing_names():
+    return {_name_of(p): p.name for p in _workflow_files() if _pushes_to_main(p)}
+
+
+def test_every_pushing_workflow_triggers_a_deploy(listed_names, pushing_names):
+    missing = {n: f for n, f in pushing_names.items() if n not in listed_names}
+    assert not missing, (
+        'These workflows push commits to main but are not in build.yml\'s '
+        f'workflow_run list, so their commits will never deploy: {missing}. '
+        'Add the exact `name:` string to .github/workflows/build.yml.'
+    )
+
+
+def test_no_dead_entries_in_the_trigger_list(listed_names):
+    """An entry naming no existing workflow is dead weight that reads as coverage."""
+    real = {_name_of(p) for p in _workflow_files()} | {SELF_NAME}
+    dead = [n for n in listed_names if n not in real]
+    assert not dead, (
+        f'build.yml lists workflows that do not exist: {dead}. '
+        'They were renamed or retired; the entry silently matches nothing.'
+    )
+
+
+def test_listed_workflows_actually_push(listed_names, pushing_names):
+    """A non-pushing workflow in the list fires a build on every completion."""
+    extra = [n for n in listed_names if n not in pushing_names]
+    assert not extra, (
+        f'These are in build.yml\'s workflow_run list but never `git push`: {extra}. '
+        'They trigger a gated no-op build on every run — drop them. '
+        '(Reconcile Pending Songs is the classic case: it commits only '
+        'indirectly, via a repository_dispatch to Process Pending Submission.)'
+    )
+
+
+def test_build_never_triggers_itself(listed_names):
+    """A self-trigger would loop forever; a push-to-main by build.yml would too."""
+    assert SELF_NAME not in listed_names
+    assert not _pushes_to_main(BUILD_WORKFLOW), (
+        'build.yml pushes to main. Combined with its workflow_run triggers that '
+        'is a deploy->commit->deploy loop.'
+    )

--- a/tests/test_works_writer.py
+++ b/tests/test_works_writer.py
@@ -6,6 +6,7 @@ suite guards its refusals as much as its writes:
 - create-new: suffix vs fail on collision, never a silent overwrite
 - add-part: enrichment, and refusal when the part is already there
 - update-part: correction flows that own the content
+- update-metadata: the work's OWN fields, and structurally no part
 - fork-to-arrangement: incoming chart lands as a NEW version part, the
   original untouched
 - suppression / redirect guards
@@ -32,6 +33,7 @@ from works_writer import (
     dump_work_yaml,
     fork_to_arrangement,
     load_work,
+    update_metadata,
     update_part,
 )
 
@@ -470,6 +472,114 @@ class TestForkToArrangement:
         with pytest.raises(ValueError):
             fork_to_arrangement(tmp_path, 'my-song', CHORDPRO,
                                 {'source': 'manual'}, version_label='')
+
+
+# ============================================
+# Mode: update-metadata
+# ============================================
+
+
+PROV = {'source': 'user-submission', 'source_id': 'pending:meta:x:abc123',
+        'submitted_by': '11111111-1111-4111-8111-111111111111'}
+
+
+class TestUpdateMetadata:
+    """Work-level fields, and — structurally — nothing else.
+
+    This exists because `update_part(..., work_updates=...)` cannot serve the
+    case: it has to find a part to rewrite before it writes anything, and the
+    works this is for (a song minted by a tab, with a title and no artist)
+    have no part their editor wants to touch. Reaching the work-level fields
+    through a loose part match would rewrite whichever part the match picked.
+    """
+
+    def test_it_writes_the_work_fields_and_no_part(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+        before = read_work(tmp_path, 'my-song')['parts']
+        chart = (tmp_path / 'works/my-song/lead-sheet.pro').read_bytes()
+
+        result = update_metadata(
+            tmp_path, 'my-song',
+            updates={'artist': 'Bill Monroe', 'default_key': 'A'},
+            provenance=PROV, verbose=False)
+
+        assert result.written
+        assert result.mode == 'update-metadata'
+        assert result.part_file is None
+
+        work = read_work(tmp_path, 'my-song')
+        assert work['artist'] == 'Bill Monroe'
+        assert work['default_key'] == 'A'
+        assert work['parts'] == before
+        assert (tmp_path / 'works/my-song/lead-sheet.pro').read_bytes() == chart
+
+    def test_only_whitelisted_fields(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+
+        # `parts` is the one that matters — it is what makes "touches no part"
+        # a property of the function rather than of its callers.
+        for bad in ({'parts': []}, {'id': 'somebody-else'},
+                    {'tags': ['Bluegrass']}, {'artist': 'ok', 'status': 'x'}):
+            with pytest.raises(ValueError):
+                update_metadata(tmp_path, 'my-song', updates=bad,
+                                provenance=PROV, verbose=False)
+
+        assert len(read_work(tmp_path, 'my-song')['parts']) == 1
+        assert read_work(tmp_path, 'my-song')['id'] == 'my-song'
+
+    def test_empty_values_are_dropped_never_written(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet(),
+                    artist='Bill Monroe')
+
+        update_metadata(tmp_path, 'my-song',
+                        updates={'artist': None, 'notes': '',
+                                 'composers': [], 'title': 'Renamed'},
+                        provenance=PROV, verbose=False)
+
+        work = read_work(tmp_path, 'my-song')
+        assert work['title'] == 'Renamed'
+        assert work['artist'] == 'Bill Monroe'
+        assert 'notes' not in work
+        assert 'composers' not in work
+
+    def test_nothing_to_apply_is_refused(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+        with pytest.raises(ValueError, match='no fields'):
+            update_metadata(tmp_path, 'my-song', updates={'artist': None},
+                            provenance=PROV, verbose=False)
+
+    def test_provenance_is_required_here_too(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+        with pytest.raises(ProvenanceRequiredError):
+            update_metadata(tmp_path, 'my-song', updates={'artist': 'X'},
+                            provenance={}, verbose=False)
+
+    def test_a_missing_work_is_refused(self, tmp_path):
+        with pytest.raises(WorkNotFoundError):
+            update_metadata(tmp_path, 'nobody-home', updates={'artist': 'X'},
+                            provenance=PROV, verbose=False)
+
+    def test_a_suppressed_work_is_skipped(self, tmp_path):
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+        write_registry(tmp_path, suppressed={'my-song': {'reason': 'gone'}})
+
+        result = update_metadata(tmp_path, 'my-song',
+                                 updates={'artist': 'X'}, provenance=PROV,
+                                 guards=Guards.load(tmp_path), verbose=False)
+
+        assert not result.written
+        assert 'artist' not in read_work(tmp_path, 'my-song')
+
+    def test_metadata_provenance_sits_above_parts_in_the_file(self, tmp_path):
+        # Canonical key order: the work's own fields, then its parts. A reader
+        # opening work.yaml should not have to scroll past a tab to find out
+        # who last renamed the song.
+        create_work(tmp_path, 'my-song', 'My Song', lead_sheet())
+        update_metadata(tmp_path, 'my-song', updates={'artist': 'X'},
+                        provenance=PROV, verbose=False)
+
+        text = (tmp_path / 'works/my-song/work.yaml').read_text()
+        assert text.index('metadata_provenance:') < text.index('parts:')
 
 
 def test_apply_version_metadata_is_idempotent():

--- a/works/welcome-to-new-york/work.yaml
+++ b/works/welcome-to-new-york/work.yaml
@@ -1,5 +1,6 @@
 id: welcome-to-new-york
 title: Welcome to New York
+artist: Bill Emerson
 tags:
 - Instrumental
 parts:


### PR DESCRIPTION
Five fixes from the first real use of the instant tab pipeline (#257), plus the metadata-editing scope that first use exposed. The submission itself worked end to end — row → classify → dispatch → `works_writer` → commit `f14681496` — but the tab was unreachable at its own URL, for two independent reasons that were hiding each other.

## 1. Nothing bot-committed has deployed since 2026-08-15

`build.yml` already knew `GITHUB_TOKEN` pushes don't start workflows and worked around it with `workflow_run`. What it didn't know is which workflows exist:

| listed name | reality |
|---|---|
| Process Song Submission | file deleted in `b1f61d46e` (Aug 15) |
| Process Song Correction | file deleted in `b1f61d46e` (Aug 15) |
| Sync Deleted Songs | renamed in `365d6bc4a` (Aug 14) |
| Process Tune Request | ok |

`"Process Pending Submission"` — which commits **every song and tab submission today** — was never added when phase 2b replaced the issue flow. Since Aug 15 every user submission has reached `works/` and waited for an unrelated human push, with no error anywhere: the pipeline reports success, the commit lands, CI is green, and the only symptom is a visitor getting "Song not found". It broke reaping too — `cleanup-pending` keys on `CI & Deploy` succeeding.

`workflow_run` matches on `name:` and says nothing when nothing matches. `tests/test_workflow_deploy_triggers.py` now asserts it both ways; replaying the old list fails all three defects. `Reconcile Pending Songs` is deliberately excluded — no checkout, no push.

## 2. A tab that mints a work was filed under the wrong id

`applyPendingTabs` keyed rows by `replaces_id || row.id` — correct while a tab row's id *was* the work slug, wrong once tab rows moved into the `tab:<slug>:<rand>` namespace in #257. A minting tab has no `replaces_id`, so it was filed under `tab:welcome-to-new-york:bciu053d` while every link uses the real slug. Now derived from the title with the server's rule, not parsed out of the id. Also stops the overlay row standing *beside* the published row (duplicate in search) once the commit deploys.

## 3. Editor action buttons overlapped

Not a #257 regression — that PR changed no site CSS. `work-edit.js` put word labels inside `.qc-btn`, the icon-only 32×32 shell every other caller fills with one glyph; as a flex container it can't shrink below ~55px min-content and centre-overflows a 32px box on a 40px pitch. Latent since `a3a1e45e6`. Fixed by using the labelled variant that already existed (`qc-toggle-btn`) — no new CSS.

## 4. A tab could never name its artist

Supported at every layer — `submitTab`, the column, the dispatch, `process_pending`, `works_writer` — and dropped at the first hop, because the create page had no input. The field now sits in the editor bar (a `.tef` import opens the editor directly and never sees the create form) and is sent only when the tab mints a work.

## 5. Metadata editing — own a part, or be trusted

The editor existed but keyed on `status: 'placeholder'`, which a tab work never gets. Widening that gate was the wrong fix: `savePlaceholderMetadata` wrote `status: 'placeholder'` plus a content round-trip, which on a tab-only work would have sent the row down the chart path.

So metadata becomes its own column — `part_type: 'metadata'`, content null, `replaces_id` required, `meta:<slug>:<rand>` id namespace. `works_writer.update_metadata` writes work-level fields through a whitelist that cannot name `parts` or `id`.

**The rule:** own any part of the work → edit its details; trusted users → any work; otherwise **403**. It's the one mode that can be refused: every other column ends somewhere safe, but there is no alternate arrangement of a title.

**Two ownership questions now exist and must not be merged.** `submittersOf(yaml, partType)` stays type-scoped because its answer buys an in-place rewrite of someone's *content* — unscoping it is the escalation where a banjo tab bought edit rights over a stranger's lyrics. `anyPartOwners(yaml)` is looser because its answer buys only work-level fields. Both carry comments saying so; the asymmetry is pinned in a side-by-side test.

### Three bugs found on the way, none of them the feature

- The idempotence marker hashes `content`, null here — every metadata row would have shared one marker, making the first edit of a work turn every later edit into a silent no-op.
- `unretryableReason` demanded content, so every well-formed metadata row would have been marked permanently unretryable and opened an alert issue an hour later.
- `build_works_index` published `author` (a display name) on tablature parts but not `submitted_by` (the uuid), so a tab submitter had the affordance from the overlay and lost it once published. Row level, arrangements and document parts already published it.

`works/welcome-to-new-york/work.yaml` is corrected directly to `artist: Bill Emerson`, since `works/` is the authoritative hand-editable store.

**Deploy note:** `20260818010000_pending_songs_metadata.sql` must be applied. `20260818000000` is already applied to prod and is untouched.

699 pytest / 1943 vitest / 73 deno green.