### PR TITLE
fix(shell): the top band rolls itself up instead of overlapping

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -9927,11 +9927,16 @@ body.dungeon-mode #search-stats {
 
 .app-banner-dismiss:hover { opacity: 1; }
 
+/* The band's regions hold their natural width (the title is the one elastic
+   part). Letting them shrink is what produced the overlap this replaces: the
+   nav compressed past its content, spilled out of .topbar-left, and painted
+   over the actions. Holding their width instead turns "too narrow" into a
+   clean scrollWidth overflow, which is the signal shell.js measures. */
 .topbar-left {
     display: flex;
     align-items: center;
     gap: var(--space-sm);
-    min-width: 0;
+    flex-shrink: 0;
 }
 
 .topbar-back {
@@ -9982,6 +9987,7 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     display: flex;
     align-items: center;
     gap: var(--space-xs);
+    flex-shrink: 0;
 }
 
 .topbar-nav-link {
@@ -9993,6 +9999,7 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     color: var(--text-secondary);
     text-decoration: none;
     font-size: var(--font-sm);
+    white-space: nowrap;
 }
 
 .topbar-nav-link:hover { color: var(--text); background: var(--bg-secondary); }
@@ -10013,6 +10020,7 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     align-items: center;
     gap: var(--space-xs);
     margin-left: auto;
+    flex-shrink: 0;
 }
 
 .topbar-action-btn {
@@ -10026,6 +10034,7 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     font-size: var(--font-sm);
     padding: 0.3rem 0.6rem;
     cursor: pointer;
+    white-space: nowrap;
 }
 
 .topbar-action-btn:hover { border-color: var(--accent); }
