### PR TITLE
Correct a stale workflow comment

### DIFF
--- a/.github/workflows/sync-community-input.yml
+++ b/.github/workflows/sync-community-input.yml
@@ -38,9 +38,10 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          # The fetch scripts silently fall back to the cached files when
-          # creds are missing — fail loudly here instead so a misconfigured
-          # secret can't masquerade as "nothing to sync".
+          # The fetch scripts exit non-zero on their own if they cannot reach
+          # Supabase, so this check is belt-and-braces. It stays because it
+          # fails a step earlier and renders as a proper Actions annotation,
+          # which is easier to spot than a Python traceback.
           if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
             echo "::error::SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY secrets are not set"
             exit 1

--- a/.github/workflows/sync-deleted-songs.yml
+++ b/.github/workflows/sync-deleted-songs.yml
@@ -32,9 +32,10 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          # The fetch scripts silently fall back to the cached files when
-          # creds are missing — fail loudly here instead so a misconfigured
-          # secret can't masquerade as "nothing to sync".
+          # The fetch scripts exit non-zero on their own if they cannot reach
+          # Supabase, so this check is belt-and-braces. It stays because it
+          # fails a step earlier and renders as a proper Actions annotation,
+          # which is easier to spot than a Python traceback.
           if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
             echo "::error::SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY secrets are not set"
             exit 1


### PR DESCRIPTION
Both sync workflows carried a comment saying the fetch scripts *"silently fall back to the cached files when creds are missing"*. That stopped being true in #256, and a comment describing behaviour that no longer exists is worse than none — the next reader trusts it over the code.

The credential guard stays: it fails a step earlier and renders as a proper Actions annotation rather than a Python traceback. The comment now says that's why it's there, rather than claiming it's the only thing between a misconfigured secret and a silent no-op.

No behaviour change. Both files validated as YAML.