### PR TITLE
fix(paste): keep the song body when a whole UG page is pasted

### DIFF
--- a/docs/js/__tests__/smart-paste.test.js
+++ b/docs/js/__tests__/smart-paste.test.js
@@ -97,3 +97,89 @@ Rating`;
         expect(res.text).toContain('just some prose about tabs');
     });
 });
+
+// Regression: a whole-page select-all from a UG tab, chrome and all. The song
+// body used to be sliced away entirely — the header's "Tuning:E A D G B E"
+// reads as a chord line, so it won the start scan, and the chord-diagram
+// list's "Chords" header then ended the slice a few lines later.
+describe('cleanUltimateGuitarPaste on a full-page paste', () => {
+    const FULL_PAGE = `Tabs
+Courses
++ Publish tab
+Sample Song Chords by Some Artist
+451,846 views, added to favorites 13,040 times
+Difficulty:Absolute Beginner
+Tuning:E A D G B E
+Key:F#
+Capo:4th fret
+Author someuser [a] 123. 4 contributors total, last edit on 5 hours ago
+We have an official Sample Song tab made by UG professional guitarists.
+Chords
+D
+G
+A
+E
+Strumming
+EditIs this strumming pattern correct?
+[Verse 1]
+D
+first placeholder lyric line
+G                                        A
+second placeholder lyric line
+X
+Please rate this tab
+Welcome Offer
+Related tabs
+© 2026
+Ultimate-Guitar.com`;
+
+    it('keeps the song body and drops the page header', () => {
+        const res = cleanUltimateGuitarPaste(FULL_PAGE);
+        expect(res.cleaned).toBe(true);
+        expect(res.title).toBe('Sample Song');
+        expect(res.artist).toBe('Some Artist');
+        expect(res.text).toContain('[Verse 1]');
+        expect(res.text).toContain('first placeholder lyric line');
+        expect(res.text).toContain('second placeholder lyric line');
+        // header metadata, chord-diagram list and footer are all gone
+        expect(res.text).not.toContain('Tuning:');
+        expect(res.text).not.toContain('Capo:');
+        expect(res.text).not.toContain('Author someuser');
+        expect(res.text).not.toContain('Strumming');
+        expect(res.text).not.toContain('Ultimate-Guitar.com');
+        expect(res.text).not.toContain('Please rate this tab');
+    });
+
+    it('converts the full-page paste to ChordPro rather than a header dump', () => {
+        const res = convertPastedText(FULL_PAGE);
+        expect(res.kind).toBe('chordpro');
+        expect(res.text).toContain('{sov: Verse 1}');
+        expect(res.text).toContain('[D]first placeholder lyric line');
+        expect(res.text).toContain('[G]second placeholder lyric line');
+    });
+
+    it('finds the song without section markers, past the chord-diagram list', () => {
+        const noMarkers = `Sample Song Chords by Some Artist
+Tuning:E A D G B E
+Key:F#
+Capo:4th fret
+Chords
+D
+G
+A
+E
+Strumming
+D                    A
+first placeholder lyric line
+G                    D
+second placeholder lyric line`;
+        const res = cleanUltimateGuitarPaste(noMarkers);
+        expect(res.cleaned).toBe(true);
+        const lines = res.text.split('\n');
+        // the slice starts at the real chord line, not at the header or the
+        // trailing "E" of the chord-diagram list
+        expect(lines[0]).toMatch(/^D\s+A\s*$/);
+        expect(res.text).toContain('first placeholder lyric line');
+        expect(res.text).toContain('second placeholder lyric line');
+    });
+});

--- a/docs/js/smart-paste.js
+++ b/docs/js/smart-paste.js
@@ -8,6 +8,10 @@
  */
 function editorIsChordLine(line) {
     if (!line.trim()) return false;
+    // Labelled page metadata, not chords: "Tuning:E A D G B E" reads as five
+    // chords out of six words and clears the ratio test below. Real
+    // chords-over-lyrics lines never carry a colon.
+    if (line.includes(':')) return false;
     const words = line.trim().split(/\s+/);
     if (words.length === 0) return false;
     const chordPattern = /^[A-G][#b]?(?:maj|min|m|sus|dim|aug|add|M|7|9|11|13)*(?:\/[A-G][#b]?)?$/;
@@ -224,6 +228,47 @@ export function cleanChordUPaste(text) {
     };
 }
 
+const UG_SECTION_MARKER =
+    /^\[(Verse|Chorus|Intro|Bridge|Outro|Instrumental|Pre-Chorus|Hook|Interlude)/i;
+
+// Lines from UG's page header that sit above the song body. They are skipped
+// when falling back to the chord-over-lyrics scan for the song's first line.
+const UG_METADATA_LINE = [
+    /^Difficulty\s*:/i,
+    /^Tuning\s*:/i,
+    /^Key\s*:/i,
+    /^Capo\s*:/i,
+    /^Author\s/i,
+    /^[\d,]+\s+views\b/i,
+    /\sChords\s+by\s/i,
+    /^We have an official\b/i,
+    /^Strumming$/i,
+    /^Edit/i,
+];
+
+function isUgMetadataLine(line) {
+    return UG_METADATA_LINE.some(re => re.test(line));
+}
+
+/**
+ * UG prints a chord-diagram list above the song: a "Chords" header followed by
+ * one bare chord name per line. Return the index just past that block, or
+ * `start` unchanged when no block begins there.
+ */
+function skipUgChordDiagramBlock(lines, start) {
+    if (lines[start].trim() !== 'Chords') return start;
+    let i = start + 1;
+    while (i < lines.length) {
+        const trimmed = lines[i].trim();
+        if (!trimmed.includes(' ') && editorIsChordLine(trimmed)) {
+            i++;
+            continue;
+        }
+        break;
+    }
+    return i;
+}
+
 /**
  * Clean Ultimate Guitar paste format
  */
@@ -254,16 +299,34 @@ export function cleanUltimateGuitarPaste(text) {
         }
     }
 
-    // Find song content start
+    // Find song content start. The section-marker scan sweeps the whole paste
+    // before the chord-over-lyrics fallback gets a turn: UG's metadata header
+    // and its chord-diagram list both read as chord lines, so racing the two
+    // scans in one loop let page chrome win on every standard UG page and the
+    // real song body was sliced away.
     for (let i = 0; i < lines.length; i++) {
-        const line = lines[i].trim();
-        if (/^\[(Verse|Chorus|Intro|Bridge|Outro|Instrumental|Pre-Chorus|Hook|Interlude)/i.test(line)) {
+        if (UG_SECTION_MARKER.test(lines[i].trim())) {
             songStartIndex = i;
             break;
         }
-        if (editorIsChordLine(line) && i + 1 < lines.length && lines[i + 1].trim() && !editorIsChordLine(lines[i + 1])) {
-            songStartIndex = i;
-            break;
+    }
+
+    // No section markers (some tabs carry none): fall back to the first
+    // chord-line/lyric-line pair, stepping over the metadata header and the
+    // chord-diagram list so neither is mistaken for the song.
+    if (songStartIndex === -1) {
+        for (let i = 0; i < lines.length; i++) {
+            const past = skipUgChordDiagramBlock(lines, i);
+            if (past !== i) {
+                i = past - 1;
+                continue;
+            }
+            const line = lines[i].trim();
+            if (isUgMetadataLine(line)) continue;
+            if (editorIsChordLine(line) && i + 1 < lines.length && lines[i + 1].trim() && !editorIsChordLine(lines[i + 1])) {
+                songStartIndex = i;
+                break;
+            }
         }
     }
 
@@ -282,7 +345,7 @@ export function cleanUltimateGuitarPaste(text) {
             line.startsWith('© ') ||
             line === 'Chords' ||
             (line === 'X' && i > songStartIndex + 10) ||
-            line.includes('Please, rate this tab') ||
+            /please,?\s+rate this tab/i.test(line) ||
             line.match(/^\d+\.\d+$/) ||
             line.match(/^\d+ rates$/) ||
             /^\*?\s*Alternates?\s*:?\s*$/i.test(line)) {


### PR DESCRIPTION
## Problem

A select-all from an Ultimate Guitar tab page came out of the smart-paste pipeline as five lines of page metadata — tuning, key, capo, the author credit — with the entire chords-and-lyrics body discarded. Reported after pasting a full UG page into the manual lyrics-and-chords entry workflow.

Not a Visual editor regression: `git show 80ec83d18^:docs/js/editor.js` carries byte-identical start/end scan logic, so the bug predates both the extraction into `smart-paste.js` and `baf914cfa`. The Visual editor only surfaced it.

## Root cause

Two faults compounded in `cleanUltimateGuitarPaste`'s slice:

1. **The start scan raced two tests in one loop.** A `[Section]`-marker check and a chord-over-lyrics heuristic shared a single pass, so whichever matched at the lower index won. UG's header line `Tuning:E A D G B E` splits into six words, five of them valid chord names, which clears `editorIsChordLine`'s >50% ratio test — so the header always won, dozens of lines above the real `[Verse 1]`.

2. **The end scan stopped at the first line equal to `Chords`**, which on a full page is the chord-diagram list's header sitting *between* the metadata and the song. Start and end both landed in page chrome.

A third, latent fault: even with a correct start, the chord-diagram list itself would have been taken as the song start, since its last entry is followed by a non-chord line.

## Fix

- The section-marker scan sweeps the whole paste before the heuristic fallback gets a turn.
- The fallback steps over the metadata header (`isUgMetadataLine`) and the chord-diagram list (`skipUgChordDiagramBlock`) so neither is mistaken for the song body.
- `editorIsChordLine` rejects any line carrying a colon — real chord lines never have one, labelled metadata routinely does.
- UG's `Please rate this tab` end marker is now a regex; the old comma-bearing literal never matched the actual page text.

## Testing

- Three regression tests in `smart-paste.test.js`: the full-page paste, its ChordPro conversion, and the no-section-markers fallback. Fixtures use placeholder lyrics rather than copyrighted song text.
- Full suite green: **2809 tests across 108 files**. `editorIsChordLine` is shared with the Raw and OTF editors, so the whole suite was run rather than just the paste tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)