@@ -10039,6 +10048,7 @@ body.dungeon-mode .topbar-brand .brand-dungeon-face {
     display: flex;
     align-items: center;
     gap: var(--space-xs);
+    flex-shrink: 0;
 }
 
 .topbar-icon-btn {
@@ -10142,12 +10152,43 @@ body.has-bottomband .container {
     margin: var(--space-xs) 0;
 }
 
-/* Collapse top-band labels to icons well before they can crowd the band */
+/* ---- Top band density ladder (driven by shell.js updateDensity) ----
+   The band measures itself and adds these classes cumulatively until its
+   content fits, so the collapse follows the CONTENT — a long display name,
+   a view with three actions — rather than a viewport width that cannot know
+   what the band is currently carrying. Ordered cheapest-loss-first; nothing
+   that disappears here becomes unreachable. */
+
+/* 1. Tighten the spacing before anything is actually dropped. */
+.app-topbar.density-snug { gap: 0.35rem; padding: 0 0.5rem; }
+.app-topbar.density-snug .topbar-nav-link,
+.app-topbar.density-snug .topbar-action-btn { padding: 0.3rem 0.45rem; }
+
+/* 2. The display name goes; the avatar still opens the account menu. */
+.app-topbar.density-no-name .user-name { display: none; }
+
+/* 3. The center title goes; the page itself still shows it. */
+.app-topbar.density-no-title .topbar-title { display: none; }
+
+/* 4. Actions become icons — the label survives as the button's tooltip. */
+.app-topbar.density-icons .topbar-action-label,
+.app-topbar.density-icons .auth-text { display: none; }
+
+/* 5. Nav becomes icons. */
+.app-topbar.density-nav-icons .topbar-nav-label { display: none; }
+
+/* 6. Fully rolled up: nav leaves the band for the ⋯ menu, where shell.js
+      renderOverflow has already put the same items as text entries. */
+.app-topbar.density-nav-overflow .topbar-nav { display: none; }
+
+/* No-JS / no-ResizeObserver fallback: without the ladder the band still has
+   to cope, so keep the old viewport breakpoint for the un-measured case
+   only. shell.js sets data-density on its first pass, which retires this. */
 @media (max-width: 800px) {
-    .topbar-nav-label { display: none; }
-    .topbar-nav-link { padding: 0.3rem 0.45rem; }
-    .topbar-action-label { display: none; }
-    .topbar-title { display: none; }
+    .app-topbar:not([data-density]) .topbar-nav-label { display: none; }
+    .app-topbar:not([data-density]) .topbar-nav-link { padding: 0.3rem 0.45rem; }
+    .app-topbar:not([data-density]) .topbar-action-label { display: none; }
+    .app-topbar:not([data-density]) .topbar-title { display: none; }
 }
 
 /* ============================================

--- a/docs/js/__tests__/shell.test.js
+++ b/docs/js/__tests__/shell.test.js
@@ -87,3 +87,114 @@ describe('setBanner (DOM)', () => {
         expect(banner.querySelector('.app-banner-retry')).toBeNull();
     });
 });
+
+// The density ladder (shell.js updateDensity), added for the overlapping-band
+// bug: at ~810-830px the "Lists" nav link painted 22px over the "Lists" action
+// button, and "Add Song" wrapped to two lines from ~840px down. The old
+// collapse was a single @media (max-width: 800px) breakpoint, which cannot
+// know what the band is currently carrying — the actions differ per view and
+// a signed-in display name is as long as the person is. So the band measures
+// itself instead. jsdom has no layout, so these tests drive the measurement
+// directly: clientWidth is the band, scrollWidth is what the content needs at
+// whatever density step is currently applied.
+describe('density ladder', () => {
+    const NAV = [
+        { id: 'search', label: 'Search', href: '#search', onClick: () => {} },
+        { id: 'lists', label: 'Lists', href: '#lists', onClick: () => {} },
+    ];
+
+    // Each rung is worth 100px, so a band of width W settles on the first
+    // step whose content fits: full=1000, snug=900, no-name=800, no-title=700,
+    // icons=600, nav-icons=500, nav-overflow=400.
+    function mountBand(bandWidth) {
+        const bar = document.getElementById('app-topbar');
+        Object.defineProperty(bar, 'clientWidth', { get: () => bandWidth, configurable: true });
+        Object.defineProperty(bar, 'scrollWidth', {
+            configurable: true,
+            get: () => 1000 - 100 * [...bar.classList].filter(c => c.startsWith('density-')).length,
+        });
+        return bar;
+    }
+
+    async function freshShell() {
+        vi.resetModules();
+        document.body.innerHTML = '';
+        const mod = await import('../shell.js');
+        mod.initShell({ nav: NAV });
+        return mod;
+    }
+
+    it('stays at full density when the content already fits', async () => {
+        const { updateDensity } = await freshShell();
+        const bar = mountBand(1000);
+        updateDensity();
+
+        expect(bar.dataset.density).toBe('full');
+        expect([...bar.classList].filter(c => c.startsWith('density-'))).toEqual([]);
+    });
+
+    it('sheds only as many steps as it takes to fit', async () => {
+        const { updateDensity } = await freshShell();
+        const bar = mountBand(850);
+        updateDensity();
+
+        // 1000 and 900 overflow an 850px band; 800 fits.
+        expect(bar.dataset.density).toBe('no-name');
+        expect(bar.classList.contains('density-snug')).toBe(true);
+        expect(bar.classList.contains('density-no-name')).toBe(true);
+        expect(bar.classList.contains('density-no-title')).toBe(false);
+    });
+
+    it('bottoms out at nav-overflow and moves the nav into the ⋯ menu', async () => {
+        const { updateDensity } = await freshShell();
+        const bar = mountBand(200);   // nothing fits
+        updateDensity();
+
+        expect(bar.dataset.density).toBe('nav-overflow');
+        const menuLabels = [...document.querySelectorAll('#topbar-overflow-menu .pill-popover-item')]
+            .map(b => b.textContent);
+        expect(menuLabels).toEqual(['Search', 'Lists']);
+        // and the rolled-up entries are wired to the same handlers
+        expect(document.getElementById('overflow-nav-search')).not.toBeNull();
+    });
+
+    it('climbs back up and returns the nav to the band when room comes back', async () => {
+        const { updateDensity } = await freshShell();
+        let width = 200;
+        const bar = document.getElementById('app-topbar');
+        Object.defineProperty(bar, 'clientWidth', { get: () => width, configurable: true });
+        Object.defineProperty(bar, 'scrollWidth', {
+            configurable: true,
+            get: () => 1000 - 100 * [...bar.classList].filter(c => c.startsWith('density-')).length,
+        });
+
+        updateDensity();
+        expect(bar.dataset.density).toBe('nav-overflow');
+
+        width = 1000;
+        updateDensity();
+        expect(bar.dataset.density).toBe('full');
+        expect([...bar.classList].filter(c => c.startsWith('density-'))).toEqual([]);
+        // nav is back in the band, so it must not be duplicated in the menu
+        const menuLabels = [...document.querySelectorAll('#topbar-overflow-menu .pill-popover-item')]
+            .map(b => b.textContent);
+        expect(menuLabels).toEqual([]);
+    });
+
+    it('re-measures when a view swaps its actions in', async () => {
+        const { updateDensity, setTopBar } = await freshShell();
+        const bar = mountBand(850);
+        updateDensity();
+        expect(bar.dataset.density).toBe('no-name');
+
+        // A view whose actions are wider: every step now costs the band 50px
+        // less, so it has to shed further to fit the same 850px.
+        Object.defineProperty(bar, 'scrollWidth', {
+            configurable: true,
+            get: () => 1200 - 100 * [...bar.classList].filter(c => c.startsWith('density-')).length,
+        });
+        setTopBar({ actions: [{ id: 'export', label: 'Export', onClick: () => {} }] });
+
+        expect(bar.dataset.density).toBe('icons');
+    });
+});

--- a/docs/js/shell.js
+++ b/docs/js/shell.js
@@ -15,6 +15,8 @@ let actionsEl = null;
 let titleEl = null;
 let backBtn = null;
 let overflowMenu = null;
+let navEl = null;
+let navItems = [];
 let openPopover = null; // only one pill/overflow popover open at a time
 
 /**
@@ -74,7 +76,8 @@ export function initShell({ nav = [], onToggleTheme, onReportBug } = {}) {
     backBtn = topbarEl.querySelector('#topbar-back');
     overflowMenu = topbarEl.querySelector('#topbar-overflow-menu');
 
-    const navEl = topbarEl.querySelector('.topbar-nav');
+    navItems = nav;
+    navEl = topbarEl.querySelector('.topbar-nav');
     for (const item of nav) {
         const a = document.createElement('a');
         a.href = item.href;
@@ -114,6 +117,83 @@ export function initShell({ nav = [], onToggleTheme, onReportBug } = {}) {
     topbarEl.addEventListener('click', () => {
         document.body.classList.remove('chrome-hidden');
     });
+
+    // The band re-measures on width changes (the observer sees the viewport,
+    // since the band is full-width) and whenever supabase-auth swaps the
+    // sign-in button for an avatar + display name — that name is the usual
+    // reason a band that fit a moment ago no longer does.
+    if (typeof ResizeObserver !== 'undefined') {
+        new ResizeObserver(updateDensity).observe(topbarEl);
+    }
+    const authEl = topbarEl.querySelector('#auth-section');
+    if (authEl && typeof MutationObserver !== 'undefined') {
+        new MutationObserver(updateDensity).observe(authEl, {
+            subtree: true, childList: true, characterData: true, attributes: true,
+        });
+    }
+    updateDensity();
+}
+
+/**
+ * Responsive density — the band rolls itself up until it fits.
+ *
+ * A viewport breakpoint cannot answer "does this fit?", because the band's
+ * content width does not follow the viewport: the actions differ per view,
+ * the center title is whatever the song is called, and a signed-in name is
+ * as long as the person is. That mismatch is what let the nav spill out and
+ * paint on top of the actions at ~800-1000px. So the band measures itself
+ * instead, shedding one layer of detail at a time until the content fits.
+ *
+ * Steps are cumulative and ordered cheapest-loss-first. Each is a single
+ * `density-*` class handled in style.css, except the last, which re-homes
+ * the nav links into the ⋯ menu so they stay reachable rather than simply
+ * vanishing. The ladder bottoms out at roughly a 300px band (back · brand ·
+ * action icons · ⋯); below that the band overflows, which is deliberate —
+ * the phone rules at 640px have already trimmed it further by then.
+ */
+const DENSITY_STEPS = ['full', 'snug', 'no-name', 'no-title', 'icons', 'nav-icons', 'nav-overflow'];
+let navInOverflow = false;
+let densityPass = false;
+
+function bandFits() {
+    // 1px of slack: sub-pixel layout rounding reports phantom overflow, and a
+    // phantom overflow would collapse a band that is actually fine.
+    return topbarEl.scrollWidth <= topbarEl.clientWidth + 1;
+}
+
+function applyDensity(step) {
+    DENSITY_STEPS.forEach((name, i) => {
+        topbarEl.classList.toggle(`density-${name}`, i > 0 && i <= step);
+    });
+    topbarEl.dataset.density = DENSITY_STEPS[step];
+    const wantNavInOverflow = DENSITY_STEPS[step] === 'nav-overflow';
+    if (wantNavInOverflow !== navInOverflow) {
+        navInOverflow = wantNavInOverflow;
+        renderOverflow(lastViewOverflow);
+    }
+}
+
+/**
+ * Re-measure and pick the smallest density step the content fits in. Called
+ * on resize, on every setTopBar(), and when the auth chip changes.
+ */
+export function updateDensity() {
+    if (!topbarEl || densityPass) return;
+    densityPass = true;
+    try {
+        // Walk from the top every pass rather than nudging the current step:
+        // the previous answer is stale the moment the view's actions change,
+        // and only a full walk can climb back up when room is returned. Every
+        // step is applied inside this one synchronous task, so no
+        // intermediate state ever reaches the screen.
+        let step = 0;
+        applyDensity(step);
+        while (step < DENSITY_STEPS.length - 1 && !bandFits()) {
+            applyDensity(++step);
+        }
+    } finally {
+        densityPass = false;
+    }
 }
 
 /**
@@ -160,9 +240,14 @@ export function setTopBar({ back = null, title = null, actions = [], overflow = 
     topbarEl.querySelectorAll('.topbar-nav-link').forEach(a => {
         a.classList.toggle('active', a.dataset.nav === navActive);
     });
+
+    // Actions and title just changed, so the width that fit a moment ago
+    // tells us nothing — measure again.
+    updateDensity();
 }
 
 let overflowBase = [];
+let lastViewOverflow = [];
 
 /** Persistent overflow entries (About, Patreon, Feedback, …) seeded once by main.js. */
 export function setOverflowBase(items) {
@@ -172,8 +257,16 @@ export function setOverflowBase(items) {
 
 function renderOverflow(viewItems) {
     if (!overflowMenu) return;
+    lastViewOverflow = viewItems;
     overflowMenu.textContent = '';
-    const groups = viewItems.length ? [viewItems, overflowBase] : [overflowBase];
+    // At the last density step the nav links have left the band; they lead
+    // the ⋯ menu so navigation is still one tap away.
+    const navGroup = navInOverflow ? navItems.map(item => ({
+        id: item.id ? `overflow-nav-${item.id}` : null,
+        label: item.label,
+        onClick: item.onClick || (() => { location.href = item.href; }),
+    })) : [];
+    const groups = [navGroup, viewItems, overflowBase].filter(group => group.length);
     groups.forEach((group, i) => {
         if (i > 0 && group.length) {
             const hr = document.createElement('div');

--- a/e2e/topbar-density.spec.js
+++ b/e2e/topbar-density.spec.js
@@ -1,0 +1,160 @@
+// The top band has to roll itself up as the window narrows. Regression cover
+// for the reported bug: signed in on a song page at ~820px, the "Lists" NAV
+// link painted 22px on top of the "Lists" ACTION button, and from ~840px down
+// "Add Song" wrapped to two lines inside the 48px band.
+//
+// The old collapse was one @media (max-width: 800px) breakpoint. A viewport
+// breakpoint cannot answer "does this fit?", because the band's content width
+// does not follow the viewport — the actions differ per view and a signed-in
+// display name is as long as the person is. So these tests drive real widths
+// with a real name in the band and assert on measured geometry, not on the
+// breakpoint that happens to implement it.
+import { test, expect } from '@playwright/test';
+import { searchAndOpen } from './helpers.js';
+
+/** The DOM supabase-auth produces on sign-in. Signing in for real would need
+ *  a live Supabase session; what the band cares about is the name's width. */
+async function signInChip(page, name = 'Mike Beaumier') {
+    await page.evaluate((who) => {
+        document.getElementById('sign-in-btn')?.classList.add('hidden');
+        document.getElementById('user-info')?.classList.remove('hidden');
+        const initials = document.getElementById('user-avatar-initials');
+        initials?.classList.remove('hidden');
+        if (initials) initials.textContent = 'MB';
+        document.getElementById('user-avatar')?.classList.add('hidden');
+        const el = document.getElementById('user-name');
+        if (el) el.textContent = who;
+    }, name);
+    await page.waitForTimeout(200);
+}
+
+/** Every visible control in the band, left to right, with its box. */
+const BAND_CONTROLS = '.topbar-back, .topbar-brand, .topbar-nav-link, .topbar-action-btn, .pill, .topbar-icon-btn, #auth-section';
+
+async function bandGeometry(page) {
+    return page.evaluate((sel) => {
+        const bar = document.getElementById('app-topbar');
+        const controls = [...bar.querySelectorAll(sel)]
+            .filter(el => el.getBoundingClientRect().width > 0)
+            .map(el => ({ label: (el.textContent || el.id || '').trim().slice(0, 20), box: el.getBoundingClientRect() }))
+            .sort((a, b) => a.box.left - b.box.left);
+
+        const overlaps = [];
+        for (let i = 0; i < controls.length - 1; i++) {
+            const gap = controls[i + 1].box.left - controls[i].box.right;
+            if (gap < -1) overlaps.push(`"${controls[i].label}" over "${controls[i + 1].label}" by ${Math.round(-gap)}px`);
+        }
+
+        const barBox = bar.getBoundingClientRect();
+        return {
+            density: bar.dataset.density,
+            overlaps,
+            // how far the rightmost control pokes past the band's edge
+            spill: controls.length ? Math.round(Math.max(...controls.map(c => c.box.right)) - barBox.right) : 0,
+            // a label that wrapped makes its own control taller than the band
+            tallest: Math.round(Math.max(0, ...[...bar.querySelectorAll('.topbar-nav-link, .topbar-action-btn')]
+                .map(el => el.getBoundingClientRect().height))),
+            barHeight: Math.round(barBox.height),
+            navInBand: [...bar.querySelectorAll('.topbar-nav-link')].filter(el => el.getBoundingClientRect().width > 0).length,
+        };
+    }, BAND_CONTROLS);
+}
+
+test.describe('Top band rolls up to fit', () => {
+    // The reported width, plus the rest of the range the old breakpoint left
+    // over-full, and the narrow end where the band must fully roll up.
+    for (const width of [1440, 1000, 900, 860, 830, 820, 810, 800, 700, 640, 560, 480, 390, 330]) {
+        test(`no control overlaps or spills at ${width}px`, async ({ page }) => {
+            await page.setViewportSize({ width, height: 800 });
+            await page.goto('/#work/nine-to-five');
+            await page.waitForSelector('#app-topbar');
+            await page.waitForSelector('.song-content, .song-view', { timeout: 20000 });
+            await signInChip(page);
+
+            const band = await bandGeometry(page);
+            expect(band.overlaps, `controls collided at ${width}px`).toEqual([]);
+            expect(band.spill, `band content ran past its right edge at ${width}px`).toBeLessThanOrEqual(1);
+            // Nothing wrapped: a two-line label is ~40px against a 48px band
+            expect(band.tallest, `a label wrapped at ${width}px`).toBeLessThan(34);
+            expect(band.barHeight).toBe(48);
+        });
+    }
+
+    test('sheds the display name before it sheds navigation', async ({ page }) => {
+        await page.setViewportSize({ width: 820, height: 800 });
+        await page.goto('/#work/nine-to-five');
+        await page.waitForSelector('#app-topbar');
+        await page.waitForSelector('.song-content, .song-view', { timeout: 20000 });
+        await signInChip(page);
+
+        // At the width that used to overlap, the band is rolled up but the
+        // nav is still in it — the name went first.
+        await expect(page.locator('#user-name')).toBeHidden();
+        expect((await bandGeometry(page)).navInBand).toBeGreaterThan(0);
+    });
+
+    test('a longer display name starts rolling the band up at a wider window', async ({ page }) => {
+        await page.goto('/#work/nine-to-five');
+        await page.waitForSelector('#app-topbar');
+        await page.waitForSelector('.song-content, .song-view', { timeout: 20000 });
+
+        // The widest window at which this name no longer fits at full density.
+        // Searched rather than hardcoded: the exact pixel depends on fonts,
+        // and the property under test is the ORDER, not the number.
+        async function rollUpWidth(name) {
+            await signInChip(page, name);
+            for (let width = 1000; width >= 700; width -= 10) {
+                await page.setViewportSize({ width, height: 800 });
+                await page.waitForTimeout(120);
+                if ((await bandGeometry(page)).density !== 'full') return width;
+            }
+            return 0;
+        }
+
+        const short = await rollUpWidth('Al');
+        const long = await rollUpWidth('Mike Beaumier');
+
+        // Same band, same view, different content — which is the whole point.
+        // A media query reports the same state for both; measuring does not.
+        expect(long).toBeGreaterThan(short);
+        expect((await bandGeometry(page)).overlaps).toEqual([]);
+    });
+
+    test('fully rolled up, the nav is still reachable in the ⋯ menu', async ({ page }) => {
+        await page.setViewportSize({ width: 300, height: 700 });
+        await page.goto('/#search');
+        await page.waitForSelector('#search-input');
+        await signInChip(page);
+
+        expect((await bandGeometry(page)).density).toBe('nav-overflow');
+        expect((await bandGeometry(page)).navInBand).toBe(0);
+
+        await page.locator('#topbar-overflow-btn').click();
+        const menu = page.locator('#topbar-overflow-menu');
+        await expect(menu).toBeVisible();
+        // the nav leads the menu, above the persistent entries
+        await expect(menu.locator('.pill-popover-item').first()).toHaveText('Search');
+        await expect(menu.locator('#overflow-nav-favorites')).toBeVisible();
+
+        await menu.locator('#overflow-nav-favorites').click();
+        await expect(page).toHaveURL(/#list\/favorites/);
+    });
+
+    test('widening the window puts the labels and the nav back', async ({ page }) => {
+        await page.setViewportSize({ width: 300, height: 700 });
+        await page.goto('/#search');
+        await page.waitForSelector('#search-input');
+        await signInChip(page);
+        expect((await bandGeometry(page)).navInBand).toBe(0);
+
+        await page.setViewportSize({ width: 1440, height: 800 });
+        await page.waitForTimeout(300);
+
+        const band = await bandGeometry(page);
+        expect(band.density).toBe('full');
+        expect(band.navInBand).toBe(4);
+        await expect(page.locator('#user-name')).toBeVisible();
+        // and the nav is not left duplicated in the menu it came back from
+        await expect(page.locator('#topbar-overflow-menu #overflow-nav-search')).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
Signed in on a song page at ~820px, the "Lists" nav link painted **22px on top of** the "Lists" action button, and from ~840px down "Add Song" wrapped to two lines inside the 48px band.

## Root cause

Not the pixels — the collapse *mechanism*.

The band's only response to width was one `@media (max-width: 800px)` breakpoint. A viewport breakpoint cannot answer "does this fit?", because the band's content width does not follow the viewport: the actions differ per view, the title is whatever the song is called, and a signed-in display name is as long as the person is. Above 800px the band was simply over-full, and `.topbar-left { min-width: 0 }` let the nav compress past its content and spill over the actions rather than reporting an overflow anything could act on.

So it is a display-layer symptom whose cause is also at the display layer — the wrong abstraction for deciding when to collapse, not a bandaid over a data or parser problem.

## Fix

The band measures itself. `updateDensity()` walks a cumulative ladder and stops at the first step whose content fits:

| step | what it sheds |
|---|---|
| `snug` | spacing only — nothing disappears |
| `no-name` | the display name (avatar still opens the account menu) |
| `no-title` | the center title (the page itself still shows it) |
| `icons` | action labels (they survive as tooltips) |
| `nav-icons` | nav labels |
| `nav-overflow` | the nav leaves the band for the ⋯ menu |

It re-runs on resize, on every `setTopBar()`, and when supabase-auth swaps in the avatar and name. Each step is a single `density-*` CSS rule; only the last needs JS, to re-home the nav links into the ⋯ menu (as a leading group above a divider) so navigation stays one tap away instead of vanishing.

The band's regions now hold their natural width, so "too narrow" surfaces as a measurable `scrollWidth` overflow instead of an overlap.

Because it measures rather than guesses, the collapse follows the **content**: at 330px signed *out* the band stops at `nav-icons`; signed in as "Mike Beaumier" the same width rolls all the way to `nav-overflow`. A media query reports the same state for both.

The 800px media query survives only for `.app-topbar:not([data-density])` — the no-JS / no-`ResizeObserver` fallback, retired by the first measuring pass. The existing 640px phone rules are untouched and compose with the ladder.

## Verification

Measured against the unfixed build, both views, signed in with a real display name:

- **Overlap at 810–830px and two-line labels from 840px: gone.** No control overlaps or spills at any width from 1440px down to 300px.
- The `Add Song` control stays 25px at every width (it hit 40px — two lines — at 860px and below on the old build).
- 60 rapid resizes: zero console errors, no `ResizeObserver` feedback loop, settles clean.
- Fully rolled up, the ⋯ menu leads with Search / Add Song / Favorites / Lists and they navigate.
- **2815 unit tests** and **334 e2e tests** pass unchanged.

## Tests

- 5 unit tests in `docs/js/__tests__/shell.test.js` drive the measurement directly (jsdom has no layout), covering: fits at full, sheds only as many steps as needed, bottoms out into the ⋯ menu, climbs back up without duplicating the nav, and re-measures when a view swaps its actions in.
- New `e2e/topbar-density.spec.js` (18 tests) asserts measured geometry rather than the breakpoint that implements it — no overlap/spill/wrap across a 14-width sweep, name shed before nav, a longer name rolling up at a wider window, and the rolled-up nav staying reachable.

**These are real regression cover: the e2e spec fails 5 of its 18 tests against the unfixed build.**

Note: CI runs `npm test` (vitest) only, so the unit tests gate CI; the e2e spec is for the local suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

