### PR TITLE
Stop the hourly Supabase sync committing a no-op to main

### DIFF
--- a/scripts/lib/export_genre_suggestions.py
+++ b/scripts/lib/export_genre_suggestions.py
@@ -20,6 +20,35 @@ from pathlib import Path
 OUTPUT_FILE = Path(__file__).parent.parent.parent / 'docs' / 'data' / 'user_genre_suggestions.json'
 
 
+def write_output(output):
+    """Write the export, keeping `exported_at` stable when nothing else moved.
+
+    The hourly Sync Community Input workflow commits whatever this writes.
+    A fresh `exported_at` on every run made the file differ every hour even
+    when Supabase had returned identical data, so the workflow's
+    `git diff --staged --quiet` guard never fired and main collected a no-op
+    commit (and a CI run) every hour. Carrying the previous timestamp forward
+    on an unchanged payload makes the file byte-identical, so the guard works.
+
+    `exported_at` now means "when the data last changed" rather than "when the
+    script last ran", which is the more useful of the two. fetch_tag_overrides
+    sidesteps this by writing no timestamp at all.
+    """
+    try:
+        previous = json.loads(OUTPUT_FILE.read_text())
+    except (FileNotFoundError, ValueError):
+        previous = None
+
+    if previous is not None:
+        stale = {k: v for k, v in previous.items() if k != 'exported_at'}
+        fresh = {k: v for k, v in output.items() if k != 'exported_at'}
+        if stale == fresh:
+            output = dict(output, exported_at=previous.get('exported_at', output['exported_at']))
+
+    with open(OUTPUT_FILE, 'w') as f:
+        json.dump(output, f, indent=2, sort_keys=True)
+
+
 def export_suggestions():
     """Export all genre suggestions from Supabase to JSON."""
     # Get credentials from environment
@@ -60,8 +89,7 @@ def export_suggestions():
             'songs': {},
             'tag_totals': {}
         }
-        with open(OUTPUT_FILE, 'w') as f:
-            json.dump(output, f, indent=2, sort_keys=True)
+        write_output(output)
         print(f"Wrote empty file to {OUTPUT_FILE}")
         return
 
@@ -89,8 +117,7 @@ def export_suggestions():
     }
 
     # Write to file
-    with open(OUTPUT_FILE, 'w') as f:
-        json.dump(output, f, indent=2, sort_keys=True)
+    write_output(output)
 
     print(f"Exported {len(rows)} suggestions for {len(suggestions_by_song)} songs")
     print(f"Unique tags: {len(tag_counts)}")

--- a/tests/test_genre_export_stability.py
+++ b/tests/test_genre_export_stability.py
@@ -1,0 +1,82 @@
+"""
+Tests for export_genre_suggestions.write_output().
+
+The hourly Sync Community Input workflow commits whatever this writes, guarded
+by `git diff --staged --quiet`. A fresh `exported_at` on every run defeated that
+guard: main collected a no-op commit (and a CI run) every hour for months.
+write_output() carries the previous timestamp forward when nothing else moved,
+so an unchanged export is byte-identical and the guard fires.
+"""
+
+import json
+
+import pytest
+
+import export_genre_suggestions as ege
+
+
+@pytest.fixture
+def out_file(tmp_path, monkeypatch):
+    path = tmp_path / 'user_genre_suggestions.json'
+    monkeypatch.setattr(ege, 'OUTPUT_FILE', path)
+    return path
+
+
+def payload(exported_at, songs=None):
+    return {
+        'exported_at': exported_at,
+        'total_suggestions': 1,
+        'unique_tags': 1,
+        'unique_songs': 1,
+        'songs': songs if songs is not None else {'some-song': {'bluegrass': 1}},
+        'tag_totals': {'bluegrass': 1},
+    }
+
+
+def test_unchanged_payload_is_byte_identical(out_file):
+    """The whole point: a re-run with identical data must not dirty the file."""
+    ege.write_output(payload('2026-08-23T08:53:13.669082Z'))
+    first = out_file.read_bytes()
+
+    ege.write_output(payload('2026-08-23T09:48:10.963550Z'))
+
+    assert out_file.read_bytes() == first
+
+
+def test_changed_payload_takes_the_new_timestamp(out_file):
+    ege.write_output(payload('2026-08-23T08:53:13.669082Z'))
+
+    ege.write_output(payload('2026-08-23T09:48:10.963550Z',
+                             songs={'some-song': {'bluegrass': 2}}))
+
+    written = json.loads(out_file.read_text())
+    assert written['exported_at'] == '2026-08-23T09:48:10.963550Z'
+    assert written['songs'] == {'some-song': {'bluegrass': 2}}
+
+
+def test_first_write_creates_the_file(out_file):
+    ege.write_output(payload('2026-08-23T08:53:13.669082Z'))
+
+    written = json.loads(out_file.read_text())
+    assert written['exported_at'] == '2026-08-23T08:53:13.669082Z'
+
+
+def test_corrupt_existing_file_is_overwritten(out_file):
+    out_file.write_text('{ not json')
+
+    ege.write_output(payload('2026-08-23T09:48:10.963550Z'))
+
+    written = json.loads(out_file.read_text())
+    assert written['exported_at'] == '2026-08-23T09:48:10.963550Z'
+
+
+def test_empty_export_is_also_stable(out_file):
+    """The no-rows branch writes through the same helper."""
+    empty = {'exported_at': 'a', 'total_suggestions': 0, 'unique_tags': 0,
+             'unique_songs': 0, 'songs': {}, 'tag_totals': {}}
+    ege.write_output(empty)
+    first = out_file.read_bytes()
+
+    ege.write_output(dict(empty, exported_at='b'))
+
+    assert out_file.read_bytes() == first


### PR DESCRIPTION
Found while surveying stale worktrees — `1b3ff3d` is one instance of it.

## `main` collects a no-op commit every hour

`Sync Community Input` runs at `:27` every hour and commits whatever the two
fetch scripts write:

```yaml
git add docs/data/tag_overrides.json docs/data/user_genre_suggestions.json
git diff --staged --quiet || git commit -m "Sync tag overrides and genre suggestions from Supabase"
```

The guard is right, but it never fires. `export_genre_suggestions.py` stamps a
fresh timestamp on every run:

```python
'exported_at': datetime.utcnow().isoformat() + 'Z',
```

so the file differs every hour even when Supabase returns byte-identical data.
`1b3ff3d` is the whole of one such commit:

```diff
-  "exported_at": "2026-08-23T08:53:13.669082Z",
+  "exported_at": "2026-08-23T09:48:10.963550Z",
```

**All 30 of the most recent sync commits on `main` changed nothing else.** Each
is a push to `main`, and each push starts a `CI & Deploy` run — 24 a day.

Worth noting `fetch_tag_overrides.py` writes to the same commit step in the same
workflow and has never caused this: it emits no timestamp at all.

## The fix

Keep `exported_at` — it's useful — but carry the previous value forward when the
rest of the payload is unchanged, so an unchanged export is byte-identical and
the existing guard works. The field now means "when the data last changed"
rather than "when the script last ran".

Both call sites route through the new helper, including the no-rows branch,
which had the same stamp.

No workflow change: the guard was always correct, it was being handed a file
that always differed.

## Tests

`tests/test_genre_export_stability.py` — 5 cases: unchanged payload is
byte-identical, changed payload takes the new timestamp, first write, corrupt
existing file, and the empty-export branch.

**851 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
