### PR TITLE
fix(paste): close the sections a pasted sheet opens

### DIFF
--- a/docs/js/__tests__/smart-paste.test.js
+++ b/docs/js/__tests__/smart-paste.test.js
@@ -150,6 +150,30 @@ Ultimate-Guitar.com`;
         expect(res.text).not.toContain('Please rate this tab');
     });
 
+    it('closes every section it opens', () => {
+        // An unclosed {soc}/{sov:} parses, but does not round-trip: the
+        // serializer supplies the missing {end_of_*}, so the saved work stops
+        // matching what the editor wrote and the corpus round-trip test fails.
+        const sheet = `[Verse 1]
+D                    G
+first placeholder lyric line
+[Chorus]
+G                    D
+second placeholder lyric line
+[Verse 2]
+D                    G
+third placeholder lyric line`;
+        const res = convertPastedText(sheet);
+        const opens = (res.text.match(/\{so[vcb]\b/g) || []).length;
+        const closes = (res.text.match(/\{eo[vcb]\}/g) || []).length;
+        expect(opens).toBe(3);
+        expect(closes).toBe(opens);
+        // the verse closes before the chorus opens, and the last section
+        // closes at the end rather than being left dangling
+        expect(res.text.indexOf('{eov}')).toBeLessThan(res.text.indexOf('{soc}'));
+        expect(res.text.trimEnd().endsWith('{eov}')).toBe(true);
+    });
+
     it('converts the full-page paste to ChordPro rather than a header dump', () => {
         const res = convertPastedText(FULL_PAGE);
         expect(res.kind).toBe('chordpro');

--- a/docs/js/smart-paste.js
+++ b/docs/js/smart-paste.js
@@ -68,6 +68,22 @@ export function editorConvertToChordPro(text) {
     const result = [];
     let i = 0;
 
+    // The section currently awaiting its closing directive ('v' | 'c' | 'b').
+    // A pasted sheet marks where sections start and never where they end, so
+    // this tracks the open one and closes it at the next marker or at EOF.
+    // Without it the output carries {soc}/{sov:} with no {eoc}/{eov}: that
+    // parses fine, but it does not round-trip — the serializer supplies the
+    // missing {end_of_*}, so a saved work no longer matches what the editor
+    // wrote and the corpus round-trip test fails on it.
+    let openSection = null;
+
+    const closeOpenSection = () => {
+        if (openSection === 'c') result.push('{eoc}');
+        else if (openSection === 'v') result.push('{eov}');
+        else if (openSection === 'b') result.push('{eob}');
+        openSection = null;
+    };
+
     while (i < lines.length) {
         const line = lines[i];
         const trimmed = line.trim();
@@ -81,14 +97,18 @@ export function editorConvertToChordPro(text) {
         if (editorIsSectionMarker(trimmed)) {
             const sectionName = trimmed.slice(1, -1).trim();
             const lowerName = sectionName.toLowerCase();
+            closeOpenSection();
             if (lowerName.includes('chorus')) {
                 result.push('{soc}');
+                openSection = 'c';
             } else if (lowerName.includes('verse')) {
                 result.push(`{sov: ${sectionName}}`);
+                openSection = 'v';
             } else if (lowerName.includes('instrumental') || lowerName.includes('break')) {
                 result.push(`{comment: ${sectionName}}`);
             } else if (lowerName.includes('bridge')) {
                 result.push('{sob}');
+                openSection = 'b';
             } else {
                 result.push(`{comment: ${sectionName}}`);
             }
@@ -127,6 +147,13 @@ export function editorConvertToChordPro(text) {
         result.push(line);
         i++;
     }
+
+    // Close the last section tight against its content: a sheet that ends in
+    // blank lines would otherwise trail its {eoc} after the gap.
+    while (openSection && result.length && result[result.length - 1].trim() === '') {
+        result.pop();
+    }
+    closeOpenSection();
 
     return result.join('\n');
 }

--- a/works/9-to-5-dolly-parton/lead-sheet.pro
+++ b/works/9-to-5-dolly-parton/lead-sheet.pro
@@ -5,7 +5,7 @@
 [D]Jump in the shower and the blood starts pumpin'
 [G]Out on the streets the traffic starts jumpin'
 With[D] folks like me on the[A] job from 9 [D]to 5
-
+{end_of_verse}
 
 {start_of_chorus}
 Workin' [G]9 to 5 - what a way to make a livin'
@@ -16,7 +16,7 @@ It's [E]enough to drive you[A] crazy if you let it
 You would[D] think that I would deserve a fair promotion
 Want to[G] move ahead but the boss won't seem to let me
 I [E]swear sometimes that man i[A]s out to get m[D]e mmmmmmm
-
+{end_of_chorus}
 
 {start_of_verse: Verse 2}
 [D]They let you dream just to watch 'em shatter
@@ -25,7 +25,7 @@ But [D]you got dreams he'll never take a[A]way
 [D]In the same boat with a lot of your friends
 [G]Waitin' for the day your ship'll come in
 And the [D]tide's gonna turn, an' it's [A]all gonna roll your[D] way
-
+{end_of_verse}
 
 {start_of_chorus}
 Workin' [G]9 to 5 - what a way to make a livin'
@@ -36,7 +36,7 @@ It's [E]enough to drive you[A] crazy if you let it
 There's a [D]better life - and you think about it don't you
 It's a [G]rich man's game - no matter what they call it
 And you [E]spend your life putting[A] money in his wallet
-
+{end_of_chorus}
 
 {start_of_chorus}
 [G]9 to 5 - what a way to make a livin'
@@ -47,3 +47,4 @@ It's [E]enough to drive you[A] crazy if you let it
 There's a [D]better life - and you dream about it don't you
 It's a [G]rich man's game - no matter what they call it
 And you [E]spend your life putting[A] money in his wallet
+{end_of_chorus}


### PR DESCRIPTION
Unblocks `main`, which has been red since `4eedbaead` — the gated deploy has been skipped on every push since.

## Problem

`editorConvertToChordPro` emitted `{soc}` / `{sov:}` / `{sob}` on each section marker and never emitted a matching close. That parses, but it does not round-trip: `serializeSong` supplies the missing `{end_of_*}`, so a work saved from a pasted sheet stops matching what the editor wrote, and the corpus round-trip property test in `visual-editor-model.test.js:190` fails on it.

The gap predates #269 but was unreachable from a full-page paste, because the song body never survived the UG cleaner to reach the converter. Unblocking the body exposed it, and the first song pasted through the fixed path — `works/9-to-5-dolly-parton` — landed with five opening directives and zero closing ones.

## Fix

- Track the open section; close it at the next marker or at EOF, trimming trailing blanks first so a sheet ends tight against its content rather than after a gap.
- Short forms (`{eov}` / `{eoc}` / `{eob}`) match the short openers already emitted; the model preserves both raw forms on round-trip.
- Repairs the committed lead sheet by running it through `serializeSong(parseSong(...))`, the same normalization the test asserts. All 36 content lines unchanged; only the 5 missing `{end_of_*}` lines added, and a second pass is verified to be a no-op.

## Testing

- New test asserts `opens === closes`, that a verse closes before the next chorus opens, and that the final section is not left dangling. The previous tests checked only that `{sov:}` / `{soc}` appeared, which is why the suite stayed green over the defect.
- Full suite: **2810 tests across 108 files, all passing** (was 2809 + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)